### PR TITLE
BUGZILLA-847044 kagent.dispose() is never called

### DIFF
--- a/jbpm-gwt/jbpm-gwt-core/pom.xml
+++ b/jbpm-gwt/jbpm-gwt-core/pom.xml
@@ -103,6 +103,11 @@
       <version>1.0</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Following 2 dependencies needed for making the build work with JDK5 -->
     <dependency>

--- a/jbpm-gwt/jbpm-gwt-core/src/main/java/org/jbpm/integration/console/StatefulKnowledgeSessionUtil.java
+++ b/jbpm-gwt/jbpm-gwt-core/src/main/java/org/jbpm/integration/console/StatefulKnowledgeSessionUtil.java
@@ -30,6 +30,8 @@ import java.util.concurrent.CopyOnWriteArraySet;
 
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
 
 import org.drools.KnowledgeBase;
 import org.drools.KnowledgeBaseFactory;
@@ -94,21 +96,32 @@ public class StatefulKnowledgeSessionUtil {
     
     private static int ksessionId = 0;
     private static Properties _jbpmConsoleProperties = new Properties();
-    private static KnowledgeAgent kagent;
+    private static KnowledgeAgent kagent = null;
     private static Set<String> knownPackages;
    
     protected StatefulKnowledgeSessionUtil() {
     }
-   
-    @Override
-    protected void finalize() throws Throwable { 
-        dispose();
+
+    public static class StatefulKnowledgeSessionUtilDisposeListener implements ServletContextListener {
+
+        public void contextInitialized(ServletContextEvent servletContextEvent) {
+            // Do nothing
+        }
+
+        public void contextDestroyed(ServletContextEvent servletContextEvent) {
+            dispose();
+        }
     }
     
-    protected void dispose() { 
-       SessionHolder.statefulKnowledgeSession.dispose(); 
-       _jbpmConsoleProperties = null;
-       SessionHolder.statefulKnowledgeSession = null;
+    public static void dispose() {
+        if (kagent != null) {
+            logger.debug("Disposing StatefulKnowledgeSessionUtil");
+            SessionHolder.statefulKnowledgeSession.dispose();
+            _jbpmConsoleProperties = null;
+            SessionHolder.statefulKnowledgeSession = null;
+            kagent.dispose();
+            kagent = null;
+        }
     }
    
     /**

--- a/jbpm-gwt/jbpm-gwt-core/src/main/resources/META-INF/web.xml
+++ b/jbpm-gwt/jbpm-gwt-core/src/main/resources/META-INF/web.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-fragment>
+  <listener>
+    <listener-class>org.jbpm.integration.console.StatefulKnowledgeSessionUtil.StatefulKnowledgeSessionUtilDisposeListener</listener-class>
+  </listener>
+</web-fragment>


### PR DESCRIPTION
Warning: Untested changes because I was unable to build and run jbpm-console locally from source, even before writing these changes:
- just deploying the war to a clean EAP 6 does not work.
- the installer doesn't work (download errors, wrong versions, ...)
- https://docspace.corp.redhat.com/docs/DOC-111367 does not work: it doesn't start from source
