### PR TITLE
JBPM-3451 No logging/indication that a script task has failed due to not...

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/SimpleBPMNProcessTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/SimpleBPMNProcessTest.java
@@ -1950,6 +1950,21 @@ public class SimpleBPMNProcessTest extends JbpmBpmn2TestCase {
 		ProcessInstance processInstance = ksession.startProcess("Composite");
 		assertTrue(processInstance.getState() == ProcessInstance.STATE_COMPLETED);
 	}
+	
+    public void testNullVariableInScriptTaskProcess() throws Exception {
+        KnowledgeBase kbase = createKnowledgeBase("BPMN2-NullVariableInScriptTaskProcess.bpmn2");
+        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
+        ProcessInstance process = ksession.startProcess("nullVariableInScriptAfterTimer");
+
+        assertEquals(ProcessInstance.STATE_ACTIVE, process.getState());
+       
+        long sleep = 1000;
+        logger.debug("Sleeping " + sleep/1000 + " seconds." );
+        Thread.sleep(sleep);
+        
+        assertTrue(ProcessInstance.STATE_ABORTED == process.getState());
+        
+    }
 
 	private KnowledgeBase createKnowledgeBase(String process) throws Exception {
 		KnowledgeBaseFactory

--- a/jbpm-bpmn2/src/test/resources/BPMN2-NullVariableInScriptTaskProcess.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-NullVariableInScriptTaskProcess.bpmn2
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<definitions id="Definition"
+             targetNamespace="http://www.jboss.org/drools"
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:g="http://www.jboss.org/drools/flow/gpd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <itemDefinition id="_timeBefore" structureRef="java.lang.Long" />
+  <itemDefinition id="_timeExecution" structureRef="java.lang.Long" />
+
+  <process processType="Private" isExecutable="true" 
+           id="nullVariableInScriptAfterTimer" 
+           name="nullVariableInScriptAfterTimer" 
+           tns:packageName="defaultPackage" >
+
+    <!-- process variables -->
+    <property id="timeBeforeTimer" itemSubjectRef="_timeBeforeTimerItem"/>
+    <property id="timerExecutionTime" itemSubjectRef="_timerExecutionTimeItem"/>
+
+    <!-- nodes -->
+    <startEvent id="_1" name="Start" />
+    <endEvent id="_2" name="End" >
+    <terminateEventDefinition/>
+    </endEvent>
+    
+    <scriptTask id="_5" name="Before Timer" scriptFormat="http://www.java.com/java" >
+      <script>System.out.println("Before Timer");
+timeBeforeTimer = System.currentTimeMillis();</script>
+    </scriptTask>
+
+    <intermediateCatchEvent id="_4" name="Timer" >
+      <timerEventDefinition>
+        <timeCycle>500</timeCycle>
+      </timerEventDefinition>
+    </intermediateCatchEvent>
+
+    <scriptTask id="_3" name="After Timer" scriptFormat="http://www.java.com/java" >
+      <script>System.out.println("After Timer");
+timerExecutionTime = System.currentTimeMillis() - (Long) timeBeforeTimer;</script>
+    </scriptTask>
+ 
+
+    <!-- connections -->
+    <sequenceFlow id="_3-_2" sourceRef="_3" targetRef="_2" />
+    <sequenceFlow id="_4-_3" sourceRef="_4" targetRef="_3" />
+    <sequenceFlow id="_5-_4" sourceRef="_5" targetRef="_4" />
+    <sequenceFlow id="_1-_5" sourceRef="_1" targetRef="_5" />
+
+  </process>
+
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="org.plugtree.training.jbpm.delaytimereventprocess" >
+      <bpmndi:BPMNShape bpmnElement="_1" >
+        <dc:Bounds x="16" y="16" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_2" >
+        <dc:Bounds x="463" y="16" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_3" >
+        <dc:Bounds x="326" y="16" width="105" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_4" >
+        <dc:Bounds x="246" y="16" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_5" >
+        <dc:Bounds x="96" y="16" width="118" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_3-_2" >
+        <di:waypoint x="378" y="40" />
+        <di:waypoint x="487" y="40" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_4-_3" >
+        <di:waypoint x="270" y="40" />
+        <di:waypoint x="378" y="40" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_5-_4" >
+        <di:waypoint x="155" y="40" />
+        <di:waypoint x="270" y="40" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_1-_5" >
+        <di:waypoint x="40" y="40" />
+        <di:waypoint x="155" y="40" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/jbpm-flow/pom.xml
+++ b/jbpm-flow/pom.xml
@@ -87,5 +87,9 @@
       <artifactId>org.osgi.compendium</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
... being able to resolve a variable, when script is executed after a timer

Added logger that will log the error message and in addition to that process instance will be aborted to prevent of leaving unmanaged process instances as it failed on action node that is not recoverable (it is not StateBasedNodeInstance)
