### PR TITLE
install script extention

### DIFF
--- a/jbpm-installer/corejar-conf/jbpm.console.properties
+++ b/jbpm-installer/corejar-conf/jbpm.console.properties
@@ -2,4 +2,9 @@ jbpm.console.server.host=localhost
 jbpm.console.server.port=8080
 jbpm.console.task.service.host=127.0.0.1
 jbpm.console.task.service.port=9123
-
+guvnor.protocol=http
+guvnor.host=localhost:8080
+guvnor.subdomain=drools-guvnor
+guvnor.usr=admin
+guvnor.pwd=admin
+guvnor.packages=


### PR DESCRIPTION
the installation script extended with the possibility to copy the jbpm.console.properties from the corejar-conf folder to the jbpm-gwt-core.jar.
