### PR TITLE
Human task persistence cleanup

### DIFF
--- a/jbpm-human-task-war/src/main/resources/META-INF/persistence.xml
+++ b/jbpm-human-task-war/src/main/resources/META-INF/persistence.xml
@@ -11,27 +11,25 @@
     <non-jta-data-source>java:jboss/datasources/jbpmDS</non-jta-data-source>       
     <mapping-file>META-INF/Taskorm.xml</mapping-file>
     <class>org.jbpm.task.Attachment</class>
-    <class>org.jbpm.task.Content</class>
     <class>org.jbpm.task.BooleanExpression</class>
     <class>org.jbpm.task.Comment</class>
-    <class>org.jbpm.task.Deadline</class>
-    <class>org.jbpm.task.Comment</class>
+    <class>org.jbpm.task.Content</class>
     <class>org.jbpm.task.Deadline</class>
     <class>org.jbpm.task.Delegation</class>
+    <class>org.jbpm.task.EmailNotification</class>
+    <class>org.jbpm.task.EmailNotificationHeader</class>
     <class>org.jbpm.task.Escalation</class>
     <class>org.jbpm.task.Group</class>
     <class>org.jbpm.task.I18NText</class>
     <class>org.jbpm.task.Notification</class>
-    <class>org.jbpm.task.EmailNotification</class>
-    <class>org.jbpm.task.EmailNotificationHeader</class>
+    <class>org.jbpm.task.OnAllSubTasksEndParentEndStrategy</class>
+    <class>org.jbpm.task.OnParentAbortAllSubTasksEndStrategy</class>
     <class>org.jbpm.task.PeopleAssignments</class>
     <class>org.jbpm.task.Reassignment</class>
     <class>org.jbpm.task.Status</class>
+    <class>org.jbpm.task.SubTasksStrategy</class>
     <class>org.jbpm.task.Task</class>
     <class>org.jbpm.task.TaskData</class>
-    <class>org.jbpm.task.SubTasksStrategy</class>
-    <class>org.jbpm.task.OnParentAbortAllSubTasksEndStrategy</class>
-    <class>org.jbpm.task.OnAllSubTasksEndParentEndStrategy</class>
     <class>org.jbpm.task.User</class>
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>          


### PR DESCRIPTION
- sorted classes alphabetically
- left out duplicate classes

Should be more readable and those duplicate classes were redundant, I believe...
