### PR TITLE
Session util logging

### DIFF
--- a/jbpm-gwt/jbpm-gwt-core/src/main/java/org/jbpm/integration/console/StatefulKnowledgeSessionUtil.java
+++ b/jbpm-gwt/jbpm-gwt-core/src/main/java/org/jbpm/integration/console/StatefulKnowledgeSessionUtil.java
@@ -189,7 +189,7 @@ public class StatefulKnowledgeSessionUtil {
                 kagent.applyChangeSet(ResourceFactory.newReaderResource(guvnorUtils.createChangeSet()));
                 kbase = kagent.getKnowledgeBase();
             } catch (Throwable t) {
-                logger.error("Could not load processes from Guvnor: " + t.getMessage());
+                logger.error("Could not load processes from Guvnor: " + t.getMessage(), t);
             }
         } else {
             logger.warn("Could not connect to Guvnor.");


### PR DESCRIPTION
The message is not enough find out what failed, especially when it's null. The Throwable object should be logged too.
