### PR TITLE
Cleaning up org.jbpm javadoc production

### DIFF
--- a/jbpm-bam/src/main/java/org/jbpm/process/audit/package-info.java
+++ b/jbpm-bam/src/main/java/org/jbpm/process/audit/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Business Activity Monitoring (BAM) resources supporting activity events and activity logs.
+ */
+ package org.jbpm.process.audit;

--- a/jbpm-flow/src/main/java/org/jbpm/marshalling/impl/ProcessInstanceMarshaller.java
+++ b/jbpm-flow/src/main/java/org/jbpm/marshalling/impl/ProcessInstanceMarshaller.java
@@ -32,7 +32,7 @@ import org.drools.runtime.process.WorkflowProcessInstance;
  * InputMarshaller, that delegates in a ProcessInstanceMarshaller to stream in/out runtime
  * information.
  * 
- * @see OutPutMarshaller
+ * @see org.drools.marshalling.impl.OutputMarshaller
  * @see InputMarshaller
  * @see ProcessMarshallerRegistry
  * 

--- a/jbpm-flow/src/main/java/org/jbpm/process/core/Process.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/Process.java
@@ -84,7 +84,7 @@ public interface Process extends org.drools.definition.process.Process, ContextC
       /** 
        * Sets the imports of this RuleFlow process
        * 
-       * @param imports   the imports as a List of fully qualified class names
+       * @param functionImports   the imports as a List of fully qualified class names
        */
      void setFunctionImports(List<String> functionImports);      
 
@@ -99,7 +99,7 @@ public interface Process extends org.drools.definition.process.Process, ContextC
     /**
      * Sets the imports of this RuleFlow process
      * 
-     * @param imports	the globals as a Map with the name as key and the type as value
+     * @param globals	the globals as a Map with the name as key and the type as value
      */
     void setGlobals(Map<String, String> globals);
 

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/Constraint.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/Constraint.java
@@ -89,7 +89,7 @@ public interface Constraint {
      * Method for setting the dialect of the constraint,
      * e.g. "mvel" or "java"
      * 
-     * @param type  the dialect of the constraint
+     * @param dialect  the dialect of the constraint
      */
     void setDialect(String dialect);
     

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/WorkflowProcess.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/WorkflowProcess.java
@@ -54,7 +54,7 @@ public interface WorkflowProcess extends org.drools.definition.process.WorkflowP
     /**
      * Sets the imports of this RuleFlow process
      * 
-     * @param imports	the imports as a List of fully qualified class names
+     * @param functionImports	the imports as a List of fully qualified class names
      */
     void setFunctionImports(List<String> functionImports);
 
@@ -69,7 +69,7 @@ public interface WorkflowProcess extends org.drools.definition.process.WorkflowP
     /**
      * Sets the imports of this RuleFlow process
      * 
-     * @param imports	the globals as a Map with the name as key and the type as value
+     * @param globals	the globals as a Map with the name as key and the type as value
      */
     void setGlobals(Map<String, String> globals);
 

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/ConnectionImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/ConnectionImpl.java
@@ -46,8 +46,9 @@ public class ConnectionImpl implements Connection, Serializable {
      * and a type.
      * 
      * @param from      The from node
+	 * @param fromType  The node type
      * @param to        The to node
-     * @param type      The connection type
+     * @param toType    The connection type
      */
     public ConnectionImpl(final Node from, final String fromType,
                           final Node to, final String toType) {

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/PermissionDeniedException.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/PermissionDeniedException.java
@@ -20,7 +20,7 @@ package org.jbpm.task.service;
  * Exception that is thrown when a <code>User</code> try to perform an <code>Operation</code> on a <code>Task</code>
  *
  * @author <a href="mailto:stampy88@yahoo.com">dave sinclair</a>
- * @see org.jbpm.task.service.TaskServiceSession#taskOperation(Operation, long, String, String, ContentData)  
+ * @see org.jbpm.task.service.TaskServiceSession#taskOperation(Operation, long, String, String, ContentData, List)  
  */
 public class PermissionDeniedException extends TaskException{
     public PermissionDeniedException(String message) {

--- a/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/processinstance/ProcessInstanceInfo.java
+++ b/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/processinstance/ProcessInstanceInfo.java
@@ -167,8 +167,8 @@ public class ProcessInstanceInfo{
      * <li>..and the marshaller retrieves the context instance</li>
      * <li>..which actually (re)sets all variables in {@link VariableScopeInstance}.setContextInstanceContainer(...)</li>
      * <li>This of course causes {@link ProcessEventSupport}.fireBeforeVariableChanged(...) to fire.</li>
-     * <li>Then the {@link JPAWorkingMemoryDBLogger} ends up logging a variable change -- but the associated 
-     *     process instance hasn't been persisted yet.</li> 
+     * <li>Then the {@link org.jbpm.process.audit.JPAWorkingMemoryDbLogger} ends up logging a variable change 
+	 * -- but the associated process instance hasn't been persisted yet.</li> 
      * <li>So the variable instance change is associated with process instance "0"</li>
      * <li>...and can never be retrieved, because "0" is not a valid id.</li>
      * </ul>

--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,85 @@
             <argLine>-Xmx1024m -XX:MaxPermSize=128m</argLine>
           </configuration>
         </plugin> 
-      </plugins>
-     </pluginManagement>
+		<plugin>
+		  <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.8</version>
+		  <configuration>
+			<!-- Default configuration for all reports -->
+			<excludePackageNames>org.jbpm.examples*</excludePackageNames>
+			<links>
+			  <link>http://docs.jboss.org/jbpm/v5.2/javadocs/</link>
+			</links>
+			<tags>
+			  <tag>
+				<name>model</name>
+				<placement>a</placement>
+				<head>Model:</head>
+			  </tag>
+			  <tag>
+				<name>generated</name>
+				<placement>a</placement>
+				<head>Generated Class</head>
+			  </tag>
+			  <tag>
+				<name>ordered</name>
+				<placement>a</placement>
+				<head>Ordered Sequence</head>
+			  </tag>
+			</tags>
+			<groups>
+			  <group>
+				<title>BPMN</title>
+				<packages>org.jbpm.bpmn2*</packages>
+			  </group>
+			  <group>
+				<title>Compiler</title>
+				<packages>org.jbpm.compiler*</packages>
+			  </group>
+			  <group>
+			    <title>Console</title>
+				<packages>org.jbpm.integration*</packages>
+			  </group>
+			  <group>
+			    <title>Process</title>
+				<packages>org.jbpm.process*</packages>
+			  </group>
+			  <group>
+			    <title>Ruleflow</title>
+				<packages>org.jbpm.ruleflow*</packages>
+			  </group>
+			  <group>
+			    <title>Task</title>
+				<packages>org.jbpm.task*</packages>
+			  </group>
+			  <group>
+			    <title>Workflow</title>
+				<packages>org.jbpm.workflow*</packages>
+			  </group>
+			  <!--
+			  <group>
+			    <title>Examples</title>
+				<packages>org.jbpm.examples*</packages>
+			  </group>
+			  -->
+			</groups>
+		  </configuration>
+		  <executions>
+			<execution>
+			  <id>aggregate</id>
+              <goals>
+                <goal>aggregate</goal>
+              </goals>
+              <phase>site</phase>
+              <configuration>
+                <!-- Specific configuration for the aggregate report -->
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+	  </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>


### PR DESCRIPTION
1. Changes to the top-level POM to add javadoc plugin configuration including grouping of packages
2. addition of a token package documentation example
3. elimination of all javadoc build errors
