### PR TITLE
removes naming restriction for conditional events when referring to proc...

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/SimpleBPMNProcessTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/SimpleBPMNProcessTest.java
@@ -16,6 +16,9 @@
 
 package org.jbpm.bpmn2;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
@@ -42,6 +45,7 @@ import org.drools.event.process.ProcessNodeLeftEvent;
 import org.drools.event.process.ProcessNodeTriggeredEvent;
 import org.drools.event.process.ProcessStartedEvent;
 import org.drools.event.process.ProcessVariableChangedEvent;
+import org.drools.event.rule.DebugAgendaEventListener;
 import org.drools.impl.KnowledgeBaseFactoryServiceImpl;
 import org.drools.io.ResourceFactory;
 import org.drools.process.core.datatype.impl.type.ObjectDataType;
@@ -51,6 +55,7 @@ import org.drools.runtime.process.WorkItem;
 import org.drools.runtime.process.WorkItemHandler;
 import org.drools.runtime.process.WorkItemManager;
 import org.drools.runtime.process.WorkflowProcessInstance;
+import org.drools.runtime.rule.FactHandle;
 import org.jbpm.bpmn2.core.Association;
 import org.jbpm.bpmn2.core.DataStore;
 import org.jbpm.bpmn2.core.Definitions;
@@ -66,6 +71,7 @@ import org.jbpm.compiler.xml.XmlProcessReader;
 import org.jbpm.process.instance.impl.demo.DoNothingWorkItemHandler;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.jbpm.ruleflow.core.RuleFlowProcess;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Attr;
@@ -1950,6 +1956,44 @@ public class SimpleBPMNProcessTest extends JbpmBpmn2TestCase {
 		ProcessInstance processInstance = ksession.startProcess("Composite");
 		assertTrue(processInstance.getState() == ProcessInstance.STATE_COMPLETED);
 	}
+	
+    public void testIntermediateCatchEventConditionFilterByProcessInstance()throws Exception {
+        KnowledgeBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventConditionFilterByProcessInstance.bpmn2");
+        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
+        Map<String,Object> params1 = new HashMap<String,Object>();
+        params1.put("personId", Long.valueOf(1L));
+        Person person1 = new Person();
+        person1.setId(1L);
+        WorkflowProcessInstance pi1 = (WorkflowProcessInstance) ksession.createProcessInstance("IntermediateCatchEventConditionFilterByProcessInstance", params1);
+        long pi1id = pi1.getId();
+        
+        ksession.insert(pi1);
+        FactHandle personHandle1 = ksession.insert(person1);
+        
+        ksession.startProcessInstance(pi1.getId());
+        
+        Map<String,Object> params2 = new HashMap<String,Object>();
+        params2.put("personId", Long.valueOf(2L));
+        Person person2 = new Person();
+        person2.setId(2L);
+        
+        WorkflowProcessInstance pi2 = (WorkflowProcessInstance) ksession.createProcessInstance("IntermediateCatchEventConditionFilterByProcessInstance", params2);
+        long pi2id = pi2.getId();
+        
+        ksession.insert(pi2);
+        FactHandle personHandle2 = ksession.insert(person2);
+        
+        ksession.startProcessInstance(pi2.getId());
+        
+        person1.setName("John");
+        ksession.update(personHandle1, person1);
+        
+        
+        
+        assertNull("First process should be completed", ksession.getProcessInstance(pi1id));
+        assertNotNull("Second process should NOT be completed", ksession.getProcessInstance(pi2id));
+
+    }
 
 	private KnowledgeBase createKnowledgeBase(String process) throws Exception {
 		KnowledgeBaseFactory

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/objects/Person.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/objects/Person.java
@@ -18,10 +18,11 @@ package org.jbpm.bpmn2.objects;
 
 import java.io.Serializable;
 
+
 public class Person implements Serializable {
     
 	private static final long serialVersionUID = 5L;
-	
+	private Long id;
 	private String name;
 
     public String getName() {
@@ -32,4 +33,11 @@ public class Person implements Serializable {
         this.name = name;
     }
 
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public long getId() {
+        return id;
+    }
 }

--- a/jbpm-bpmn2/src/test/resources/BPMN2-IntermediateCatchEventConditionFilterByProcessInstance.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-IntermediateCatchEventConditionFilterByProcessInstance.bpmn2
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:g="http://www.jboss.org/drools/flow/gpd" xmlns:tns="http://www.jboss.org/drools" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="Definition" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.jboss.org/drools" typeLanguage="http://www.java.com/javaTypes">
+  <itemDefinition id="_varIdItem" structureRef="java.lang.String"/>
+  <itemDefinition id="_varNameItem" structureRef="java.lang.String"/>
+  <process id="IntermediateCatchEventConditionFilterByProcessInstance" tns:packageName="defaultPackage" name="IntermediateCatchEventConditionFilterByProcessInstance" isExecutable="true" processType="Private">
+    <property id="personId" itemSubjectRef="_varIdItem"/>
+    <property id="varName" itemSubjectRef="_varNameItem"/>
+    <startEvent id="__1" name="Start">
+      <outgoing>__1-_2</outgoing>
+    </startEvent>
+    <scriptTask id="_2" name="Started">
+      <incoming>__1-_2</incoming>
+      <outgoing>_2-_18</outgoing>
+      <script>System.out.println(&quot;Started for person: &quot; + kcontext.getVariable(&quot;personId&quot;));</script>
+    </scriptTask>
+    <intermediateCatchEvent id="_18" name="Proceed">
+      <incoming>_2-_18</incoming>
+      <outgoing>_18-_9</outgoing>
+      <conditionalEventDefinition id="ConditionalEventDefinition_1">
+        <condition xsi:type="tFormalExpression" id="FormalExpression_1" language="http://www.jboss.org/drools/rule">
+        
+        p: org.drools.runtime.process.WorkflowProcessInstance()
+        personId: Long() from p.getVariable(&quot;personId&quot;)
+        org.jbpm.bpmn2.objects.Person(id == personId, name == &quot;John&quot;)
+        
+        </condition>
+      </conditionalEventDefinition>
+    </intermediateCatchEvent>
+    <endEvent id="_3" name="End">
+      <incoming>_9-_3</incoming>
+      <terminateEventDefinition id="TerminateEventDefinition_1"/>
+    </endEvent>
+    <scriptTask id="_9" name="Proceeded">
+      <incoming>_18-_9</incoming>
+      <outgoing>_9-_3</outgoing>
+      <script>System.out.println(&quot;Proceeded for person: &quot; + kcontext.getVariable(&quot;personId&quot;));</script>
+    </scriptTask>
+    <sequenceFlow id="__1-_2" sourceRef="__1" targetRef="_2"/>
+    <sequenceFlow id="_2-_18" sourceRef="_2" targetRef="_18"/>
+    <sequenceFlow id="_9-_3" sourceRef="_9" targetRef="_3"/>
+    <sequenceFlow id="_18-_9" sourceRef="_18" targetRef="_9"/>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="IntermediateCatchEventConditionFilterByProcessInstance">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="__1" isHorizontal="true">
+        <dc:Bounds height="48.0" width="48.0" x="16.0" y="19.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ScriptTask_1" bpmnElement="_2" isHorizontal="true">
+        <dc:Bounds height="55.0" width="85.0" x="96.0" y="16.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_IntermediateCatchEvent_1" bpmnElement="_18" isHorizontal="true">
+        <dc:Bounds height="32.0" width="32.0" x="213.0" y="27.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="_3" isHorizontal="true">
+        <dc:Bounds height="48.0" width="48.0" x="394.0" y="19.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ScriptTask_2" bpmnElement="_9" isHorizontal="true">
+        <dc:Bounds height="55.0" width="85.0" x="277.0" y="16.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="__1-_2" sourceElement="BPMNShape_StartEvent_1" targetElement="BPMNShape_ScriptTask_1">
+        <di:waypoint xsi:type="dc:Point" x="64.0" y="43.0"/>
+        <di:waypoint xsi:type="dc:Point" x="96.0" y="43.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="_2-_18" sourceElement="BPMNShape_ScriptTask_1" targetElement="BPMNShape_IntermediateCatchEvent_1">
+        <di:waypoint xsi:type="dc:Point" x="181.0" y="43.0"/>
+        <di:waypoint xsi:type="dc:Point" x="213.0" y="43.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="_9-_3" sourceElement="BPMNShape_ScriptTask_2" targetElement="BPMNShape_EndEvent_1">
+        <di:waypoint xsi:type="dc:Point" x="362.0" y="43.0"/>
+        <di:waypoint xsi:type="dc:Point" x="394.0" y="43.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="_18-_9" sourceElement="BPMNShape_IntermediateCatchEvent_1" targetElement="BPMNShape_ScriptTask_2">
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="43.0"/>
+        <di:waypoint xsi:type="dc:Point" x="277.0" y="43.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateNodeInstance.java
@@ -143,7 +143,8 @@ public class StateNodeInstance extends CompositeContextNodeInstance implements E
     	final Map<?, ?> declarations = activation.getSubRule().getOuterDeclarations();
         for ( Iterator<?> it = declarations.values().iterator(); it.hasNext(); ) {
             Declaration declaration = (Declaration) it.next();
-            if ("processInstance".equals(declaration.getIdentifier())) {
+            if ("processInstance".equals(declaration.getIdentifier()) 
+                    || "org.drools.runtime.process.WorkflowProcessInstance".equals(declaration.getTypeName())) {
             	Object value = declaration.getValue(
         			((StatefulKnowledgeSessionImpl) getProcessInstance().getKnowledgeRuntime()).session,
         			((InternalFactHandle) activation.getTuple().get(declaration)).getObject());


### PR DESCRIPTION
...ess instance

Currently to be able to filter rules based on process instance user need to name the binding variable exactly "processInstance" this pull request adds additional check that will verify the type of the variable
