### PR TITLE
BZ804976 - Compensate boundary event catches wrong event type

### DIFF
--- a/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BoundaryEventHandler.java
+++ b/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BoundaryEventHandler.java
@@ -30,6 +30,7 @@ import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.NodeContainer;
 import org.jbpm.workflow.core.node.EventNode;
 import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
@@ -204,6 +205,18 @@ public class BoundaryEventHandler extends AbstractNodeHandler {
             final boolean cancelActivity) throws SAXException {
         super.handleNode(node, element, uri, localName, parser);
         EventNode eventNode = (EventNode) node;
+        NodeList childs = element.getChildNodes();
+        for (int i = 0; i < childs.getLength(); i++) {
+            if (childs.item(i) instanceof Element) {
+                Element el = (Element) childs.item(i);
+                if ("compensateEventDefinition".equalsIgnoreCase(el.getNodeName())) {
+                    String activityRef = el.getAttribute("activityRef");
+                    if (activityRef != null && activityRef.length() > 0) {
+                        eventNode.setMetaData("ActivityRef", activityRef);
+                    }
+                }
+            }
+        }
         eventNode.setMetaData("AttachedTo", attachedTo);
         List<EventFilter> eventFilters = new ArrayList<EventFilter>();
         EventTypeFilter eventFilter = new EventTypeFilter();

--- a/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
+++ b/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
@@ -398,8 +398,11 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
                                 "kcontext.getProcessInstance().signalEvent(\"Timer-" + attachedTo + "-" + timeCycle + (timer.getPeriod() == null ? "" : "###" + timer.getPeriod()) + "\", null);"));
                         }
                     } else if (type.startsWith("Compensate-")) {
-                    	String uniqueId = (String) node.getMetaData().get("UniqueId");
-            	        String eventType = "Compensate-" + uniqueId;
+                    	String activityRef = (String) node.getMetaData().get("ActivityRef");
+                    	if (activityRef == null) {
+                    	    activityRef = attachedTo;
+                    	}
+            	        String eventType = "Compensate-" + activityRef;
             	        ((EventTypeFilter) ((EventNode) node).getEventFilters().get(0)).setType(eventType);
                     }
                 }

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/SimpleBPMNProcessTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/SimpleBPMNProcessTest.java
@@ -38,6 +38,8 @@ import org.drools.builder.ResourceType;
 import org.drools.compiler.PackageBuilderConfiguration;
 import org.drools.definition.process.Process;
 import org.drools.event.process.DefaultProcessEventListener;
+import org.drools.event.process.ProcessNodeLeftEvent;
+import org.drools.event.process.ProcessNodeTriggeredEvent;
 import org.drools.event.process.ProcessStartedEvent;
 import org.drools.event.process.ProcessVariableChangedEvent;
 import org.drools.impl.KnowledgeBaseFactoryServiceImpl;
@@ -1171,6 +1173,7 @@ public class SimpleBPMNProcessTest extends JbpmJUnitTestCase {
 		ProcessInstance processInstance = ksession
 				.startProcess("CompensateEndEvent");
 		assertProcessInstanceCompleted(processInstance.getId(), ksession);
+		assertNodeTriggered(processInstance.getId(), "StartProcess", "Task", "CompensateEvent", "CompensateEvent2", "Compensate", "EndEvent");
 	}
 
 	public void testServiceTask() throws Exception {

--- a/jbpm-bpmn2/src/test/resources/BPMN2-CompensateEndEvent.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-CompensateEndEvent.bpmn2
@@ -26,7 +26,7 @@
     <endEvent id="_3" name="CompensateEvent" >
       <compensateEventDefinition activityRef="_2"/>
     </endEvent>
-    <boundaryEvent id="_5" name="CompensateEvent" attachedToRef="_2" >
+    <boundaryEvent id="_5" name="CompensateEvent2" attachedToRef="_2" >
       <compensateEventDefinition/>
     </boundaryEvent>
     <scriptTask id="_6" name="Compensate" >


### PR DESCRIPTION
Fix that makes compansate events to be matched based on:
1. activityRef attribute of compensateEventDefinition if defined - to be inline with spec
2. attachedTo attrbute of boundaryEvent construct
