### PR TITLE
BZ-772241: replace deprecated join() and session.close() for awaitUninterruptibly()

### DIFF
--- a/jbpm-human-task/src/main/java/org/jbpm/task/service/mina/MinaTaskClientConnector.java
+++ b/jbpm-human-task/src/main/java/org/jbpm/task/service/mina/MinaTaskClientConnector.java
@@ -95,7 +95,7 @@ public class MinaTaskClientConnector implements TaskClientConnector {
                                                        new ObjectSerializationCodecFactory()));
 
             ConnectFuture future1 = connector.connect( address );
-            future1.join();
+            future1.awaitUninterruptibly();
             if (!future1.isConnected()) {
                 return false;
             }
@@ -108,26 +108,28 @@ public class MinaTaskClientConnector implements TaskClientConnector {
     }
 
     public void disconnect() {
-        if ( session!= null && session.isConnected() ) {
-            session.close();
-            session.getCloseFuture().join();
+        if (session != null && session.isConnected()) {
+            session.close(true).awaitUninterruptibly();
+        }
+        if (this.connector != null && this.connector.isActive()) {
+            this.connector.dispose();
+            this.connector = null;
         }
     }
 
-	public void write(Object message) {
-		session.write(message);
-	}
+    public void write(Object message) {
+        session.write(message);
+    }
 
-	public BaseHandler getHandler() {
-		return handler;
-	}
+    public BaseHandler getHandler() {
+        return handler;
+    }
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public AtomicInteger getCounter() {
-		return counter;
-	}
-
+    public AtomicInteger getCounter() {
+        return counter;
+    }
 }


### PR DESCRIPTION
Closing the connector when the communication is over will cause the automatic release of "opened files"/sockets that Mina is using for the Human Task interactions. 
https://bugzilla.redhat.com/show_bug.cgi?id=772241
