### PR TITLE
Adding JMS Human Task Server to jbpm-human-task

### DIFF
--- a/jbpm-human-task/pom.xml
+++ b/jbpm-human-task/pom.xml
@@ -36,6 +36,11 @@
       <version>2.0.0.GA</version>
     </dependency>
     <dependency>
+      <groupId>javax.jms</groupId>
+      <artifactId>jms</artifactId>
+      <version>1.1</version>
+    </dependency>
+    <dependency>
       <groupId>javax.persistence</groupId>
       <artifactId>persistence-api</artifactId>
     </dependency>
@@ -95,5 +100,17 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+	  <groupId>org.apache.activemq</groupId>
+	  <artifactId>activemq-all</artifactId>
+	  <version>5.2.0</version>
+	  <scope>test</scope>
+	</dependency>
+	<dependency>
+	  <groupId>org.easymock</groupId>
+	  <artifactId>easymock</artifactId>
+	  <version>3.0</version>
+	  <scope>test</scope>
+	</dependency>
   </dependencies>
 </project>

--- a/jbpm-human-task/src/main/java/org/jbpm/process/workitem/wsht/CommandBasedWSThroughJMSHumanTaskHandler.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/process/workitem/wsht/CommandBasedWSThroughJMSHumanTaskHandler.java
@@ -1,0 +1,50 @@
+package org.jbpm.process.workitem.wsht;
+
+import java.lang.reflect.Field;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.drools.SystemEventListenerFactory;
+import org.drools.runtime.KnowledgeRuntime;
+import org.jbpm.process.workitem.wsht.CommandBasedWSHumanTaskHandler;
+import org.jbpm.process.workitem.wsht.WSHumanTaskHandler;
+import org.jbpm.task.service.TaskClient;
+import org.jbpm.task.service.jms.JMSTaskClientConnector;
+import org.jbpm.task.service.jms.JMSTaskClientHandler;
+import org.jbpm.task.service.jms.WSHumanTaskJMSProperties;
+
+public class CommandBasedWSThroughJMSHumanTaskHandler extends CommandBasedWSHumanTaskHandler {
+
+	public CommandBasedWSThroughJMSHumanTaskHandler(KnowledgeRuntime session) {
+		super(session);
+	}
+
+	@Override
+	public void connect() {
+		try {
+			final Field field = WSHumanTaskHandler.class.getDeclaredField("client");
+			TaskClient client = (TaskClient) field.get(this);
+			if (client == null) {
+				client = new TaskClient(new JMSTaskClientConnector(
+						"org.drools.process.workitem.wsht.WSThroughJMSHumanTaskHandler",
+						new JMSTaskClientHandler(SystemEventListenerFactory
+								.getSystemEventListener()),
+						WSHumanTaskJMSProperties.getInstance().getProperties(),
+						new InitialContext(WSHumanTaskJMSProperties.getInstance().getProperties())));
+				field.set(this, client);
+				boolean connected = client.connect();
+				if (!connected) {
+					throw new IllegalArgumentException("Could not connect to the task client");
+				}
+			}
+			super.connect();
+		} catch (NoSuchFieldException e) {
+			throw new RuntimeException("Problem configuring the human task connector", e);
+		} catch (IllegalAccessException e) {
+			throw new RuntimeException("Problem accessing the human task connector", e);
+		} catch (NamingException e) {
+			throw new RuntimeException("Problem accesing the JNDI directory", e);
+		}
+	}
+}

--- a/jbpm-human-task/src/main/java/org/jbpm/process/workitem/wsht/WSThroughJMSHumanTaskHandler.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/process/workitem/wsht/WSThroughJMSHumanTaskHandler.java
@@ -1,0 +1,48 @@
+package org.jbpm.process.workitem.wsht;
+
+import java.lang.reflect.Field;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.drools.SystemEventListenerFactory;
+import org.jbpm.task.service.TaskClient;
+import org.jbpm.task.service.jms.JMSTaskClientConnector;
+import org.jbpm.task.service.jms.JMSTaskClientHandler;
+import org.jbpm.task.service.jms.WSHumanTaskJMSProperties;
+
+
+public class WSThroughJMSHumanTaskHandler extends WSHumanTaskHandler {
+
+	public WSThroughJMSHumanTaskHandler() {
+		super();
+	}
+	
+	@Override
+	public void connect() {
+		try {
+			final Field field = WSHumanTaskHandler.class.getDeclaredField("client");
+			TaskClient client = (TaskClient) field.get(this);
+			if (client == null) {
+				client = new TaskClient(new JMSTaskClientConnector(
+						"org.jbpm.process.workitem.wsht.WSThroughJMSHumanTaskHandler",
+						new JMSTaskClientHandler(SystemEventListenerFactory
+								.getSystemEventListener()),
+						WSHumanTaskJMSProperties.getInstance().getProperties(),
+						new InitialContext(WSHumanTaskJMSProperties.getInstance().getProperties())));
+				field.set(this, client);
+				boolean connected = client.connect();
+				if (!connected) {
+					throw new IllegalArgumentException("Could not connect to the task client");
+				}
+			}
+			super.connect();
+		} catch (NoSuchFieldException e) {
+			throw new RuntimeException("Problem configuring the human task connector", e);
+		} catch (IllegalAccessException e) {
+			throw new RuntimeException("Problem accessing the human task connector", e);
+		} catch (NamingException e) {
+			throw new RuntimeException("Problem accesing the JNDI directory", e);
+		}
+	}
+}

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/BaseJMSHandler.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/BaseJMSHandler.java
@@ -1,0 +1,20 @@
+package org.jbpm.task.service.jms;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.drools.task.service.ResponseHandler;
+import org.jbpm.task.service.BaseHandler;
+
+public class BaseJMSHandler implements BaseHandler {
+
+	protected Map<Integer, ResponseHandler> responseHandlers;
+
+	public BaseJMSHandler() {
+		this.responseHandlers = new HashMap<Integer, ResponseHandler>();
+	}
+
+	public void addResponseHandler(int id, ResponseHandler responseHandler) {
+		this.responseHandlers.put(Integer.valueOf(id), responseHandler);
+	}
+}

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/BaseJMSTaskServer.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/BaseJMSTaskServer.java
@@ -1,0 +1,122 @@
+package org.jbpm.task.service.jms;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.ObjectMessage;
+import javax.jms.Queue;
+import javax.jms.QueueConnection;
+import javax.jms.QueueConnectionFactory;
+import javax.jms.QueueSession;
+import javax.jms.Session;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jbpm.task.service.TaskServer;
+
+public abstract class BaseJMSTaskServer extends TaskServer {
+
+	private boolean running;
+	private static final Log logger = LogFactory.getLog(BaseJMSTaskServer.class);
+	private JMSTaskServerHandler handler;
+	private Properties connectionProperties;
+	private Context context;
+	private Queue queue;
+	private Queue responseQueue;
+	private QueueConnection connection;
+	private QueueSession session;
+	private MessageConsumer consumer;
+	
+	public BaseJMSTaskServer(JMSTaskServerHandler handler, Properties properties, Context context) {
+		this.handler = handler;
+		this.connectionProperties = properties;
+		this.context = context;
+	}
+
+	public void run() {
+		try {
+			start();
+			while (this.running) {
+				Message clientMessage = this.consumer.receive();
+				if (clientMessage != null) {
+					Object object = readMessage(clientMessage);
+					String selector = readSelector(clientMessage);
+					this.handler.messageReceived(this.session, object, this.responseQueue, selector);
+				}
+			}
+		} catch (JMSException e) {
+			if ("102".equals(e.getErrorCode())) {
+				logger.info(e.getMessage());
+			} else {
+				logger.error(e.getMessage());
+			}
+		} catch (Exception e) {
+			throw new RuntimeException("Error leyendo mensaje", e);
+		}
+	}
+
+	private Object readMessage(Message msgReceived) throws IOException {
+		ObjectMessage strmMsgReceived = (ObjectMessage) msgReceived;
+		try {
+			return strmMsgReceived.getObject();
+		} catch (JMSException e) {
+			throw new IOException("Error reading message");
+		}
+	}
+	
+	private String readSelector(Message msgReceived) throws JMSException {
+		return msgReceived.getStringProperty(TaskServiceConstants.SELECTOR_NAME);
+	}
+
+	public void start() throws Exception {
+		Context ctx = this.context;
+		if (this.context == null) {
+			ctx = new InitialContext();
+		}
+		String connFactoryName = this.connectionProperties.getProperty(TaskServiceConstants.TASK_SERVER_CONNECTION_FACTORY_NAME);
+		boolean transacted = Boolean.valueOf(this.connectionProperties.getProperty(TaskServiceConstants.TASK_SERVER_TRANSACTED_NAME));
+		String ackModeString = this.connectionProperties.getProperty(TaskServiceConstants.TASK_SERVER_ACKNOWLEDGE_MODE_NAME);
+		String queueName = this.connectionProperties.getProperty(TaskServiceConstants.TASK_SERVER_QUEUE_NAME_NAME);
+		String responseQueueName = this.connectionProperties.getProperty(TaskServiceConstants.TASK_SERVER_RESPONSE_QUEUE_NAME_NAME);
+		int ackMode = Session.DUPS_OK_ACKNOWLEDGE; //default
+		if ("AUTO_ACKNOWLEDGE".equals(ackModeString)) {
+			ackMode = Session.AUTO_ACKNOWLEDGE;
+		} else if ("CLIENT_ACKNOWLEDGE".equals(ackModeString)) {
+			ackMode = Session.CLIENT_ACKNOWLEDGE;
+		}
+		QueueConnectionFactory factory = (QueueConnectionFactory) ctx.lookup(connFactoryName);
+		try {
+			this.connection = factory.createQueueConnection();
+			this.session = connection.createQueueSession(transacted, ackMode);
+			this.queue = this.session.createQueue(queueName);
+			this.responseQueue = this.session.createQueue(responseQueueName);
+			this.consumer = this.session.createReceiver(this.queue);
+			this.connection.start();
+		} catch (JMSException e) {
+			throw new RuntimeException("No se pudo levantar la cola servidora del JMSTaskServer", e);
+		}
+		this.running = true;
+	}
+
+	public void stop() throws Exception {
+		if (this.running) {
+			this.running = false;
+			closeAll();
+		}
+	}
+
+	private void closeAll() throws JMSException {
+		this.consumer.close();
+		this.session.close();
+		this.connection.close();
+	}
+
+	public boolean isRunning() {
+		return this.running;
+	}
+}

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/JMSSessionWriter.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/JMSSessionWriter.java
@@ -1,0 +1,42 @@
+package org.jbpm.task.service.jms;
+ 
+import java.io.IOException;
+import java.io.Serializable;
+
+import javax.jms.JMSException;
+import javax.jms.MessageProducer;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+
+import org.jbpm.task.service.SessionWriter;
+
+public class JMSSessionWriter implements SessionWriter {
+	private final Session session;
+	private final MessageProducer producer;
+	private final String selector;
+
+	public JMSSessionWriter(Session session, MessageProducer producer, String selector) {
+		this.session = session;
+		this.producer = producer;
+		this.selector = selector;
+	}
+
+	public void write(Object message) throws IOException {
+		try {
+			ObjectMessage clientMessage = this.session.createObjectMessage();
+			clientMessage.setObject((Serializable) message);
+			
+			clientMessage.setStringProperty(TaskServiceConstants.SELECTOR_NAME, this.selector);
+			this.producer.send(clientMessage);
+			this.session.commit();
+		} catch (JMSException e) {
+			throw new IOException("Unable to create message: " + e.getMessage());
+		} finally {
+			try {
+				this.session.commit();
+			} catch (JMSException e) {
+				throw new IOException("Unable to commit message: " + e.getMessage());
+			}
+		}
+	}
+}

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/JMSTaskClientConnector.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/JMSTaskClientConnector.java
@@ -1,0 +1,187 @@
+package org.jbpm.task.service.jms;
+
+import java.io.Serializable;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.ObjectMessage;
+import javax.jms.Queue;
+import javax.jms.QueueConnection;
+import javax.jms.QueueConnectionFactory;
+import javax.jms.QueueSession;
+import javax.jms.Session;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jbpm.task.service.BaseHandler;
+import org.jbpm.task.service.TaskClientConnector;
+
+public class JMSTaskClientConnector implements TaskClientConnector {
+	
+	private static final Log log = LogFactory.getLog(JMSTaskClientConnector.class);
+	protected QueueConnection connection;
+	protected QueueSession session;
+	protected Queue queue;
+	protected Queue responseQueue;
+	protected final BaseJMSHandler handler;
+	protected final String name;
+	protected AtomicInteger counter;
+	private MessageProducer producer;
+	private Properties connectionProperties;
+	private Context context;
+	
+	private String selector;
+	
+
+	public JMSTaskClientConnector(String name, BaseJMSHandler handler, Properties connectionProperties, Context context) {
+		if (name == null) {
+			throw new IllegalArgumentException("Name can not be null");
+		}
+		this.name = name;
+		this.handler = handler;
+		this.connectionProperties = connectionProperties;
+		this.context = context;
+		this.counter = new AtomicInteger();
+	}
+
+	public boolean connect(String address, int port) {
+		return connect();
+	}
+
+	public boolean connect() {
+		if (this.session != null) { 
+			//throw new IllegalStateException("Already connected. Disconnect first.");
+			return true;
+		}
+		try {
+			
+			String connFactoryName = connectionProperties.getProperty(TaskServiceConstants.TASK_CLIENT_CONNECTION_FACTORY_NAME);
+			String transactedQueueString = connectionProperties.getProperty(TaskServiceConstants.TASK_CLIENT_TRANSACTED_QUEUE_NAME);
+			String acknowledgeModeString = connectionProperties.getProperty(TaskServiceConstants.TASK_CLIENT_ACKNOWLEDGE_MODE_NAME);
+			String queueName = connectionProperties.getProperty(TaskServiceConstants.TASK_CLIENT_QUEUE_NAME_NAME);
+			String responseQueueName = connectionProperties.getProperty(TaskServiceConstants.TASK_CLIENT_RESPONSE_QUEUE_NAME_NAME);
+			boolean transactedQueue = Boolean.valueOf(transactedQueueString);
+			int acknowledgeMode = Session.DUPS_OK_ACKNOWLEDGE; //default
+			if ("AUTO_ACKNOWLEDGE".equals(acknowledgeModeString)) {
+				acknowledgeMode = Session.AUTO_ACKNOWLEDGE;
+			} else if ("CLIENT_ACKNOWLEDGE".equals(acknowledgeModeString)) {
+				acknowledgeMode = Session.CLIENT_ACKNOWLEDGE;
+			}
+			Context ctx = this.context;
+			if (ctx == null) {
+				ctx = new InitialContext();
+			}
+			QueueConnectionFactory factory = (QueueConnectionFactory) ctx.lookup(connFactoryName);
+			this.connection = factory.createQueueConnection();
+			this.session = this.connection.createQueueSession(transactedQueue, acknowledgeMode);
+			this.queue = this.session.createQueue(queueName);
+			this.responseQueue = this.session.createQueue(responseQueueName);
+			this.producer = this.session.createProducer(this.queue);
+			this.connection.start();
+			return true;
+		} catch (Exception e) {
+			log.error(e.getMessage());
+		}
+		return false;
+	}
+	
+	private Object readMessage(ObjectMessage serverMessage) throws JMSException {
+		return serverMessage.getObject();
+	}
+
+	public void disconnect() {
+		if (this.producer != null) {
+			try {
+				this.producer.close();
+			} catch (Exception e) { 
+			} finally {
+				this.producer = null;
+			}
+		}
+		if (this.session != null) {
+			try {
+				this.session.close();
+			} catch (Exception e) {
+			} finally {
+				this.session = null;
+			}
+		}
+		if (this.connection != null) {
+			try {
+				this.connection.close();
+			} catch (Exception e) {
+			} finally {
+				this.connection = null;
+			}
+		}
+	}
+
+	public void write(Object object) {
+		try {
+			ObjectMessage message = this.session.createObjectMessage();
+			this.selector = UUID.randomUUID().toString();
+			Thread responseThread = new Thread(new Responder(selector));
+			responseThread.start();
+			message.setStringProperty(TaskServiceConstants.SELECTOR_NAME, this.selector);
+			message.setObject((Serializable)object);
+			this.producer.send(message);
+			this.session.commit();
+		} catch (Throwable e) {
+			throw new RuntimeException("Error creating message", e);
+		}
+	}
+
+	public AtomicInteger getCounter() {
+		return this.counter;
+	}
+
+	public BaseHandler getHandler() {
+		return this.handler;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+	
+	protected class Responder implements Runnable {
+		
+		private final String selector;
+		
+		protected Responder(String selector) {
+			this.selector = selector;
+		}
+		
+		public void run() {
+			MessageConsumer consumer = null;
+			try {
+				consumer = session.createConsumer(responseQueue, " " + TaskServiceConstants.SELECTOR_NAME + " like '" + selector + "%' ");
+				ObjectMessage serverMessage = (ObjectMessage) consumer.receive();
+				if (serverMessage != null) {
+					((JMSTaskClientHandler) handler).messageReceived(session, readMessage(serverMessage), responseQueue, selector);
+				}
+			} catch (JMSException e) {
+				if (!"102".equals(e.getErrorCode())) {
+					throw new RuntimeException("No se pudo recibir respuesta JMS", e);
+				}
+				log.info(e.getMessage());
+				return;
+			} catch (Exception e) {
+				throw new RuntimeException("Error inesperado recibiendo respuesta JMS", e);
+			} finally {
+				if (consumer != null) {
+					try {
+						consumer.close();
+					} catch (Exception e) {
+						log.info("No se pudo cerrar el consumer: " + e.getMessage());
+					}
+				}
+			}
+		}
+	}
+}

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/JMSTaskClientHandler.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/JMSTaskClientHandler.java
@@ -1,0 +1,50 @@
+package org.jbpm.task.service.jms;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jms.Destination;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.Topic;
+
+import org.drools.SystemEventListener;
+import org.jbpm.task.service.TaskClient;
+import org.jbpm.task.service.TaskClientHandler;
+
+public class JMSTaskClientHandler extends BaseJMSHandler {
+	private TaskClientHandler handler;
+	private Map<String, MessageProducer> producers;
+
+	public JMSTaskClientHandler(SystemEventListener systemEventListener) {
+		this.handler = new TaskClientHandler(this.responseHandlers, systemEventListener);
+		this.producers = new HashMap<String, MessageProducer>();
+	}
+
+	public TaskClient getClient() {
+		return this.handler.getClient();
+	}
+
+	public void setClient(TaskClient client) {
+		this.handler.setClient(client);
+	}
+
+	public void exceptionCaught(Session session, Throwable cause) throws Exception {
+	}
+
+	public void messageReceived(Session session, Object message, Destination destination, String selector) throws Exception {
+		String name = "";
+		if (destination instanceof Queue) {
+			name = ((Queue) destination).getQueueName();
+		} else if (destination instanceof Topic) {
+			name = ((Topic) destination).getTopicName();
+		}
+		MessageProducer producer = (MessageProducer) this.producers.get(name);
+		if (producer == null) {
+			producer = session.createProducer(destination);
+			this.producers.put(name, producer);
+		}
+		this.handler.messageReceived(new JMSSessionWriter(session, producer, selector), message);
+	}
+}

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/JMSTaskServer.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/JMSTaskServer.java
@@ -1,0 +1,15 @@
+package org.jbpm.task.service.jms;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.drools.SystemEventListenerFactory;
+import org.jbpm.task.service.TaskService;
+
+public class JMSTaskServer extends BaseJMSTaskServer {
+
+	public JMSTaskServer(TaskService service, Properties connProperties, Context context) {
+		super(new JMSTaskServerHandler(service, SystemEventListenerFactory.getSystemEventListener()), connProperties, context);
+	}
+}

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/JMSTaskServerHandler.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/JMSTaskServerHandler.java
@@ -1,0 +1,40 @@
+package org.jbpm.task.service.jms;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jms.Destination;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.QueueSession;
+import javax.jms.Topic;
+
+import org.drools.SystemEventListener;
+import org.jbpm.task.service.TaskServerHandler;
+import org.jbpm.task.service.TaskService;
+
+public class JMSTaskServerHandler {
+	
+	private TaskServerHandler handler;
+	private Map<String, MessageProducer> producers;
+
+	public JMSTaskServerHandler(TaskService service, SystemEventListener systemEventListener) {
+		this.handler = new TaskServerHandler(service, systemEventListener);
+		this.producers = new HashMap<String, MessageProducer>();
+	}
+
+	public void messageReceived(QueueSession session, Object message, Destination destination, String selector) throws Exception {
+		String name = "";
+		if (destination instanceof Queue) {
+			name = ((Queue) destination).getQueueName();
+		} else if (destination instanceof Topic) {
+			name = ((Topic) destination).getTopicName();
+		}
+		MessageProducer producer = (MessageProducer) this.producers.get(name);
+		if (producer == null) {
+			producer = session.createProducer(destination);
+			this.producers.put(name, producer);
+		}
+		this.handler.messageReceived(new JMSSessionWriter(session, producer, selector), message);
+	}
+}

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/TaskServiceConstants.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/TaskServiceConstants.java
@@ -1,0 +1,22 @@
+package org.jbpm.task.service.jms;
+
+public interface TaskServiceConstants {
+
+	String SELECTOR_NAME = "taskClientId";
+	
+	String TASK_SERVER_RESPONSE_QUEUE_NAME_NAME = "JMSTaskServer.responseQueueName";
+	String TASK_SERVER_QUEUE_NAME_NAME = "JMSTaskServer.queueName";
+	String TASK_SERVER_ACKNOWLEDGE_MODE_NAME = "JMSTaskServer.acknowledgeMode";
+	String TASK_SERVER_TRANSACTED_NAME = "JMSTaskServer.transacted";
+	String TASK_SERVER_CONNECTION_FACTORY_NAME = "JMSTaskServer.connectionFactory";
+	
+	String TASK_CLIENT_RESPONSE_QUEUE_NAME_NAME = "JMSTaskClient.responseQueueName";
+	String TASK_CLIENT_QUEUE_NAME_NAME = "JMSTaskClient.queueName";
+	String TASK_CLIENT_ACKNOWLEDGE_MODE_NAME = "JMSTaskClient.acknowledgeMode";
+	String TASK_CLIENT_TRANSACTED_QUEUE_NAME = "JMSTaskClient.transactedQueue";
+	String TASK_CLIENT_CONNECTION_FACTORY_NAME = "JMSTaskClient.connectionFactory";
+	
+	String NAMING_FACTORY_INITIAL_NAME = "java.naming.factory.initial";
+	String NAMING_PROVIDER_URL_NAME = "java.naming.provider.url";
+	String NAMING_FACTORY_URL_PKGS_NAME = "java.naming.factory.url.pkgs";
+}

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/WSHumanTaskJMSProperties.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/jms/WSHumanTaskJMSProperties.java
@@ -1,0 +1,31 @@
+package org.jbpm.task.service.jms;
+
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.ResourceBundle;
+
+public class WSHumanTaskJMSProperties {
+
+	private static final WSHumanTaskJMSProperties INSTANCE = new WSHumanTaskJMSProperties();
+	
+	private Properties properties = new Properties(); 
+	
+	private WSHumanTaskJMSProperties() {
+		super();
+		ResourceBundle bundle = ResourceBundle.getBundle("jmsht.conf");
+		Enumeration<String> keys = bundle.getKeys();
+		while (keys.hasMoreElements()) {
+			String key = keys.nextElement();
+			String value = bundle.getString(key);
+			this.properties.setProperty(key, value);
+		}
+	}
+	
+	public Properties getProperties() {
+		return properties;
+	}
+	
+	public static WSHumanTaskJMSProperties getInstance() {
+		return INSTANCE;
+	}
+}

--- a/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/IcalJMSTest.java
+++ b/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/IcalJMSTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.task.service.jms;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.drools.SystemEventListenerFactory;
+import org.drools.util.ChainedProperties;
+import org.drools.util.ClassLoaderUtil;
+import org.easymock.EasyMock;
+import org.jbpm.task.service.IcalBaseTest;
+import org.jbpm.task.service.TaskClient;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.subethamail.wiser.Wiser;
+
+public class IcalJMSTest extends IcalBaseTest {
+
+	private BrokerService broker;
+	private Context context;
+	
+	@Override @BeforeClass
+	protected void setUp() throws Exception {
+		super.setUp();
+		
+		broker = new BrokerService();
+		broker.start();
+		ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(broker.getVmConnectorURI());
+		
+		this.context = EasyMock.createMock(Context.class);
+		EasyMock.expect(context.lookup("ConnectionFactory")).andReturn(factory).anyTimes();
+		EasyMock.replay(context);
+		
+		ChainedProperties props = new ChainedProperties("process.email.conf", ClassLoaderUtil.getClassLoader(null, getClass(), false ));
+        setEmailHost(props.getProperty("host", "locahost"));
+        setEmailPort(props.getProperty("port", "2345"));    
+		
+		Properties serverProperties = new Properties();
+		serverProperties.setProperty("JMSTaskServer.connectionFactory", "ConnectionFactory");
+		serverProperties.setProperty("JMSTaskServer.transacted", "true");
+		serverProperties.setProperty("JMSTaskServer.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		serverProperties.setProperty("JMSTaskServer.queueName", "tasksQueue");
+		serverProperties.setProperty("JMSTaskServer.responseQueueName", "tasksResponseQueue");
+		
+		server = new JMSTaskServer(taskService, serverProperties, context);
+		Thread thread = new Thread(server);
+		thread.start();
+		System.out.println("Waiting for the JMS Task Server to come up");
+        while (!server.isRunning()) {
+        	System.out.print(".");
+        	Thread.sleep( 50 );
+        }
+
+        Properties clientProperties = new Properties();
+		clientProperties.setProperty("JMSTaskClient.connectionFactory", "ConnectionFactory");
+		clientProperties.setProperty("JMSTaskClient.transactedQueue", "true");
+		clientProperties.setProperty("JMSTaskClient.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		clientProperties.setProperty("JMSTaskClient.queueName", "tasksQueue");
+		clientProperties.setProperty("JMSTaskClient.responseQueueName", "tasksResponseQueue");
+        
+		client = new TaskClient(new JMSTaskClientConnector("client 1",
+								new JMSTaskClientHandler(SystemEventListenerFactory.getSystemEventListener()),
+								clientProperties, context));
+		client.connect();
+
+        setWiser(new Wiser());
+        getWiser().setHostname(getEmailHost());
+        getWiser().setPort(Integer.parseInt(getEmailPort()));         
+        getWiser().start();
+	
+	}
+
+	@AfterClass
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		client.disconnect();
+		server.stop();
+		broker.stop();
+		getWiser().stop();
+	}
+}

--- a/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/JMSTaskServerTest.java
+++ b/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/JMSTaskServerTest.java
@@ -1,0 +1,172 @@
+package org.jbpm.task.service.jms;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import javax.naming.Context;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import junit.framework.TestCase;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.drools.SystemEventListenerFactory;
+import org.easymock.EasyMock;
+import org.jbpm.task.Group;
+import org.jbpm.task.I18NText;
+import org.jbpm.task.Status;
+import org.jbpm.task.Task;
+import org.jbpm.task.TaskData;
+import org.jbpm.task.User;
+import org.jbpm.task.service.ContentData;
+import org.jbpm.task.service.TaskClient;
+import org.jbpm.task.service.TaskServer;
+import org.jbpm.task.service.TaskService;
+import org.jbpm.task.service.TaskServiceSession;
+import org.jbpm.task.service.responsehandlers.BlockingAddTaskResponseHandler;
+
+/**
+ * Test case to see if this component works.
+ * 
+ * @author Mariano De Maio
+ */
+public class JMSTaskServerTest extends TestCase {
+
+	/**
+	 * Initial context
+	 */
+	private Context context;
+	
+	/**
+	 * server instance
+	 */
+	private TaskServer server;
+	
+	/**
+	 * Starts the server
+	 */
+	@Override
+	protected void setUp() throws Exception {
+
+		ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+		
+		this.context = EasyMock.createMock(Context.class);
+		EasyMock.expect(context.lookup("ConnectionFactory")).andReturn(factory).anyTimes();
+		EasyMock.replay(context);
+		
+		EntityManagerFactory localEntityManagerFactory = Persistence.createEntityManagerFactory("org.jbpm.task");
+		TaskService localTaskService = new TaskService(localEntityManagerFactory, SystemEventListenerFactory.getSystemEventListener());
+		TaskServiceSession localTaskServiceSession = localTaskService.createSession();
+		for (int i = 0; i < 10; i++) {
+			User user = new User("usr" + i);
+			localTaskServiceSession.addUser(user);
+		}
+		for (int j = 0; j < 3; j++) {
+			localTaskServiceSession.addGroup(new Group("grp" + j));
+		}
+
+  		Properties serverProperties = new Properties();
+		serverProperties.setProperty("JMSTaskServer.connectionFactory", "ConnectionFactory");
+		serverProperties.setProperty("JMSTaskServer.transacted", "true");
+		serverProperties.setProperty("JMSTaskServer.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		serverProperties.setProperty("JMSTaskServer.queueName", "tasksQueue");
+		serverProperties.setProperty("JMSTaskServer.responseQueueName", "tasksResponseQueue");
+  		
+		this.server = new JMSTaskServer(localTaskService, serverProperties, context);
+		Thread thread = new Thread(this.server);
+		thread.start();
+		localTaskServiceSession.dispose();
+	}
+	
+	/**
+	 * Creates a new client
+	 * @return the created client.
+	 */
+	protected TaskClient createTaskClient() {
+		Properties clientProperties = new Properties();
+		clientProperties.setProperty("JMSTaskClient.connectionFactory", "ConnectionFactory");
+		clientProperties.setProperty("JMSTaskClient.transactedQueue", "true");
+		clientProperties.setProperty("JMSTaskClient.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		clientProperties.setProperty("JMSTaskClient.queueName", "tasksQueue");
+		clientProperties.setProperty("JMSTaskClient.responseQueueName", "tasksResponseQueue");
+		TaskClient client = new TaskClient(
+				new JMSTaskClientConnector(
+						"org.jbpm.process.workitem.wsht.WSThroughJMSHumanTaskHandler",
+						new JMSTaskClientHandler(SystemEventListenerFactory.getSystemEventListener()),
+						clientProperties, context
+				)
+		);
+		
+		return client;
+	}
+	
+	/**
+	 * Stops the server
+	 */
+	@Override
+	protected void tearDown() throws Exception {
+		server.stop();
+	}
+	
+	/**
+	 * Tests two consecutive connections to see how it works.
+	 * @throws Exception
+	 */
+	public void testDoubleUsage() throws Exception {
+		
+		while(!server.isRunning()) {
+			Thread.sleep(100); // waits until the server finishes the startup
+		}
+		
+		TaskClient client = createTaskClient();
+		
+		client.connect();
+		
+		Task task = new Task();
+		List<I18NText> names1 = new ArrayList<I18NText>();
+		I18NText text1 = new I18NText("en-UK", "tarea1");
+		names1.add(text1);
+		task.setNames(names1);
+		TaskData taskData = new TaskData();
+		taskData.setStatus(Status.Created);
+		taskData.setCreatedBy(new User("usr0"));
+		taskData.setActualOwner(new User("usr0"));
+		task.setTaskData(taskData);
+		
+		ContentData data = new ContentData();
+		BlockingAddTaskResponseHandler addTaskHandler = new BlockingAddTaskResponseHandler();
+		client.addTask(task, data, addTaskHandler);
+		
+		long taskId = addTaskHandler.getTaskId();
+
+		client.disconnect();
+		
+		client.connect();
+		
+		assertTrue("taskId debe ser un valor mayor a cero", taskId > 0);
+		
+		Task task2 = new Task();
+		List<I18NText> names2 = new ArrayList<I18NText>();
+		I18NText text2 = new I18NText("en-UK", "tarea1");
+		names2.add(text2);
+		task2.setNames(names2);
+		TaskData taskData2 = new TaskData();
+		taskData2.setStatus(Status.Created);
+		taskData2.setCreatedBy(new User("usr0"));
+		taskData2.setActualOwner(new User("usr0"));
+		task2.setTaskData(taskData2);
+	    
+		ContentData data2 = new ContentData();
+		BlockingAddTaskResponseHandler addTaskHandler2 = new BlockingAddTaskResponseHandler();
+		client.addTask(task2, data2, addTaskHandler2);
+		
+		long taskId2 = addTaskHandler2.getTaskId();
+		
+		assertTrue("taskId2 debe ser un valor mayor a cero", taskId2 > 0);
+		assertNotSame("taskId y taskId2 deben ser distintos", taskId, taskId2);
+		
+		client.disconnect();
+	}
+	
+}

--- a/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskLifeCycleJMSTest.java
+++ b/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskLifeCycleJMSTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.task.service.jms;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.drools.SystemEventListenerFactory;
+import org.easymock.EasyMock;
+import org.jbpm.task.service.TaskClient;
+import org.jbpm.task.service.TaskLifeCycleBaseTest;
+
+public class TaskLifeCycleJMSTest extends TaskLifeCycleBaseTest {
+
+	private Context context;
+	
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		
+		ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+		
+		this.context = EasyMock.createMock(Context.class);
+		EasyMock.expect(context.lookup("ConnectionFactory")).andReturn(factory).anyTimes();
+		EasyMock.replay(context);
+		
+		Properties serverProperties = new Properties();
+		serverProperties.setProperty("JMSTaskServer.connectionFactory", "ConnectionFactory");
+		serverProperties.setProperty("JMSTaskServer.transacted", "true");
+		serverProperties.setProperty("JMSTaskServer.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		serverProperties.setProperty("JMSTaskServer.queueName", "tasksQueue");
+		serverProperties.setProperty("JMSTaskServer.responseQueueName", "tasksResponseQueue");
+		
+		server = new JMSTaskServer(taskService, serverProperties, context);
+		Thread thread = new Thread(server);
+		thread.start();
+		System.out.println("Waiting for the JMS Task Server to come up");
+        while (!server.isRunning()) {
+        	System.out.print(".");
+        	Thread.sleep( 50 );
+        }
+
+        Properties clientProperties = new Properties();
+		clientProperties.setProperty("JMSTaskClient.connectionFactory", "ConnectionFactory");
+		clientProperties.setProperty("JMSTaskClient.transactedQueue", "true");
+		clientProperties.setProperty("JMSTaskClient.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		clientProperties.setProperty("JMSTaskClient.queueName", "tasksQueue");
+		clientProperties.setProperty("JMSTaskClient.responseQueueName", "tasksResponseQueue");
+        
+		client = new TaskClient(new JMSTaskClientConnector("client 1",
+								new JMSTaskClientHandler(SystemEventListenerFactory.getSystemEventListener()),
+								clientProperties, context));
+		client.connect();
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		client.disconnect();
+		server.stop();
+	}
+
+}

--- a/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskServiceCommentsAndAttachmentsJMSTest.java
+++ b/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskServiceCommentsAndAttachmentsJMSTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.task.service.jms;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.drools.SystemEventListenerFactory;
+import org.easymock.EasyMock;
+import org.jbpm.task.service.TaskClient;
+import org.jbpm.task.service.TaskServiceCommentsAndAttachmentsBaseTest;
+
+public class TaskServiceCommentsAndAttachmentsJMSTest extends TaskServiceCommentsAndAttachmentsBaseTest {
+
+	private Context context;
+	
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		
+		ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+		
+		this.context = EasyMock.createMock(Context.class);
+		EasyMock.expect(context.lookup("ConnectionFactory")).andReturn(factory).anyTimes();
+		EasyMock.replay(context);
+		
+		Properties serverProperties = new Properties();
+		serverProperties.setProperty("JMSTaskServer.connectionFactory", "ConnectionFactory");
+		serverProperties.setProperty("JMSTaskServer.transacted", "true");
+		serverProperties.setProperty("JMSTaskServer.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		serverProperties.setProperty("JMSTaskServer.queueName", "tasksQueue");
+		serverProperties.setProperty("JMSTaskServer.responseQueueName", "tasksResponseQueue");
+		
+		server = new JMSTaskServer(taskService, serverProperties, context);
+		Thread thread = new Thread(server);
+		thread.start();
+		System.out.println("Waiting for the JMS Task Server to come up");
+        while (!server.isRunning()) {
+        	System.out.print(".");
+        	Thread.sleep( 50 );
+        }
+
+        Properties clientProperties = new Properties();
+		clientProperties.setProperty("JMSTaskClient.connectionFactory", "ConnectionFactory");
+		clientProperties.setProperty("JMSTaskClient.transactedQueue", "true");
+		clientProperties.setProperty("JMSTaskClient.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		clientProperties.setProperty("JMSTaskClient.queueName", "tasksQueue");
+		clientProperties.setProperty("JMSTaskClient.responseQueueName", "tasksResponseQueue");
+        
+		client = new TaskClient(new JMSTaskClientConnector("client 1",
+								new JMSTaskClientHandler(SystemEventListenerFactory.getSystemEventListener()),
+								clientProperties, context));
+		client.connect();
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		client.disconnect();
+		server.stop();
+	}
+
+}

--- a/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskServiceDeadlinesJMSTest.java
+++ b/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskServiceDeadlinesJMSTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.task.service.jms;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.drools.SystemEventListenerFactory;
+import org.easymock.EasyMock;
+import org.jbpm.task.service.TaskClient;
+import org.jbpm.task.service.TaskServiceDeadlinesBaseTest;
+import org.subethamail.wiser.Wiser;
+
+public class TaskServiceDeadlinesJMSTest extends TaskServiceDeadlinesBaseTest {
+
+	private Context context;
+	
+	@Override
+	protected void setUp() throws Exception {        
+		super.setUp();
+
+		setConf(new Properties());
+		getConf().setProperty("mail.smtp.host", "localhost");
+		getConf().setProperty("mail.smtp.port", "2345");
+		getConf().setProperty("from", "from@domain.com");
+		getConf().setProperty("replyTo", "replyTo@domain.com");
+		getConf().setProperty("defaultLanguage", "en-UK");
+
+		ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+		
+		this.context = EasyMock.createMock(Context.class);
+		EasyMock.expect(context.lookup("ConnectionFactory")).andReturn(factory).anyTimes();
+		EasyMock.replay(context);
+		
+		Properties serverProperties = new Properties();
+		serverProperties.setProperty("JMSTaskServer.connectionFactory", "ConnectionFactory");
+		serverProperties.setProperty("JMSTaskServer.transacted", "true");
+		serverProperties.setProperty("JMSTaskServer.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		serverProperties.setProperty("JMSTaskServer.queueName", "tasksQueue");
+		serverProperties.setProperty("JMSTaskServer.responseQueueName", "tasksResponseQueue");
+		
+		server = new JMSTaskServer(taskService, serverProperties, context);
+		Thread thread = new Thread(server);
+		thread.start();
+		System.out.println("Waiting for the JMS Task Server to come up");
+        while (!server.isRunning()) {
+        	System.out.print(".");
+        	Thread.sleep( 50 );
+        }
+
+        Properties clientProperties = new Properties();
+		clientProperties.setProperty("JMSTaskClient.connectionFactory", "ConnectionFactory");
+		clientProperties.setProperty("JMSTaskClient.transactedQueue", "true");
+		clientProperties.setProperty("JMSTaskClient.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		clientProperties.setProperty("JMSTaskClient.queueName", "tasksQueue");
+		clientProperties.setProperty("JMSTaskClient.responseQueueName", "tasksResponseQueue");
+        
+        client = new TaskClient(new JMSTaskClientConnector("client 1",
+				new JMSTaskClientHandler(SystemEventListenerFactory.getSystemEventListener()),
+				clientProperties, context));
+        client.connect();
+
+		setWiser(new Wiser());
+		getWiser().setHostname(getConf().getProperty("mail.smtp.host"));
+		getWiser().setPort(Integer.parseInt(getConf().getProperty("mail.smtp.port")));        
+		getWiser().start();
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		client.disconnect();
+		server.stop();
+		getWiser().stop();
+	}
+
+}

--- a/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskServiceEscalationJMSTest.java
+++ b/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskServiceEscalationJMSTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.task.service.jms;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.drools.SystemEventListenerFactory;
+import org.easymock.EasyMock;
+import org.jbpm.task.service.TaskClient;
+import org.jbpm.task.service.TaskServiceEscalationBaseTest;
+
+public class TaskServiceEscalationJMSTest extends TaskServiceEscalationBaseTest {
+
+	private Context context;
+	
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		
+		ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+		
+		this.context = EasyMock.createMock(Context.class);
+		EasyMock.expect(context.lookup("ConnectionFactory")).andReturn(factory).anyTimes();
+		EasyMock.replay(context);
+		
+		Properties serverProperties = new Properties();
+		serverProperties.setProperty("JMSTaskServer.connectionFactory", "ConnectionFactory");
+		serverProperties.setProperty("JMSTaskServer.transacted", "true");
+		serverProperties.setProperty("JMSTaskServer.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		serverProperties.setProperty("JMSTaskServer.queueName", "tasksQueue");
+		serverProperties.setProperty("JMSTaskServer.responseQueueName", "tasksResponseQueue");
+		
+		server = new JMSTaskServer(taskService, serverProperties, context);
+		Thread thread = new Thread(server);
+		thread.start();
+		System.out.println("Waiting for the JMS Task Server to come up");
+        while (!server.isRunning()) {
+        	System.out.print(".");
+        	Thread.sleep( 50 );
+        }
+
+        Properties clientProperties = new Properties();
+		clientProperties.setProperty("JMSTaskClient.connectionFactory", "ConnectionFactory");
+		clientProperties.setProperty("JMSTaskClient.transactedQueue", "true");
+		clientProperties.setProperty("JMSTaskClient.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		clientProperties.setProperty("JMSTaskClient.queueName", "tasksQueue");
+		clientProperties.setProperty("JMSTaskClient.responseQueueName", "tasksResponseQueue");
+        
+		client = new TaskClient(new JMSTaskClientConnector("client 1",
+								new JMSTaskClientHandler(SystemEventListenerFactory.getSystemEventListener()),
+								clientProperties, context));
+		client.connect();
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		client.disconnect();
+		server.stop();
+	}
+
+}

--- a/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskServiceEventMessagingJMSTest.java
+++ b/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskServiceEventMessagingJMSTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.task.service.jms;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.drools.SystemEventListenerFactory;
+import org.easymock.EasyMock;
+import org.jbpm.task.MockUserInfo;
+import org.jbpm.task.service.TaskClient;
+import org.jbpm.task.service.TaskServiceEventMessagingBaseTest;
+
+public class TaskServiceEventMessagingJMSTest extends TaskServiceEventMessagingBaseTest {
+
+	private Context context;
+	
+    @Override
+    protected void setUp() throws Exception {
+    	super.setUp();
+		
+		ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+		
+		this.context = EasyMock.createMock(Context.class);
+		EasyMock.expect(context.lookup("ConnectionFactory")).andReturn(factory).anyTimes();
+		EasyMock.replay(context);
+		
+		Properties serverProperties = new Properties();
+		serverProperties.setProperty("JMSTaskServer.connectionFactory", "ConnectionFactory");
+		serverProperties.setProperty("JMSTaskServer.transacted", "true");
+		serverProperties.setProperty("JMSTaskServer.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		serverProperties.setProperty("JMSTaskServer.queueName", "tasksQueue");
+		serverProperties.setProperty("JMSTaskServer.responseQueueName", "tasksResponseQueue");
+		
+		server = new JMSTaskServer(taskService, serverProperties, context);
+		Thread thread = new Thread(server);
+		thread.start();
+		System.out.println("Waiting for the JMS Task Server to come up");
+        while (!server.isRunning()) {
+        	System.out.print(".");
+        	Thread.sleep( 50 );
+        }
+        
+        Properties clientProperties = new Properties();
+		clientProperties.setProperty("JMSTaskClient.connectionFactory", "ConnectionFactory");
+		clientProperties.setProperty("JMSTaskClient.transactedQueue", "true");
+		clientProperties.setProperty("JMSTaskClient.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		clientProperties.setProperty("JMSTaskClient.queueName", "tasksQueue");
+		clientProperties.setProperty("JMSTaskClient.responseQueueName", "tasksResponseQueue");
+        
+		client = new TaskClient(new JMSTaskClientConnector("client 1",
+								new JMSTaskClientHandler(SystemEventListenerFactory.getSystemEventListener()),
+								clientProperties, context));
+		client.connect();
+        
+        MockUserInfo userInfo = new MockUserInfo();
+        userInfo.getEmails().put(users.get("tony"), "tony@domain.com");
+        userInfo.getEmails().put(users.get("steve"), "steve@domain.com");
+
+        userInfo.getLanguages().put(users.get("tony"), "en-UK");
+        userInfo.getLanguages().put(users.get("steve"), "en-UK");
+        taskService.setUserinfo(userInfo);
+    }
+
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        client.disconnect();
+        server.stop();
+    }    
+    
+}

--- a/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskServiceJMSTest.java
+++ b/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskServiceJMSTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.task.service.jms;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.drools.SystemEventListenerFactory;
+import org.easymock.EasyMock;
+import org.jbpm.task.service.TaskClient;
+import org.jbpm.task.service.TaskServiceBaseTest;
+
+public class TaskServiceJMSTest extends TaskServiceBaseTest {
+
+	private Context context;
+	
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		
+		ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+		
+		this.context = EasyMock.createMock(Context.class);
+		EasyMock.expect(context.lookup("ConnectionFactory")).andReturn(factory).anyTimes();
+		EasyMock.replay(context);
+		
+		Properties serverProperties = new Properties();
+		serverProperties.setProperty("JMSTaskServer.connectionFactory", "ConnectionFactory");
+		serverProperties.setProperty("JMSTaskServer.transacted", "true");
+		serverProperties.setProperty("JMSTaskServer.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		serverProperties.setProperty("JMSTaskServer.queueName", "tasksQueue");
+		serverProperties.setProperty("JMSTaskServer.responseQueueName", "tasksResponseQueue");
+		
+		server = new JMSTaskServer(taskService, serverProperties, context);
+		Thread thread = new Thread(server);
+		thread.start();
+		System.out.println("Waiting for the JMS Task Server to come up");
+        while (!server.isRunning()) {
+        	System.out.print(".");
+        	Thread.sleep( 50 );
+        }
+
+        Properties clientProperties = new Properties();
+		clientProperties.setProperty("JMSTaskClient.connectionFactory", "ConnectionFactory");
+		clientProperties.setProperty("JMSTaskClient.transactedQueue", "true");
+		clientProperties.setProperty("JMSTaskClient.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		clientProperties.setProperty("JMSTaskClient.queueName", "tasksQueue");
+		clientProperties.setProperty("JMSTaskClient.responseQueueName", "tasksResponseQueue");
+        
+		client = new TaskClient(new JMSTaskClientConnector("client 1",
+								new JMSTaskClientHandler(SystemEventListenerFactory.getSystemEventListener()),
+								clientProperties, context));
+		client.connect();
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		client.disconnect();
+		server.stop();
+	}
+
+}

--- a/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskServiceLifeCycleJMSTest.java
+++ b/jbpm-human-task/src/test/java/org/jbpm/task/service/jms/TaskServiceLifeCycleJMSTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.task.service.jms;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.drools.SystemEventListenerFactory;
+import org.easymock.EasyMock;
+import org.jbpm.task.service.TaskClient;
+import org.jbpm.task.service.TaskServiceLifeCycleBaseTest;
+
+public class TaskServiceLifeCycleJMSTest extends TaskServiceLifeCycleBaseTest {
+
+	private Context context;
+	
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		
+		ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+		
+		this.context = EasyMock.createMock(Context.class);
+		EasyMock.expect(context.lookup("ConnectionFactory")).andReturn(factory).anyTimes();
+		EasyMock.replay(context);
+		
+		Properties serverProperties = new Properties();
+		serverProperties.setProperty("JMSTaskServer.connectionFactory", "ConnectionFactory");
+		serverProperties.setProperty("JMSTaskServer.transacted", "true");
+		serverProperties.setProperty("JMSTaskServer.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		serverProperties.setProperty("JMSTaskServer.queueName", "tasksQueue");
+		serverProperties.setProperty("JMSTaskServer.responseQueueName", "tasksResponseQueue");
+		
+		server = new JMSTaskServer(taskService, serverProperties, context);
+		Thread thread = new Thread(server);
+		thread.start();
+		System.out.println("Waiting for the JMS Task Server to come up");
+        while (!server.isRunning()) {
+        	System.out.print(".");
+        	Thread.sleep( 50 );
+        }
+
+        Properties clientProperties = new Properties();
+		clientProperties.setProperty("JMSTaskClient.connectionFactory", "ConnectionFactory");
+		clientProperties.setProperty("JMSTaskClient.transactedQueue", "true");
+		clientProperties.setProperty("JMSTaskClient.acknowledgeMode", "AUTO_ACKNOWLEDGE");
+		clientProperties.setProperty("JMSTaskClient.queueName", "tasksQueue");
+		clientProperties.setProperty("JMSTaskClient.responseQueueName", "tasksResponseQueue");
+        
+		client = new TaskClient(new JMSTaskClientConnector("client 1",
+								new JMSTaskClientHandler(SystemEventListenerFactory.getSystemEventListener()),
+								clientProperties, context));
+		client.connect();
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		client.disconnect();
+		server.stop();
+	}
+
+}


### PR DESCRIPTION
I've created an implementation of TaskServer that only uses the JMS API for connection. I thought it could be shared with the community, since a lot of implementors might want to use other implementations different from HornetQ (such is our case here at Osde, where we were asked to use JBoss Messaging for the moment).

It basically uses two queues, one for the requests and one for the responses. Tests have been implemented using ActiveMQ
