### PR TITLE
Update jboss seam to 2.2.4.EAP in soaProfile

### DIFF
--- a/jbpm-human-task/pom.xml
+++ b/jbpm-human-task/pom.xml
@@ -116,4 +116,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <profiles>
+    <profile>
+      <id>soaProfile</id>
+      <activation>
+        <property>
+          <name>soa</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.seam</groupId>
+          <artifactId>jboss-seam</artifactId>
+          <version>2.2.4.EAP5</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
This is for avoiding jboss seam version conflict between drools and ewp.
