### PR TITLE
Multi thread process persistence test case - concurrency issue

### DIFF
--- a/jbpm-test/src/test/java/org/jbpm/persistence/ProcessMultiThreadPersistenceTest.java
+++ b/jbpm-test/src/test/java/org/jbpm/persistence/ProcessMultiThreadPersistenceTest.java
@@ -44,7 +44,7 @@ public class ProcessMultiThreadPersistenceTest {
 
     private static HashMap<String, Object> context;
 
-    private static final int LOOPS = 20;
+    private static final int LOOPS = 100;
 
     public static void main(String args[]) {
 	ProcessMultiThreadPersistenceTest test = new ProcessMultiThreadPersistenceTest();


### PR DESCRIPTION
Multi thread process persistence test case - concurrency issue, see:
https://bugzilla.redhat.com/show_bug.cgi?id=805899

Test runs 100 loops and randomly sometimes throws exceptions. There are two threads each runs a business process and uses persistence.

You can pull these changes to both master and 5.2.x jbpm branches.
