### PR TITLE
BZ807965 - Process ID cannot be the same as process Name, for any proces...

### DIFF
--- a/jbpm-gwt/jbpm-gwt-shared/src/main/java/org/jbpm/integration/console/shared/GuvnorConnectionUtils.java
+++ b/jbpm-gwt/jbpm-gwt-shared/src/main/java/org/jbpm/integration/console/shared/GuvnorConnectionUtils.java
@@ -386,7 +386,25 @@ public class GuvnorConnectionUtils {
                 applyAuth(checkConnection);
                 checkConnection.connect();
                 if(checkConnection.getResponseCode() == 200) {
-                    return true;
+                    
+                    XMLInputFactory factory = XMLInputFactory.newInstance();
+                    XMLStreamReader reader = factory
+                            .createXMLStreamReader(checkConnection.getInputStream());
+                    
+                    boolean foundFormFormat = false;
+                    while (reader.hasNext()) {
+                        if (reader.next() == XMLStreamReader.START_ELEMENT) {
+                            if ("format".equals(reader.getLocalName())) {
+                                reader.next();
+                                String pname = reader.getElementText();
+                                if ("flt".equalsIgnoreCase(pname)) {
+                                    foundFormFormat = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    return foundFormFormat;
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
...s within a package deployed to jbpm-console

Ensures that when console checks for process/task forms in Guvnor it will fetch only proper formats of assets (flt)
