### PR TITLE
JBPM-3584 - Compensate end event process fails with persistence

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/Hibernate4ProcessPersistenceTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/Hibernate4ProcessPersistenceTest.java
@@ -172,7 +172,7 @@ public class Hibernate4ProcessPersistenceTest {
         if (logs != null) {
             for (NodeInstanceLog l: logs) {
                 String nodeName = l.getNodeName();
-                if (l.getType() == NodeInstanceLog.TYPE_ENTER && names.contains(nodeName)) {
+                if ((l.getType() == NodeInstanceLog.TYPE_ENTER || l.getType() == NodeInstanceLog.TYPE_EXIT) && names.contains(nodeName)) {
                     names.remove(nodeName);
                 }
             }

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/JbpmBpmn2TestCase.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/JbpmBpmn2TestCase.java
@@ -236,7 +236,8 @@ public abstract class JbpmBpmn2TestCase extends TestCase {
 			if (logs != null) {
 				for (NodeInstanceLog l: logs) {
 					String nodeName = l.getNodeName();
-					if (l.getType() == NodeInstanceLog.TYPE_ENTER && names.contains(nodeName)) {
+					// needs to check both types as catch events will not have TYPE_ENTER entries
+					if ((l.getType() == NodeInstanceLog.TYPE_ENTER || l.getType() == NodeInstanceLog.TYPE_EXIT) && names.contains(nodeName)) {
 						names.remove(nodeName);
 					}
 				}

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/SimplePersistenceBPMNProcessTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/SimplePersistenceBPMNProcessTest.java
@@ -1,0 +1,75 @@
+package org.jbpm.bpmn2;
+
+import org.drools.KnowledgeBase;
+import org.drools.event.process.DefaultProcessEventListener;
+import org.drools.event.process.ProcessNodeLeftEvent;
+import org.drools.event.process.ProcessNodeTriggeredEvent;
+import org.drools.runtime.StatefulKnowledgeSession;
+import org.drools.runtime.process.ProcessInstance;
+import org.jbpm.process.instance.impl.demo.DoNothingWorkItemHandler;
+
+public class SimplePersistenceBPMNProcessTest extends JbpmBpmn2TestCase {
+    
+    public SimplePersistenceBPMNProcessTest() {
+        super(true);
+    }
+    
+    public void testCompensateEndEventProcess() throws Exception {
+        KnowledgeBase kbase = createKnowledgeBase("BPMN2-CompensateEndEvent.bpmn2");
+        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
+        ProcessInstance processInstance = ksession
+                .startProcess("CompensateEndEvent");
+        assertProcessInstanceCompleted(processInstance.getId(), ksession);
+        assertNodeTriggered(processInstance.getId(), "StartProcess", "Task", "CompensateEvent", "CompensateEvent2", "Compensate", "EndEvent");
+    }
+    
+    public void testSignalBoundaryEventOnTask() throws Exception {
+        KnowledgeBase kbase = createKnowledgeBase("BPMN2-BoundarySignalEventOnTaskbpmn2.bpmn");
+        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new TestWorkItemHandler());
+        ksession.addEventListener(new DefaultProcessEventListener() {
+
+            @Override
+            public void afterNodeLeft(ProcessNodeLeftEvent event) {
+                System.out.println("After node left " + event.getNodeInstance().getNodeName());
+            }
+
+            @Override
+            public void afterNodeTriggered(ProcessNodeTriggeredEvent event) {
+                System.out.println("After node triggered " + event.getNodeInstance().getNodeName());
+            }
+
+            @Override
+            public void beforeNodeLeft(ProcessNodeLeftEvent event) {
+                System.out.println("Before node left " + event.getNodeInstance().getNodeName());
+            }
+
+            @Override
+            public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {
+                System.out.println("Before node triggered " + event.getNodeInstance().getNodeName());
+            }
+           
+        });
+        ProcessInstance processInstance = ksession.startProcess("BoundarySignalOnTask");
+        ksession.signalEvent("MyMessage", "hello");
+        assertProcessInstanceCompleted(processInstance.getId(), ksession);
+        assertNodeTriggered(processInstance.getId(), "StartProcess", "User Task", "Boundary event", "Signal received", "End2");
+    }
+    
+    public void testIntermediateCatchEventSignal() throws Exception {
+        KnowledgeBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventSignal.bpmn2");
+        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new DoNothingWorkItemHandler());
+        ProcessInstance processInstance = ksession
+                .startProcess("IntermediateCatchEvent");
+        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        ksession = restoreSession(ksession, true);
+        // now signal process instance
+        ksession.signalEvent("MyMessage", "SomeValue", processInstance.getId());
+        assertProcessInstanceCompleted(processInstance.getId(), ksession);
+        assertNodeTriggered(processInstance.getId(), "StartProcess", "UserTask", "EndProcess", "event");
+    }
+
+}

--- a/jbpm-test/src/main/java/org/jbpm/test/JbpmJUnitTestCase.java
+++ b/jbpm-test/src/main/java/org/jbpm/test/JbpmJUnitTestCase.java
@@ -378,7 +378,7 @@ public abstract class JbpmJUnitTestCase extends Assert {
 			if (logs != null) {
 				for (NodeInstanceLog l: logs) {
 					String nodeName = l.getNodeName();
-					if (l.getType() == NodeInstanceLog.TYPE_ENTER && names.contains(nodeName)) {
+					if ((l.getType() == NodeInstanceLog.TYPE_ENTER || l.getType() == NodeInstanceLog.TYPE_EXIT) && names.contains(nodeName)) {
 						names.remove(nodeName);
 					}
 				}


### PR DESCRIPTION
While asserting if node was triggered there is an need to check both types of history log events (enter and exit) as catch events will not have enter events but only exit. 
