### PR TITLE
Documentation fix - explanation for .wid and .conf files

### DIFF
--- a/jbpm-docs/src/main/docbook/en-US/Chapter-DomainSpecificProcesses/Chapter-DomainSpecificProcesses.xml
+++ b/jbpm-docs/src/main/docbook/en-US/Chapter-DomainSpecificProcesses/Chapter-DomainSpecificProcesses.xml
@@ -144,8 +144,11 @@ node definition to the existing palette nodes, adjust the drools.workDefinitions
 as follows including the default set configuration file:</para>
 
 <programlisting>
-  drools.workDefinitions = MyWorkDefinitions.conf WorkDefinitions.conf
+  drools.workDefinitions = MyWorkDefinitions.wid WorkDefinitions.conf
 </programlisting>
+
+<para>It is recommended to use extension .wid for your own definitions of domain specific nodes.
+Do not be confused with extension .conf, it is used only for backward compatibility.</para>
 
   </section>
 


### PR DESCRIPTION
Fixed error and added explanation for files used for own node definitions in docs.
