### PR TITLE
more descriptive jbpm-flow exceptions

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/WorkflowRuntimeException.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/WorkflowRuntimeException.java
@@ -1,0 +1,111 @@
+package org.jbpm.workflow.instance;
+
+import java.text.MessageFormat;
+
+import org.drools.runtime.process.NodeInstance;
+
+/**
+ * This exception provides the context information of the error in execution of the flow. <br/>
+ * It would be helpful to located the error instead of confusing stack trace
+ * 
+ * @author tanxu
+ * @date Mar 19, 2012
+ * @since
+ */
+public class WorkflowRuntimeException extends RuntimeException {
+
+    private long processInstanceId;
+    private String processId;
+    private long nodeInstanceId;
+    private long nodeId;
+    private String nodeName;
+
+    public WorkflowRuntimeException(Exception e) {
+        super(e);
+    }
+
+    public WorkflowRuntimeException(NodeInstance nodeInstance, Exception e) {
+        super(e);
+        this.processInstanceId = nodeInstance.getProcessInstance().getId();
+        this.processId = nodeInstance.getProcessInstance().getProcessId();
+        this.nodeInstanceId = nodeInstance.getId();
+        this.nodeId = nodeInstance.getNodeId();
+        this.nodeName = nodeInstance.getNodeName();
+    }
+
+    /**
+     * @return the processInstanceId
+     */
+    public long getProcessInstanceId() {
+        return processInstanceId;
+    }
+
+    /**
+     * @param processInstanceId the processInstanceId to set
+     */
+    public void setProcessInstanceId(long processInstanceId) {
+        this.processInstanceId = processInstanceId;
+    }
+
+    /**
+     * @return the processId
+     */
+    public String getProcessId() {
+        return processId;
+    }
+
+    /**
+     * @param processId the processId to set
+     */
+    public void setProcessId(String processId) {
+        this.processId = processId;
+    }
+
+    /**
+     * @return the nodeInstanceId
+     */
+    public long getNodeInstanceId() {
+        return nodeInstanceId;
+    }
+
+    /**
+     * @param nodeInstanceId the nodeInstanceId to set
+     */
+    public void setNodeInstanceId(long nodeInstanceId) {
+        this.nodeInstanceId = nodeInstanceId;
+    }
+
+    /**
+     * @return the nodeId
+     */
+    public long getNodeId() {
+        return nodeId;
+    }
+
+    /**
+     * @param nodeId the nodeId to set
+     */
+    public void setNodeId(long nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    /**
+     * @return the nodeName
+     */
+    public String getNodeName() {
+        return nodeName;
+    }
+
+    /**
+     * @param nodeName the nodeName to set
+     */
+    public void setNodeName(String nodeName) {
+        this.nodeName = nodeName;
+    }
+
+    @Override
+    public String getMessage() {
+        return MessageFormat.format("[{0}:{4} - {1}:{2}] -- {3}", getProcessId(),
+                getNodeName(), getNodeId(), getCause().getMessage(), getProcessInstanceId());
+    }
+}

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/ExtendedNodeInstanceImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/ExtendedNodeInstanceImpl.java
@@ -59,24 +59,21 @@ public abstract class ExtendedNodeInstanceImpl extends NodeInstanceImpl {
 			}
 		}
 	}
-	
+
 	protected void executeAction(DroolsAction droolsAction) {
 		Action action = (Action) droolsAction.getMetaData("Action");
 		ProcessContext context = new ProcessContext(getProcessInstance().getKnowledgeRuntime());
 		context.setNodeInstance(this);
 		try {
 			action.execute(context);
-		} catch (Exception exception) {
-			exception.printStackTrace();
-			String exceptionName = exception.getClass().getName();
+		} catch (Exception e) {
+			String exceptionName = e.getClass().getName();
 			ExceptionScopeInstance exceptionScopeInstance = (ExceptionScopeInstance)
 				resolveContextInstance(ExceptionScope.EXCEPTION_SCOPE, exceptionName);
 			if (exceptionScopeInstance == null) {
-				exception.printStackTrace();
-				throw new IllegalArgumentException(
-					"Could not find exception handler for " + exceptionName + " while executing node " + getNodeId());
+				throw new RuntimeException("unable to execute Action: " + e.getMessage(), e);
 			}
-			exceptionScopeInstance.handleException(exceptionName, exception);
+			exceptionScopeInstance.handleException(exceptionName, e);
 		}
 	}
 	

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
@@ -39,6 +39,7 @@ import org.jbpm.process.instance.context.exclusive.ExclusiveGroupInstance;
 import org.jbpm.process.instance.context.variable.VariableScopeInstance;
 import org.jbpm.workflow.core.impl.NodeImpl;
 import org.jbpm.workflow.instance.WorkflowProcessInstance;
+import org.jbpm.workflow.instance.WorkflowRuntimeException;
 import org.jbpm.workflow.instance.node.CompositeNodeInstance;
 
 /**
@@ -119,7 +120,15 @@ public abstract class NodeInstanceImpl implements org.jbpm.workflow.instance.Nod
     		((InternalProcessRuntime) kruntime.getProcessRuntime())
     			.getProcessEventSupport().fireBeforeNodeTriggered(this, kruntime);
     	}
-        internalTrigger(from, type);
+        try {
+            internalTrigger(from, type);
+        }
+        catch (WorkflowRuntimeException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            throw new WorkflowRuntimeException(this, e);
+        }
         if (!hidden) {
         	((InternalProcessRuntime) kruntime.getProcessRuntime())
         		.getProcessEventSupport().fireAfterNodeTriggered(this, kruntime);

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ActionNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ActionNodeInstance.java
@@ -46,7 +46,7 @@ public class ActionNodeInstance extends NodeInstanceImpl {
 		    context.setNodeInstance(this);
 	        action.execute(context);		    
 		} catch (Exception e) {
-		    throw new RuntimeException("unable to execute Action", e);
+		    throw new RuntimeException("unable to execute Action: " + e.getMessage(), e);
 		}
     	triggerCompleted();
     }


### PR DESCRIPTION
introduces modifications to jbpm-flow that throw more descriptive exception messages.
the new exception messages provide context to the problem and allows for a BRMS system admin to isolate workFlow related problems more quickly.

The following is an example of an existing workflow exception thrown by jbpm5 prior to this patch :
        Caused by: java.lang.RuntimeException: unable to execute Action

with this patch applied, the following is an example of the new exception providing context to the root problem:
       Caused by: org.jbpm.workflow.instance.WorkflowRuntimeException  : unable to execute Action, NodeId=8, NodeName=”ExitScript”, ProcessId=”ErrorAfterFirstSafePoint”
