### PR TITLE
JbpmJUnitTestCase

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/JbpmJUnitTestCase.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/JbpmJUnitTestCase.java
@@ -157,7 +157,7 @@ public abstract class JbpmJUnitTestCase extends TestCase {
 		    StatefulKnowledgeSession result = JPAKnowledgeService.newStatefulKnowledgeSession(kbase, null, env);
 		    new JPAWorkingMemoryDbLogger(result);
 		    if (log == null) {
-		    	log = new JPAProcessInstanceDbLog();
+		    	log = new JPAProcessInstanceDbLog(result.getEnvironment());
 		    }
 		    return result;
 		} else {


### PR DESCRIPTION
Updated JPAProcessInstanceDbLog to use current ksession environment, which enforces to reuse the same EntityManagerFactory instance.
