### PR TITLE
make use of JBoss AS7 modules for hornetq dependencies

### DIFF
--- a/jbpm-gwt/jbpm-gwt-console-server/pom.xml
+++ b/jbpm-gwt/jbpm-gwt-console-server/pom.xml
@@ -89,6 +89,11 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-war-plugin</artifactId>
             <configuration>
+                <archive>
+                    <manifestEntries>
+                        <Dependencies>org.hornetq</Dependencies>
+                    </manifestEntries>
+                </archive>
                <!-- exclude old codec version from gwt-console-server -->
                <dependentWarExcludes>WEB-INF/lib/commons-codec-1.3.jar,WEB-INF/lib/mvel2-2.0.18-RC4.jar</dependentWarExcludes>   
             </configuration>

--- a/jbpm-human-task-war/pom.xml
+++ b/jbpm-human-task-war/pom.xml
@@ -42,10 +42,10 @@
     	<artifactId>hornetq-core</artifactId>
     </dependency>
     <dependency>
-    	<groupId>org.jboss.netty</groupId>
-    	<artifactId>netty</artifactId>
-    	<version>3.2.0.Final</version>
-    	<scope>runtime</scope>
+       <groupId>org.jboss.netty</groupId>
+       <artifactId>netty</artifactId>
+       <version>3.2.0.Final</version>
+       <scope>runtime</scope>
     </dependency>
 
     <!-- Test -->
@@ -60,4 +60,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <build>
+    <pluginManagement>
+     <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-war-plugin</artifactId>
+            <configuration>
+                <archive>
+                    <manifestEntries>
+                        <Dependencies>org.hornetq</Dependencies>
+                    </manifestEntries>
+                </archive>
+               </configuration>
+          </plugin>
+       </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/jbpm-installer/build.xml
+++ b/jbpm-installer/build.xml
@@ -373,6 +373,12 @@
     </copy>
     <!-- Fix for conflicting javassist jar -->
     <delete file="${install.home}/target/jbpm-gwt-console-server-war/WEB-INF/lib/javassist-3.6.0.GA.jar"/>
+  	<!-- remove hornetq related libs as they are referenced from jboss module -->
+  	<delete>
+      <fileset dir="${install.home}/target/jbpm-gwt-console-server-war/WEB-INF/lib/" includes="hornetq*.jar,netty*.jar" />
+    </delete>
+  	<delete file="hornetq-core-2.2.10.Final.jar"/>
+  	<delete file="${install.home}/target/jbpm-gwt-console-server-war/WEB-INF/lib/netty-3.1.5.GA.jar"/>
     <!-- Other configuration like work item handlers -->
     <copy todir="${install.home}/target/jbpm-gwt-console-server-war/WEB-INF/classes" overwrite="true">
       <fileset dir="${install.home}/conf"/>


### PR DESCRIPTION
Instead of packaging hornetq and its dependencies (netty) into web applications use dedicated manifest attribute (Dependencies) to refern to hornetq libraries on Jboss AS 7. 
Installer ant script modified to remove hornetq and netty libs from console as by default it is packaged due to JBoss AS 5 requires it.
