### PR TITLE
JBPM-3592: Task owned query method should allow filter tasks by state

### DIFF
--- a/jbpm-human-task/src/main/java/org/jbpm/task/AsyncTaskService.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/AsyncTaskService.java
@@ -105,6 +105,8 @@ public interface AsyncTaskService {
     void getTasksAssignedAsTaskStakeholder(String userId, String language, TaskSummaryResponseHandler responseHandler);
 
     void getTasksOwned(String userId, String language, TaskSummaryResponseHandler responseHandler);
+    
+    void getTasksOwned(String userId, List<Status> status, String language, TaskSummaryResponseHandler responseHandler);
 
     void nominate(long taskId, String userId, List<OrganizationalEntity> potentialOwners, TaskOperationResponseHandler responseHandler);
 

--- a/jbpm-human-task/src/main/java/org/jbpm/task/TaskService.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/TaskService.java
@@ -94,6 +94,8 @@ public interface TaskService {
     List<TaskSummary> getTasksAssignedAsTaskStakeholder(String userId, String language);
 
     List<TaskSummary>  getTasksOwned(String userId, String language);
+    
+    List<TaskSummary>  getTasksOwned(String userId, List<Status> status, String language);
 
     void nominate(long taskId, String userId, List<OrganizationalEntity> potentialOwners);
 

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/AsyncTaskServiceWrapper.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/AsyncTaskServiceWrapper.java
@@ -29,6 +29,7 @@ import org.jbpm.task.Attachment;
 import org.jbpm.task.Comment;
 import org.jbpm.task.Content;
 import org.jbpm.task.OrganizationalEntity;
+import org.jbpm.task.Status;
 import org.jbpm.task.Task;
 import org.jbpm.task.TaskService;
 import org.jbpm.task.query.TaskSummary;
@@ -488,6 +489,19 @@ public class AsyncTaskServiceWrapper implements TaskService {
     public List<TaskSummary> getTasksOwned(String userId, String language) {
         BlockingTaskSummaryResponseHandler responseHandler = new BlockingTaskSummaryResponseHandler();
         taskService.getTasksOwned(userId, language, responseHandler);
+        try {
+            responseHandler.waitTillDone(timeout);
+        } catch (Exception e) {
+            if (responseHandler.getError() != null) {
+                throw responseHandler.getError();
+            }
+        }
+        return responseHandler.getResults();
+    }
+    
+    public List<TaskSummary> getTasksOwned(String userId, List<Status> status, String language) {
+        BlockingTaskSummaryResponseHandler responseHandler = new BlockingTaskSummaryResponseHandler();
+        taskService.getTasksOwned(userId, status, language, responseHandler);
         try {
             responseHandler.waitTillDone(timeout);
         } catch (Exception e) {

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/CommandName.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/CommandName.java
@@ -76,6 +76,7 @@ public enum CommandName {
     DeleteCommentResponse,    
     
     QueryTasksOwned,    
+    QueryTasksOwnedWithParticularStatus,    
     QueryTasksAssignedAsBusinessAdministrator,
     QueryTasksAssignedAsExcludedOwner,
     QueryTasksAssignedAsPotentialOwner,

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/TaskClient.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/TaskClient.java
@@ -27,6 +27,7 @@ import org.jbpm.task.Attachment;
 import org.jbpm.task.Comment;
 import org.jbpm.task.Content;
 import org.jbpm.task.OrganizationalEntity;
+import org.jbpm.task.Status;
 import org.jbpm.task.Task;
 import org.jbpm.task.service.TaskClientHandler.AddAttachmentResponseHandler;
 import org.jbpm.task.service.TaskClientHandler.AddCommentResponseHandler;
@@ -408,6 +409,22 @@ public class TaskClient implements AsyncTaskService{
         args.add( language );
         Command cmd = new Command( counter.getAndIncrement(),
                                    CommandName.QueryTasksOwned,
+                                   args );
+        handler.addResponseHandler( cmd.getId(),
+                                    responseHandler );
+        connector.write( cmd );
+    }
+    
+    public void getTasksOwned(String userId,
+                              List<Status> status,
+                              String language,
+                              TaskSummaryResponseHandler responseHandler) {
+        List<Object> args = new ArrayList<Object>( 3 );
+        args.add( userId );
+        args.add( status );
+        args.add( language );
+        Command cmd = new Command( counter.getAndIncrement(),
+                                   CommandName.QueryTasksOwnedWithParticularStatus,
                                    args );
         handler.addResponseHandler( cmd.getId(),
                                     responseHandler );

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/TaskServerHandler.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/TaskServerHandler.java
@@ -29,6 +29,7 @@ import org.jbpm.task.Attachment;
 import org.jbpm.task.Comment;
 import org.jbpm.task.Content;
 import org.jbpm.task.OrganizationalEntity;
+import org.jbpm.task.Status;
 import org.jbpm.task.Task;
 import org.jbpm.task.query.TaskSummary;
 
@@ -246,6 +247,24 @@ public class TaskServerHandler {
                     List<TaskSummary> results = taskSession.getTasksOwned(
                             (String) cmd.getArguments().get(0),
                             (String) cmd.getArguments().get(1));
+
+                    // return
+                    List args = Arrays.asList((new List[] {results}));
+                    Command resultsCmnd = new Command(cmd.getId(),
+                            CommandName.QueryTaskSummaryResponse,
+                            args);
+                    session.write(resultsCmnd);
+                    break;
+                }
+                case QueryTasksOwnedWithParticularStatus: {
+                    // prepare
+                    response = CommandName.QueryTaskSummaryResponse;
+                    
+                    // execute
+                    List<TaskSummary> results = taskSession.getTasksOwned(
+                            (String) cmd.getArguments().get(0),
+                            (List<Status>) cmd.getArguments().get(1),
+                            (String) cmd.getArguments().get(2));
 
                     // return
                     List args = Arrays.asList((new List[] {results}));

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/TaskServiceSession.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/TaskServiceSession.java
@@ -598,6 +598,11 @@ public class TaskServiceSession extends TaskPersistenceManagerAccessor {
         doCallbackUserOperation(userId);
         return tpm.queryTasksWithUserIdAndLanguage("TasksOwned", userId, language);
     }
+    
+    public List<TaskSummary> getTasksOwned(final String userId, List<Status> status, final String language) {
+        doCallbackUserOperation(userId);
+        return tpm.queryTasksWithUserIdStatusAndLanguage("TasksOwnedWithParticularStatus", userId, status, language);
+    }
 
     public List<TaskSummary> getTasksAssignedAsBusinessAdministrator(final String userId,
                                                                      final String language) {

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/local/LocalTaskService.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/local/LocalTaskService.java
@@ -29,6 +29,7 @@ import org.jbpm.task.Attachment;
 import org.jbpm.task.Comment;
 import org.jbpm.task.Content;
 import org.jbpm.task.OrganizationalEntity;
+import org.jbpm.task.Status;
 import org.jbpm.task.Task;
 import org.jbpm.task.TaskService;
 import org.jbpm.task.query.TaskSummary;
@@ -198,6 +199,10 @@ public class LocalTaskService implements TaskService {
 
     public List<TaskSummary> getTasksOwned(String userId, String language) {
         return session.getTasksOwned(userId, language);
+    }
+    
+    public List<TaskSummary> getTasksOwned(String userId, List<Status> status, String language) {
+        return session.getTasksOwned(userId, status, language);
     }
 
     public void nominate(long taskId, String userId, List<OrganizationalEntity> potentialOwners) {

--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/persistence/TaskPersistenceManager.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/persistence/TaskPersistenceManager.java
@@ -223,6 +223,16 @@ public class TaskPersistenceManager {
 
         return (List<TaskSummary>) resultListObject;
     }
+    
+    public List<TaskSummary> queryTasksWithUserIdStatusAndLanguage(String queryName, String userId, List<Status> status, String language) { 
+        Query query = createQuery(queryName);
+        query.setParameter("userId", userId);
+        query.setParameter("status", status);
+        query.setParameter("language", language);
+        Object resultListObject = query.getResultList();
+
+        return (List<TaskSummary>) resultListObject;
+    }
 
 
  

--- a/jbpm-human-task/src/main/resources/META-INF/Taskorm.xml
+++ b/jbpm-human-task/src/main/resources/META-INF/Taskorm.xml
@@ -557,6 +557,57 @@ where
           </query>
           <!-- hint name="org.hibernate.timeout" value="200"/ -->
       </named-query>
+      
+      <named-query name="TasksOwnedWithParticularStatus">
+          <query>
+select
+    new org.jbpm.task.query.TaskSummary(
+    t.id,
+    t.taskData.processInstanceId,
+    name.text,
+    subject.text,
+    description.text,
+    t.taskData.status,
+    t.priority,
+    t.taskData.skipable,
+    t.taskData.actualOwner,
+    t.taskData.createdBy,
+    t.taskData.createdOn,
+    t.taskData.activationTime,
+    t.taskData.expirationTime,
+    t.taskData.processId,
+    t.taskData.processSessionId)
+from
+    Task t 
+    left join t.taskData.createdBy
+    left join t.subjects as subject
+    left join t.descriptions as description
+    left join t.names as name
+where
+    t.taskData.actualOwner.id = :userId and
+
+    t.taskData.status in (:status) and
+
+    (
+    name.language = :language
+    or t.names.size = 0
+    ) and
+
+    (
+    subject.language = :language
+    or t.subjects.size = 0
+    ) and
+
+    (
+    description.language = :language
+    or t.descriptions.size = 0
+    ) and
+
+    t.taskData.expirationTime is null
+          </query>
+          <!-- hint name="org.hibernate.timeout" value="200"/ -->
+      </named-query>
+      
 	  <named-query name="UnescalatedDeadlines">
           <query>
 select

--- a/jbpm-human-task/src/test/java/org/jbpm/task/service/TaskLifeCycleBaseTest.java
+++ b/jbpm-human-task/src/test/java/org/jbpm/task/service/TaskLifeCycleBaseTest.java
@@ -17,6 +17,7 @@
 package org.jbpm.task.service;
 
 import java.io.StringReader;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -127,11 +128,31 @@ public abstract class TaskLifeCycleBaseTest extends BaseTest {
         assertEquals(1, tasks.size());
         assertEquals(Status.Reserved, tasks.get(0).getStatus());
         
+        //No task in 'Ready' status for bobba
+        taskSummaryResponseHandler = new BlockingTaskSummaryResponseHandler();
+        client.getTasksOwned(users.get( "bobba" ).getId(), Arrays.asList(new Status[]{Status.Ready}) ,"en-UK", taskSummaryResponseHandler);
+        tasks = taskSummaryResponseHandler.getResults(); 
+        assertTrue(tasks.isEmpty());
+        
+        //1 task in 'Reserved' status for bobba
+        taskSummaryResponseHandler = new BlockingTaskSummaryResponseHandler();
+        client.getTasksOwned(users.get( "bobba" ).getId(), Arrays.asList(new Status[]{Status.Reserved}) ,"en-UK", taskSummaryResponseHandler);
+        tasks = taskSummaryResponseHandler.getResults(); 
+        assertEquals(1, tasks.size());
+        assertEquals(Status.Reserved, tasks.get(0).getStatus());
+        
         BlockingTaskOperationResponseHandler responseHandler = new BlockingTaskOperationResponseHandler();
         client.start( taskId, users.get( "bobba" ).getId(), responseHandler );  
 
         taskSummaryResponseHandler = new BlockingTaskSummaryResponseHandler();
         client.getTasksAssignedAsPotentialOwner(users.get( "bobba" ).getId(), "en-UK", taskSummaryResponseHandler);
+        tasks = taskSummaryResponseHandler.getResults(); 
+        assertEquals(1, tasks.size());
+        assertEquals(Status.InProgress, tasks.get(0).getStatus());
+        
+        //1 task in 'InProgress or Ready' status for bobba
+        taskSummaryResponseHandler = new BlockingTaskSummaryResponseHandler();
+        client.getTasksOwned(users.get( "bobba" ).getId(), Arrays.asList(new Status[]{Status.InProgress, Status.Ready}) ,"en-UK", taskSummaryResponseHandler);
         tasks = taskSummaryResponseHandler.getResults(); 
         assertEquals(1, tasks.size());
         assertEquals(Status.InProgress, tasks.get(0).getStatus());


### PR DESCRIPTION
- Implemented new getTasksOwned() method in client and server to retrieve the list of tasks owned by a user but that have a particular status
