### PR TITLE
JBPM-3790 - GenericCommandBasedWSHumanTaskHandler wrong HT server listen...

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/process/workitem/wsht/LocalHTWorkItemHandler.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/process/workitem/wsht/LocalHTWorkItemHandler.java
@@ -28,6 +28,16 @@ public class LocalHTWorkItemHandler extends GenericHTWorkItemHandler{
         this.setLocal(true);
     }
     
+    public LocalHTWorkItemHandler(KnowledgeRuntime session, boolean owningSessionOnly) {
+        super(session, owningSessionOnly);
+        this.setLocal(true);
+    }
+    
+    public LocalHTWorkItemHandler(TaskService client, KnowledgeRuntime session, boolean owningSessionOnly) {
+        super(client, session, owningSessionOnly);
+        this.setLocal(true);
+    }
+    
     public LocalHTWorkItemHandler(TaskService client, KnowledgeRuntime session) {
         super(client, session, null);
         this.setLocal(true);

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/OnAllSubTasksEndParentEndStrategy.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/OnAllSubTasksEndParentEndStrategy.java
@@ -47,7 +47,8 @@ public class OnAllSubTasksEndParentEndStrategy  extends SubTasksStrategy {
                 service.addEventListener(new InternalTaskEventListener(taskServiceSession));
 
                 service.getEventSupport().fireTaskCompleted( parentTask.getId(),
-                                                                parentTask.getTaskData().getActualOwner().getId() );
+                                                                parentTask.getTaskData().getActualOwner().getId(),
+                                                                parentTask.getTaskData().getProcessSessionId());
             }
     }
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/OnParentAbortAllSubTasksEndStrategy.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/OnParentAbortAllSubTasksEndStrategy.java
@@ -47,7 +47,8 @@ public class OnParentAbortAllSubTasksEndStrategy extends SubTasksStrategy {
                 service.addEventListener(new InternalTaskEventListener(taskServiceSession));
 
                 service.getEventSupport().fireTaskCompleted( subTask.getId(),
-                                                                subTask.getTaskData().getActualOwner().getId() );
+                                                                subTask.getTaskData().getActualOwner().getId(),
+                                                                subTask.getTaskData().getProcessSessionId());
             }
     }
 

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/TaskEventSupport.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/TaskEventSupport.java
@@ -27,11 +27,11 @@ import org.jbpm.task.event.entity.TaskUserEvent;
  */
 public class TaskEventSupport extends AbstractEventSupport<TaskEventListener> {
 
-    public void fireTaskClaimed(final long taskId, final String userId) {
+    public void fireTaskClaimed(final long taskId, final String userId, final int sessionId) {
         final Iterator<TaskEventListener> iter = getEventListenersIterator();
 
         if (iter.hasNext()) {
-            final TaskUserEvent event = TaskEventFactory.createClaimedEvent(taskId, userId);
+            final TaskUserEvent event = TaskEventFactory.createClaimedEvent(taskId, userId, sessionId);
 
             do {
                 iter.next().taskClaimed(event);
@@ -39,11 +39,11 @@ public class TaskEventSupport extends AbstractEventSupport<TaskEventListener> {
         }
     }
 
-    public void fireTaskCompleted(final long taskId, final String userId) {
+    public void fireTaskCompleted(final long taskId, final String userId, final int sessionId) {
         final Iterator<TaskEventListener> iter = getEventListenersIterator();
 
         if (iter.hasNext()) {
-            final TaskUserEvent event = TaskEventFactory.createCompletedEvent(taskId, userId);
+            final TaskUserEvent event = TaskEventFactory.createCompletedEvent(taskId, userId, sessionId);
 
             do {
                 iter.next().taskCompleted(event);
@@ -51,11 +51,11 @@ public class TaskEventSupport extends AbstractEventSupport<TaskEventListener> {
         }
     }
 
-    public void fireTaskFailed(final long taskId, final String userId) {
+    public void fireTaskFailed(final long taskId, final String userId, final int sessionId) {
         final Iterator<TaskEventListener> iter = getEventListenersIterator();
 
         if (iter.hasNext()) {
-            final TaskUserEvent event = TaskEventFactory.createFailedEvent(taskId, userId);
+            final TaskUserEvent event = TaskEventFactory.createFailedEvent(taskId, userId, sessionId);
 
             do {
                 iter.next().taskFailed(event);
@@ -63,11 +63,11 @@ public class TaskEventSupport extends AbstractEventSupport<TaskEventListener> {
         }
     }
 
-    public void fireTaskSkipped(final long taskId, final String userId) {
+    public void fireTaskSkipped(final long taskId, final String userId, final int sessionId) {
         final Iterator<TaskEventListener> iter = getEventListenersIterator();
 
         if (iter.hasNext()) {
-            final TaskUserEvent event = TaskEventFactory.createSkippedEvent(taskId, userId);
+            final TaskUserEvent event = TaskEventFactory.createSkippedEvent(taskId, userId, sessionId);
 
             do {
                 iter.next().taskSkipped(event);
@@ -75,11 +75,11 @@ public class TaskEventSupport extends AbstractEventSupport<TaskEventListener> {
         }
     }
 
-    public void fireTaskCreated(final long taskId, final String userId) {
+    public void fireTaskCreated(final long taskId, final String userId, final int sessionId) {
         final Iterator<TaskEventListener> iter = getEventListenersIterator();
 
         if (iter.hasNext()) {
-            final TaskUserEvent event = TaskEventFactory.createCreatedEvent(taskId, userId);
+            final TaskUserEvent event = TaskEventFactory.createCreatedEvent(taskId, userId, sessionId);
 
             do {
                 iter.next().taskCreated(event);
@@ -87,11 +87,11 @@ public class TaskEventSupport extends AbstractEventSupport<TaskEventListener> {
         }
     }
     
-    public void fireTaskForwarded(final long taskId, final String userId) {
+    public void fireTaskForwarded(final long taskId, final String userId, final int sessionId) {
         final Iterator<TaskEventListener> iter = getEventListenersIterator();
 
         if (iter.hasNext()) {
-            final TaskUserEvent event = TaskEventFactory.createForwardedEvent(taskId, userId);
+            final TaskUserEvent event = TaskEventFactory.createForwardedEvent(taskId, userId, sessionId);
 
             do {
                 iter.next().taskForwarded(event);
@@ -99,11 +99,11 @@ public class TaskEventSupport extends AbstractEventSupport<TaskEventListener> {
         }
     }
     
-    public void fireTaskStarted(final long taskId, final String userId) {
+    public void fireTaskStarted(final long taskId, final String userId, final int sessionId) {
         final Iterator<TaskEventListener> iter = getEventListenersIterator();
 
         if (iter.hasNext()) {
-            final TaskUserEvent event = TaskEventFactory.createStartedEvent(taskId, userId);
+            final TaskUserEvent event = TaskEventFactory.createStartedEvent(taskId, userId, sessionId);
 
             do {
                 iter.next().taskStarted(event);
@@ -111,11 +111,11 @@ public class TaskEventSupport extends AbstractEventSupport<TaskEventListener> {
         }
     }
     
-    public void fireTaskReleased(final long taskId, final String userId) {
+    public void fireTaskReleased(final long taskId, final String userId, final int sessionId) {
         final Iterator<TaskEventListener> iter = getEventListenersIterator();
 
         if (iter.hasNext()) {
-            final TaskUserEvent event = TaskEventFactory.createReleasedEvent(taskId, userId);
+            final TaskUserEvent event = TaskEventFactory.createReleasedEvent(taskId, userId, sessionId);
 
             do {
                 iter.next().taskReleased(event);
@@ -123,11 +123,11 @@ public class TaskEventSupport extends AbstractEventSupport<TaskEventListener> {
         }
     }
     
-    public void fireTaskStopped(final long taskId, final String userId) {
+    public void fireTaskStopped(final long taskId, final String userId, final int sessionId) {
         final Iterator<TaskEventListener> iter = getEventListenersIterator();
 
         if (iter.hasNext()) {
-            final TaskUserEvent event = TaskEventFactory.createStoppedEvent(taskId, userId);
+            final TaskUserEvent event = TaskEventFactory.createStoppedEvent(taskId, userId, sessionId);
 
             do {
                 iter.next().taskStopped(event);

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskClaimedEvent.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskClaimedEvent.java
@@ -29,8 +29,9 @@ public class TaskClaimedEvent extends TaskUserEvent {
      */
     public TaskClaimedEvent() { }
 
-    TaskClaimedEvent(long taskId, String userId) {
-        super( taskId, userId );
+
+    public TaskClaimedEvent(long taskId, String userId, int sessionId) {
+        super( taskId, userId, sessionId );
     }
 
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskCompletedEvent.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskCompletedEvent.java
@@ -29,8 +29,8 @@ public class TaskCompletedEvent extends TaskUserEvent {
      */
     public TaskCompletedEvent() { }
     
-    TaskCompletedEvent(long taskId, String userId) {
-        super( taskId, userId );
+    public TaskCompletedEvent(long taskId, String userId, int sessionId) {
+        super( taskId, userId, sessionId );
     }
     
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskCreatedEvent.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskCreatedEvent.java
@@ -28,8 +28,8 @@ public class TaskCreatedEvent extends TaskUserEvent {
      */
     public TaskCreatedEvent() { }
     
-    TaskCreatedEvent(long taskId, String userId) {
-        super( taskId, userId );
+    TaskCreatedEvent(long taskId, String userId, int sessionId) {
+        super( taskId, userId, sessionId );
     }
     
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskEvent.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskEvent.java
@@ -56,17 +56,22 @@ public abstract class TaskEvent implements Externalizable {
     @Column(nullable=true)
     protected String userId;
     
+    @Column(nullable=true)
+    protected int sessionId;
+    
     public TaskEvent() { 
         // Default constructor
     }
     
-    public TaskEvent(long taskId) {
+    public TaskEvent(long taskId, int sessionId) {
         this.taskId = taskId;
+        this.sessionId = sessionId;
     }
     
-    public TaskEvent(long taskId, String userId) {
+    public TaskEvent(long taskId, String userId, int sessionId) {
         this.taskId = taskId;
         this.userId = userId;
+        this.sessionId = sessionId;
     }
     
     public final void writeExternal(ObjectOutput out) throws IOException {
@@ -81,6 +86,7 @@ public abstract class TaskEvent implements Externalizable {
         out.writeShort(version);
         
         // where future fields should be written
+        out.writeInt(sessionId);
     }  
     
     public final void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
@@ -96,6 +102,7 @@ public abstract class TaskEvent implements Externalizable {
         short version = in.readShort();
         
         // where future fields should be read, depending on version num
+        this.sessionId = in.readInt();
     }
     
     public long getTaskId() {
@@ -118,6 +125,14 @@ public abstract class TaskEvent implements Externalizable {
     
     public TaskEventType getTaskEventType() { 
         return TaskEventType.getTypeFromValue(type);
+    }
+
+    public int getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(int sessionId) {
+        this.sessionId = sessionId;
     }
 
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskEventFactory.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskEventFactory.java
@@ -2,40 +2,40 @@ package org.jbpm.task.event.entity;
 
 public class TaskEventFactory {
 
-   public static TaskUserEvent createCreatedEvent(long taskId, String userId) { 
-      return new TaskCreatedEvent(taskId, userId);
+   public static TaskUserEvent createCreatedEvent(long taskId, String userId, final int sessionId) { 
+      return new TaskCreatedEvent(taskId, userId, sessionId);
    }
    
-   public static TaskUserEvent createClaimedEvent(long taskId, String userId) { 
-      return new TaskClaimedEvent(taskId, userId);
+   public static TaskUserEvent createClaimedEvent(long taskId, String userId, final int sessionId) { 
+      return new TaskClaimedEvent(taskId, userId, sessionId);
    }
    
-   public static TaskUserEvent createCompletedEvent(long taskId, String userId) { 
-      return new TaskCompletedEvent(taskId, userId);
+   public static TaskUserEvent createCompletedEvent(long taskId, String userId, final int sessionId) { 
+      return new TaskCompletedEvent(taskId, userId, sessionId);
    }
    
-   public static TaskUserEvent createFailedEvent(long taskId, String userId) { 
-      return new TaskFailedEvent(taskId, userId);
+   public static TaskUserEvent createFailedEvent(long taskId, String userId, final int sessionId) { 
+      return new TaskFailedEvent(taskId, userId, sessionId);
    }
    
-   public static TaskUserEvent createForwardedEvent(long taskId, String userId) { 
-      return new TaskForwardedEvent(taskId, userId);
+   public static TaskUserEvent createForwardedEvent(long taskId, String userId, final int sessionId) { 
+      return new TaskForwardedEvent(taskId, userId, sessionId);
    }
    
-   public static TaskUserEvent createReleasedEvent(long taskId, String userId) { 
-      return new TaskReleasedEvent(taskId, userId);
+   public static TaskUserEvent createReleasedEvent(long taskId, String userId, final int sessionId) { 
+      return new TaskReleasedEvent(taskId, userId, sessionId);
    }
    
-   public static TaskUserEvent createSkippedEvent(long taskId, String userId) { 
-      return new TaskSkippedEvent(taskId, userId);
+   public static TaskUserEvent createSkippedEvent(long taskId, String userId, final int sessionId) { 
+      return new TaskSkippedEvent(taskId, userId, sessionId);
    }
    
-   public static TaskUserEvent createStartedEvent(long taskId, String userId) { 
-       return new TaskStartedEvent(taskId, userId);
+   public static TaskUserEvent createStartedEvent(long taskId, String userId, final int sessionId) { 
+       return new TaskStartedEvent(taskId, userId, sessionId);
    }
    
-   public static TaskUserEvent createStoppedEvent(long taskId, String userId) { 
-      return new TaskStoppedEvent(taskId, userId);
+   public static TaskUserEvent createStoppedEvent(long taskId, String userId, final int sessionId) { 
+      return new TaskStoppedEvent(taskId, userId, sessionId);
    }
 
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskFailedEvent.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskFailedEvent.java
@@ -28,8 +28,8 @@ public class TaskFailedEvent extends TaskUserEvent {
      */
     public TaskFailedEvent() { }
     
-    TaskFailedEvent(long taskId, String userId) {
-        super( taskId, userId );
+    public TaskFailedEvent(long taskId, String userId, int sessionId) {
+        super( taskId, userId, sessionId );
     }
 
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskForwardedEvent.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskForwardedEvent.java
@@ -28,8 +28,8 @@ public class TaskForwardedEvent extends TaskUserEvent {
      */
     public TaskForwardedEvent() { }
     
-    TaskForwardedEvent(long taskId, String userId) {
-        super( taskId, userId );
+    TaskForwardedEvent(long taskId, String userId, int sessionId) {
+        super( taskId, userId, sessionId );
     }
     
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskReleasedEvent.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskReleasedEvent.java
@@ -28,8 +28,8 @@ public class TaskReleasedEvent extends TaskUserEvent {
      */
     public TaskReleasedEvent() { }
     
-    TaskReleasedEvent(long taskId, String userId) {
-        super( taskId, userId );
+    TaskReleasedEvent(long taskId, String userId, int sessionId) {
+        super( taskId, userId, sessionId );
     }
     
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskSkippedEvent.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskSkippedEvent.java
@@ -28,8 +28,8 @@ public class TaskSkippedEvent extends TaskUserEvent {
      */
     public TaskSkippedEvent() { } 
     
-    TaskSkippedEvent(long taskId, String userId) {
-        super( taskId, userId );
+    public TaskSkippedEvent(long taskId, String userId, int sessionId) {
+        super( taskId, userId, sessionId );
     }
 
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskStartedEvent.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskStartedEvent.java
@@ -28,8 +28,8 @@ public class TaskStartedEvent extends TaskUserEvent {
      */
     public TaskStartedEvent() { } 
     
-    TaskStartedEvent(long taskId, String userId) {
-        super( taskId, userId );
+    TaskStartedEvent(long taskId, String userId, int sessionId) {
+        super( taskId, userId, sessionId );
     }
     
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskStoppedEvent.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskStoppedEvent.java
@@ -28,8 +28,8 @@ public class TaskStoppedEvent extends TaskUserEvent {
      */
     public TaskStoppedEvent() { } 
     
-    TaskStoppedEvent(long taskId, String userId) {
-        super( taskId, userId );
+    TaskStoppedEvent(long taskId, String userId, int sessionId) {
+        super( taskId, userId, sessionId );
     }
     
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskUserEvent.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/event/entity/TaskUserEvent.java
@@ -28,8 +28,8 @@ public class TaskUserEvent extends TaskEvent implements Externalizable {
         super();
     }
     
-    TaskUserEvent(long taskId, String userId) {
-        super( taskId );
+    TaskUserEvent(long taskId, String userId, int sessionId) {
+        super( taskId, sessionId );
         this.userId = userId;
     }
     

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/service/TaskServiceSession.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/service/TaskServiceSession.java
@@ -209,7 +209,7 @@ public class TaskServiceSession {
             if(task.getTaskData().getActualOwner() != null){
                 actualOwner = task.getTaskData().getActualOwner().getId();
             }
-            service.getEventSupport().fireTaskCreated(task.getId(), actualOwner);
+            service.getEventSupport().fireTaskCreated(task.getId(), actualOwner, task.getTaskData().getProcessSessionId());
         }
         
         if (currentStatus == Status.Reserved) {
@@ -217,7 +217,7 @@ public class TaskServiceSession {
             SendIcal.getInstance().sendIcalForTask(task, service.getUserinfo());
 
             // trigger event support
-            service.getEventSupport().fireTaskClaimed(task.getId(), task.getTaskData().getActualOwner().getId());
+            service.getEventSupport().fireTaskClaimed(task.getId(), task.getTaskData().getActualOwner().getId(), task.getTaskData().getProcessSessionId());
         }
     }
 
@@ -396,7 +396,7 @@ public class TaskServiceSession {
 
                     // trigger event support
                     service.getEventSupport().fireTaskClaimed(task.getId(),
-                            task.getTaskData().getActualOwner().getId());
+                            task.getTaskData().getActualOwner().getId(), task.getTaskData().getProcessSessionId());
                     break;
                 }
             }
@@ -518,12 +518,14 @@ public class TaskServiceSession {
     
     private void postTaskClaimOperation(final Task task) {
         // trigger event support
-        service.getEventSupport().fireTaskClaimed(task.getId(), task.getTaskData().getActualOwner().getId());
+        service.getEventSupport().fireTaskClaimed(task.getId(), task.getTaskData().getActualOwner().getId(),
+                task.getTaskData().getProcessSessionId());
     }
     
     private void postTaskStartOperation(final Task task) {
         // trigger event support
-        service.getEventSupport().fireTaskStarted(task.getId(), task.getTaskData().getActualOwner().getId());
+        service.getEventSupport().fireTaskStarted(task.getId(), task.getTaskData().getActualOwner().getId(),
+                task.getTaskData().getProcessSessionId());
     }
     
     private void postTaskForwardOperation(final Task task) {
@@ -532,7 +534,8 @@ public class TaskServiceSession {
         if(task.getTaskData().getActualOwner() != null){
             actualOwner = task.getTaskData().getActualOwner().getId();
         }
-        service.getEventSupport().fireTaskForwarded(task.getId(), actualOwner);
+        service.getEventSupport().fireTaskForwarded(task.getId(), actualOwner,
+                task.getTaskData().getProcessSessionId());
     }
     
     private void postTaskReleaseOperation(final Task task) {
@@ -541,12 +544,14 @@ public class TaskServiceSession {
         if(task.getTaskData().getActualOwner() != null){
             actualOwner = task.getTaskData().getActualOwner().getId();
         }
-        service.getEventSupport().fireTaskReleased(task.getId(), actualOwner);
+        service.getEventSupport().fireTaskReleased(task.getId(), actualOwner,
+                task.getTaskData().getProcessSessionId());
     }
     
     private void postTaskStopOperation(final Task task) {
         // trigger event support
-        service.getEventSupport().fireTaskStopped(task.getId(), task.getTaskData().getActualOwner().getId());
+        service.getEventSupport().fireTaskStopped(task.getId(), task.getTaskData().getActualOwner().getId(),
+                task.getTaskData().getProcessSessionId());
     }
 
     private void taskCompleteOperation(final Task task, final ContentData data) {
@@ -560,7 +565,8 @@ public class TaskServiceSession {
         service.unschedule(task.getId());
         clearDeadlines(task);
         // trigger event support
-        service.getEventSupport().fireTaskCompleted(task.getId(), task.getTaskData().getActualOwner().getId());
+        service.getEventSupport().fireTaskCompleted(task.getId(), task.getTaskData().getActualOwner().getId(),
+                task.getTaskData().getProcessSessionId());
     }
 
     private void taskFailOperation(final Task task, final ContentData data) {
@@ -574,7 +580,8 @@ public class TaskServiceSession {
         service.unschedule(task.getId());
         clearDeadlines(task);
     	// trigger event support
-        service.getEventSupport().fireTaskFailed(task.getId(), task.getTaskData().getActualOwner().getId());
+        service.getEventSupport().fireTaskFailed(task.getId(), task.getTaskData().getActualOwner().getId(),
+                task.getTaskData().getProcessSessionId());
     }
 
     private void taskSkipOperation(final Task task, final String userId) {
@@ -585,7 +592,7 @@ public class TaskServiceSession {
         service.unschedule(task.getId());
         clearDeadlines(task);
         // trigger event support
-        service.getEventSupport().fireTaskSkipped(task.getId(), userId);
+        service.getEventSupport().fireTaskSkipped(task.getId(), userId, task.getTaskData().getProcessSessionId());
     }
     
     private void postTaskExitOperation(final Task task, final String userId) {

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/process/workitem/wsht/MultipleHandlersTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/process/workitem/wsht/MultipleHandlersTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2012 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.wsht;
+
+import java.util.List;
+import java.util.Map;
+
+import org.drools.process.instance.impl.WorkItemImpl;
+import org.drools.runtime.process.WorkItemHandler;
+import org.drools.runtime.process.WorkItemManager;
+import org.jbpm.task.BaseTest;
+import org.jbpm.task.Status;
+import org.jbpm.task.TaskService;
+import org.jbpm.task.TestStatefulKnowledgeSession;
+import org.jbpm.task.query.TaskSummary;
+import org.jbpm.task.service.local.LocalTaskService;
+import org.junit.Test;
+
+public class MultipleHandlersTest extends BaseTest {
+
+    private TaskService client;
+    
+    @Override
+    protected void setUp() throws Exception {
+       super.setUp();
+       client = new LocalTaskService(taskService);
+        
+    }
+
+    protected void tearDown() throws Exception {
+        
+        client.disconnect();
+        super.tearDown();
+    }
+    
+    @Test
+    public void testCompleteTaskMultipleSessions() throws Exception {
+        TestStatefulKnowledgeSession ksession = new TestStatefulKnowledgeSession();
+        
+        LocalHTWorkItemHandler handler = new LocalHTWorkItemHandler(client, ksession, true);
+        
+        TestWorkItemManager manager = new TestWorkItemManager();
+        ksession.setWorkItemManager(manager);
+        WorkItemImpl workItem = new WorkItemImpl();
+        workItem.setName("Human Task");
+        workItem.setParameter("TaskName", "TaskName");
+        workItem.setParameter("Comment", "Comment");
+        workItem.setParameter("Priority", "10");
+        workItem.setParameter("ActorId", "Darth Vader");
+        workItem.setProcessInstanceId(10);
+        handler.executeWorkItem(workItem, manager);
+        
+        TestStatefulKnowledgeSession ksession2 = new TestStatefulKnowledgeSession(10);
+        LocalHTWorkItemHandler handler2 = new LocalHTWorkItemHandler(client, ksession2, true);
+
+        TestWorkItemManager manager2 = new TestWorkItemManager();
+        ksession2.setWorkItemManager(manager2);
+        WorkItemImpl workItem2 = new WorkItemImpl();
+        workItem2.setName("Human Task");
+        workItem2.setParameter("TaskName", "TaskName");
+        workItem2.setParameter("Comment", "Comment");
+        workItem2.setParameter("Priority", "10");
+        workItem2.setParameter("ActorId", "Darth Vader");
+        workItem2.setProcessInstanceId(10);
+        handler2.executeWorkItem(workItem2, manager2);
+
+        
+        List<TaskSummary> tasks = client.getTasksAssignedAsPotentialOwner("Darth Vader", "en-UK");
+        assertEquals(2, tasks.size());
+        TaskSummary task = tasks.get(0);
+        // ensure we get first task
+        if (task.getProcessSessionId() == 10) {
+            task = tasks.get(1);
+        }
+        assertEquals("TaskName", task.getName());
+        assertEquals(10, task.getPriority());
+        assertEquals("Comment", task.getDescription());
+        assertEquals(Status.Reserved, task.getStatus());
+        assertEquals("Darth Vader", task.getActualOwner().getId());
+        assertEquals(10, task.getProcessInstanceId());
+
+        client.start(task.getId(), "Darth Vader");
+        client.complete(task.getId(), "Darth Vader", null);
+        
+        assertEquals(1, manager.getCompleteCounter());
+        assertEquals(0, manager2.getCompleteCounter());
+    }
+    
+    private class TestWorkItemManager implements WorkItemManager {
+
+        private volatile int completeCounter = 0;
+        private volatile boolean completed;
+        private volatile boolean aborted;
+        private volatile Map<String, Object> results;
+
+        public synchronized boolean waitTillCompleted(long time) {
+            if (!isCompleted()) {
+                try {
+                    wait(time);
+                } catch (InterruptedException e) {
+                    // swallow and return state of completed
+                }
+            }
+
+            return isCompleted();
+        }
+
+        public synchronized boolean waitTillAborted(long time) {
+            if (!isAborted()) {
+                try {
+                    wait(time);
+                } catch (InterruptedException e) {
+                    // swallow and return state of aborted
+                }
+            }
+
+            return isAborted();
+        }
+
+        public void abortWorkItem(long id) {
+            setAborted(true);
+        }
+
+        public synchronized boolean isAborted() {
+            return aborted;
+        }
+
+        private synchronized void setAborted(boolean aborted) {
+            this.aborted = aborted;
+            notifyAll();
+        }
+
+        public void completeWorkItem(long id, Map<String, Object> results) {
+            this.results = results;
+            setCompleted(true);
+            this.setCompleteCounter(this.getCompleteCounter() + 1);
+        }
+
+        private synchronized void setCompleted(boolean completed) {
+            this.completed = completed;
+            notifyAll();
+        }
+
+        public synchronized boolean isCompleted() {
+            return completed;
+        }
+
+        public Map<String, Object> getResults() {
+            return results;
+        }
+
+        public void registerWorkItemHandler(String workItemName, WorkItemHandler handler) {
+        }
+
+        public int getCompleteCounter() {
+            return completeCounter;
+        }
+
+        public void setCompleteCounter(int completeCounter) {
+            this.completeCounter = completeCounter;
+        }
+    }
+}

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/process/workitem/wsht/WSHumanTaskHandlerBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/process/workitem/wsht/WSHumanTaskHandlerBaseTest.java
@@ -394,7 +394,7 @@ public abstract class WSHumanTaskHandlerBaseTest extends BaseTest {
 		getClient().getTask(taskSummary.getId(), getTaskResponseHandler);
 		Task task = getTaskResponseHandler.getTask();
 		assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-		assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+		assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.DEFAULT_SESSION_ID);
 		long contentId = task.getTaskData().getDocumentContentId();
 		assertTrue(contentId != -1);
 		BlockingGetContentResponseHandler getContentResponseHandler = new BlockingGetContentResponseHandler();

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/process/workitem/wsht/async/WSHumanTaskHandlerBaseAsyncTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/process/workitem/wsht/async/WSHumanTaskHandlerBaseAsyncTest.java
@@ -448,7 +448,7 @@ public abstract class WSHumanTaskHandlerBaseAsyncTest extends BaseTest {
         getClient().getTask(taskSummary.getId(), getTaskResponseHandler);
         Task task = getTaskResponseHandler.getTask();
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
         BlockingGetContentResponseHandler getContentResponseHandler = new BlockingGetContentResponseHandler();

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/process/workitem/wsht/sync/WSHumanTaskHandlerBaseSyncTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/process/workitem/wsht/sync/WSHumanTaskHandlerBaseSyncTest.java
@@ -360,7 +360,7 @@ public abstract class WSHumanTaskHandlerBaseSyncTest extends BaseTest {
         
         Task task = getClient().getTask(taskSummary.getId());
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/task/TestStatefulKnowledgeSession.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/task/TestStatefulKnowledgeSession.java
@@ -28,8 +28,17 @@ import org.drools.runtime.rule.WorkingMemoryEntryPoint;
 import org.drools.time.SessionClock;
 
 public class TestStatefulKnowledgeSession implements StatefulKnowledgeSession {
-	public static int testSessionId = 5;
+	public static final int DEFAULT_SESSION_ID = 5;
+    private int testSessionId;
 	private Environment env;
+	
+	public TestStatefulKnowledgeSession() {
+	    testSessionId = DEFAULT_SESSION_ID;
+	}
+	
+	public TestStatefulKnowledgeSession(int id) {
+        this.testSessionId = id;
+    }
 	public Calendars getCalendars() {
 		return null;
 	}

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/task/event/TaskEventTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/task/event/TaskEventTest.java
@@ -22,7 +22,7 @@ public class TaskEventTest {
     public void testReadWriteExternal() throws Exception { 
         long taskId = 23;
         String userId = "illuminatus";
-        TaskEvent event = TaskEventFactory.createClaimedEvent(taskId, userId);
+        TaskEvent event = TaskEventFactory.createClaimedEvent(taskId, userId, -1);
         
         // Serialise the object
         ByteArrayOutputStream baos = new ByteArrayOutputStream(100);

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/task/service/persistence/variable/VariablePersistenceStrategiesSyncHTTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/task/service/persistence/variable/VariablePersistenceStrategiesSyncHTTest.java
@@ -139,7 +139,7 @@ public class VariablePersistenceStrategiesSyncHTTest extends BaseTest {
 
         Task task = getClient().getTask(taskSummary.getId());
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -191,7 +191,7 @@ public class VariablePersistenceStrategiesSyncHTTest extends BaseTest {
         Task task = getClient().getTask(taskSummary.getId());
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
         
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -255,7 +255,7 @@ public class VariablePersistenceStrategiesSyncHTTest extends BaseTest {
 
         Task task = getClient().getTask(taskSummary.getId());
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -321,7 +321,7 @@ public class VariablePersistenceStrategiesSyncHTTest extends BaseTest {
 
         Task task = getClient().getTask(taskSummary.getId());
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -374,7 +374,7 @@ public class VariablePersistenceStrategiesSyncHTTest extends BaseTest {
         Task task = getClient().getTask(taskSummary.getId());
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
 
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -433,7 +433,7 @@ public class VariablePersistenceStrategiesSyncHTTest extends BaseTest {
 
         Task task = getClient().getTask(taskSummary.getId());
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -503,7 +503,7 @@ public class VariablePersistenceStrategiesSyncHTTest extends BaseTest {
         Task task = getClient().getTask(taskSummary.getId());
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
        
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -568,7 +568,7 @@ public class VariablePersistenceStrategiesSyncHTTest extends BaseTest {
         Task task = getClient().getTask(taskSummary.getId());
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
 
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -640,7 +640,7 @@ public class VariablePersistenceStrategiesSyncHTTest extends BaseTest {
 
         Task task = getClient().getTask(taskSummary.getId());
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -730,7 +730,7 @@ public class VariablePersistenceStrategiesSyncHTTest extends BaseTest {
 
         Task task = getClient().getTask(taskSummary.getId());
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 

--- a/jbpm-human-task/jbpm-human-task-hornetq/src/main/java/org/jbpm/process/workitem/wsht/AsyncHornetQHTWorkItemHandler.java
+++ b/jbpm-human-task/jbpm-human-task-hornetq/src/main/java/org/jbpm/process/workitem/wsht/AsyncHornetQHTWorkItemHandler.java
@@ -30,6 +30,17 @@ public class AsyncHornetQHTWorkItemHandler extends AsyncGenericHTWorkItemHandler
         super(session);
         init();
     }
+    
+    public AsyncHornetQHTWorkItemHandler(KnowledgeRuntime session, boolean owningSessionOnly) {
+        super(session, owningSessionOnly);
+        init();
+    }
+    
+    public AsyncHornetQHTWorkItemHandler(AsyncTaskService client, KnowledgeRuntime session, boolean owningSessionOnly) {
+        super(session, owningSessionOnly);
+        setClient(client);
+        init();
+    }
 
     public AsyncHornetQHTWorkItemHandler(KnowledgeRuntime session, OnErrorAction action) {
         super(session, action);

--- a/jbpm-human-task/jbpm-human-task-hornetq/src/main/java/org/jbpm/process/workitem/wsht/HornetQHTWorkItemHandler.java
+++ b/jbpm-human-task/jbpm-human-task-hornetq/src/main/java/org/jbpm/process/workitem/wsht/HornetQHTWorkItemHandler.java
@@ -32,6 +32,11 @@ public class HornetQHTWorkItemHandler extends GenericHTWorkItemHandler{
         init();
     }
     
+    public HornetQHTWorkItemHandler(KnowledgeRuntime session, boolean owningSessionOnly) {
+        super(session, owningSessionOnly);
+        init();
+    }
+    
     public HornetQHTWorkItemHandler(KnowledgeRuntime session, OnErrorAction action) {
         super(session, action);
         init();
@@ -39,6 +44,11 @@ public class HornetQHTWorkItemHandler extends GenericHTWorkItemHandler{
     
     public HornetQHTWorkItemHandler(TaskService client, KnowledgeRuntime session) {
         super(client, session);
+        init();
+    }
+    
+    public HornetQHTWorkItemHandler(TaskService client, KnowledgeRuntime session, boolean owningSessionOnly) {
+        super(client, session, owningSessionOnly);
         init();
     }
     

--- a/jbpm-human-task/jbpm-human-task-hornetq/src/main/java/org/jbpm/task/service/hornetq/CommandBasedHornetQWSHumanTaskHandler.java
+++ b/jbpm-human-task/jbpm-human-task-hornetq/src/main/java/org/jbpm/task/service/hornetq/CommandBasedHornetQWSHumanTaskHandler.java
@@ -68,9 +68,16 @@ public class CommandBasedHornetQWSHumanTaskHandler implements WorkItemHandler {
 	private TaskClient client;
 	private KnowledgeRuntime session;
 	
+	private boolean ownerSessionOnly = false;
+	
 	public CommandBasedHornetQWSHumanTaskHandler(KnowledgeRuntime session) {
 		this.session = session;
 	}
+	
+	public CommandBasedHornetQWSHumanTaskHandler(KnowledgeRuntime session, boolean ownerSessionOnly) {
+        this.session = session;
+        this.ownerSessionOnly = ownerSessionOnly;
+    }
 
 	public void setConnection(String ipAddress, int port) {
 		this.ipAddress = ipAddress;
@@ -213,6 +220,12 @@ public class CommandBasedHornetQWSHumanTaskHandler implements WorkItemHandler {
         
         public void execute(Payload payload) {
             TaskEvent event = ( TaskEvent ) payload.get();
+            
+            if (ownerSessionOnly) {
+                if (event.getSessionId() != ((StatefulKnowledgeSession) session).getId()) {
+                    return;
+                }
+            }
         	long taskId = event.getTaskId();
         	GetTaskResponseHandler getTaskResponseHandler =
         		new GetCompletedTaskResponseHandler();

--- a/jbpm-human-task/jbpm-human-task-hornetq/src/test/java/org/jbpm/process/workitem/wsht/hornetq/HornetQMultipleHandlersTest.java
+++ b/jbpm-human-task/jbpm-human-task-hornetq/src/test/java/org/jbpm/process/workitem/wsht/hornetq/HornetQMultipleHandlersTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2012 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.wsht.hornetq;
+
+import java.util.List;
+import java.util.Map;
+
+import org.drools.process.instance.impl.WorkItemImpl;
+import org.drools.runtime.process.WorkItemHandler;
+import org.drools.runtime.process.WorkItemManager;
+import org.jbpm.process.workitem.wsht.AsyncHornetQHTWorkItemHandler;
+import org.jbpm.process.workitem.wsht.HornetQHTWorkItemHandler;
+import org.jbpm.task.AsyncTaskService;
+import org.jbpm.task.BaseTest;
+import org.jbpm.task.Status;
+import org.jbpm.task.TaskService;
+import org.jbpm.task.TestStatefulKnowledgeSession;
+import org.jbpm.task.query.TaskSummary;
+import org.jbpm.task.service.TaskServer;
+import org.jbpm.task.service.hornetq.HornetQTaskServer;
+import org.jbpm.task.service.responsehandlers.BlockingTaskOperationResponseHandler;
+import org.jbpm.task.service.responsehandlers.BlockingTaskSummaryResponseHandler;
+import org.jbpm.task.utils.OnErrorAction;
+import org.junit.Test;
+
+public class HornetQMultipleHandlersTest extends BaseTest {
+
+    private TaskService client;
+    private AsyncTaskService clientAsync;
+    private TaskServer server;
+    @Override
+    protected void setUp() throws Exception {
+       super.setUp();
+       server = new HornetQTaskServer(taskService, 5445);
+       Thread thread = new Thread(server);
+       thread.start();
+       System.out.println("Waiting for the HornetQTask Server to come up");
+       while (!server.isRunning()) {
+           System.out.print(".");
+           Thread.sleep(50);
+       }
+       
+    }
+
+    protected void tearDown() throws Exception {
+        if (client != null) {
+            client.disconnect();
+        }
+        
+        if (clientAsync != null) {
+            clientAsync.disconnect();
+        }
+        server.stop();
+        super.tearDown();
+    }
+    
+    @Test
+    public void testCompleteTaskMultipleSessionsSync() throws Exception {
+        TestStatefulKnowledgeSession ksession = new TestStatefulKnowledgeSession();
+        
+        HornetQHTWorkItemHandler handler = new HornetQHTWorkItemHandler(ksession, true);
+        
+        client = handler.getClient();
+        TestWorkItemManager manager = new TestWorkItemManager();
+        ksession.setWorkItemManager(manager);
+        WorkItemImpl workItem = new WorkItemImpl();
+        workItem.setName("Human Task");
+        workItem.setParameter("TaskName", "TaskName");
+        workItem.setParameter("Comment", "Comment");
+        workItem.setParameter("Priority", "10");
+        workItem.setParameter("ActorId", "Darth Vader");
+        workItem.setProcessInstanceId(10);
+        handler.executeWorkItem(workItem, manager);
+        
+        TestStatefulKnowledgeSession ksession2 = new TestStatefulKnowledgeSession(10);
+        HornetQHTWorkItemHandler handler2 = new HornetQHTWorkItemHandler("testConnector", null, ksession2, OnErrorAction.LOG);
+        handler2.setOwningSessionOnly(true);
+
+        TestWorkItemManager manager2 = new TestWorkItemManager();
+        ksession2.setWorkItemManager(manager2);
+        WorkItemImpl workItem2 = new WorkItemImpl();
+        workItem2.setName("Human Task");
+        workItem2.setParameter("TaskName", "TaskName");
+        workItem2.setParameter("Comment", "Comment");
+        workItem2.setParameter("Priority", "10");
+        workItem2.setParameter("ActorId", "Darth Vader");
+        workItem2.setProcessInstanceId(10);
+        handler2.executeWorkItem(workItem2, manager2);
+
+        
+        List<TaskSummary> tasks = client.getTasksAssignedAsPotentialOwner("Darth Vader", "en-UK");
+        assertEquals(2, tasks.size());
+        TaskSummary task = tasks.get(0);
+        // ensure we get first task
+        if (task.getProcessSessionId() == 10) {
+            task = tasks.get(1);
+        }
+        assertEquals("TaskName", task.getName());
+        assertEquals(10, task.getPriority());
+        assertEquals("Comment", task.getDescription());
+        assertEquals(Status.Reserved, task.getStatus());
+        assertEquals("Darth Vader", task.getActualOwner().getId());
+        assertEquals(10, task.getProcessInstanceId());
+
+        client.start(task.getId(), "Darth Vader");
+        client.complete(task.getId(), "Darth Vader", null);
+        
+        Thread.sleep(1000);
+        
+        assertEquals(1, manager.getCompleteCounter());
+        assertEquals(0, manager2.getCompleteCounter());
+        
+        handler.dispose();
+        handler2.dispose();
+    }
+    
+    @Test
+    public void testCompleteTaskMultipleSessionsASync() throws Exception {
+        TestStatefulKnowledgeSession ksession = new TestStatefulKnowledgeSession();
+        
+        AsyncHornetQHTWorkItemHandler handler = new AsyncHornetQHTWorkItemHandler(ksession, true);
+        clientAsync = handler.getClient();
+        TestWorkItemManager manager = new TestWorkItemManager();
+        ksession.setWorkItemManager(manager);
+        WorkItemImpl workItem = new WorkItemImpl();
+        workItem.setName("Human Task");
+        workItem.setParameter("TaskName", "TaskName");
+        workItem.setParameter("Comment", "Comment");
+        workItem.setParameter("Priority", "10");
+        workItem.setParameter("ActorId", "Darth Vader");
+        workItem.setProcessInstanceId(10);
+        handler.executeWorkItem(workItem, manager);
+        
+        TestStatefulKnowledgeSession ksession2 = new TestStatefulKnowledgeSession(10);
+        AsyncHornetQHTWorkItemHandler handler2 = new AsyncHornetQHTWorkItemHandler("testConnector", null, ksession2, OnErrorAction.LOG);
+        handler2.setOwningSessionOnly(true);
+
+        TestWorkItemManager manager2 = new TestWorkItemManager();
+        ksession2.setWorkItemManager(manager2);
+        WorkItemImpl workItem2 = new WorkItemImpl();
+        workItem2.setName("Human Task");
+        workItem2.setParameter("TaskName", "TaskName");
+        workItem2.setParameter("Comment", "Comment");
+        workItem2.setParameter("Priority", "10");
+        workItem2.setParameter("ActorId", "Darth Vader");
+        workItem2.setProcessInstanceId(10);
+        handler2.executeWorkItem(workItem2, manager2);
+
+        Thread.sleep(1000);
+        
+        BlockingTaskSummaryResponseHandler reshanlder = new BlockingTaskSummaryResponseHandler();
+        clientAsync.getTasksAssignedAsPotentialOwner("Darth Vader", "en-UK", reshanlder);
+        List<TaskSummary> tasks = reshanlder.getResults();
+        assertEquals(2, tasks.size());
+        TaskSummary task = tasks.get(0);
+        // ensure we get first task
+        if (task.getProcessSessionId() == 10) {
+            task = tasks.get(1);
+        }
+        assertEquals("TaskName", task.getName());
+        assertEquals(10, task.getPriority());
+        assertEquals("Comment", task.getDescription());
+        assertEquals(Status.Reserved, task.getStatus());
+        assertEquals("Darth Vader", task.getActualOwner().getId());
+        assertEquals(10, task.getProcessInstanceId());
+
+        BlockingTaskOperationResponseHandler resOpHandler = new BlockingTaskOperationResponseHandler();
+        clientAsync.start(task.getId(), "Darth Vader", resOpHandler);
+        resOpHandler.waitTillDone(5000);
+        
+        resOpHandler = new BlockingTaskOperationResponseHandler();
+        clientAsync.complete(task.getId(), "Darth Vader", null, resOpHandler);
+        resOpHandler.waitTillDone(5000);
+        
+        Thread.sleep(1000);
+        
+        assertEquals(1, manager.getCompleteCounter());
+        assertEquals(0, manager2.getCompleteCounter());
+        
+        handler.dispose();
+        handler2.dispose();
+    }
+    
+    private class TestWorkItemManager implements WorkItemManager {
+
+        private volatile int completeCounter = 0;
+        private volatile boolean completed;
+        private volatile boolean aborted;
+        private volatile Map<String, Object> results;
+
+        public synchronized boolean waitTillCompleted(long time) {
+            if (!isCompleted()) {
+                try {
+                    wait(time);
+                } catch (InterruptedException e) {
+                    // swallow and return state of completed
+                }
+            }
+
+            return isCompleted();
+        }
+
+        public synchronized boolean waitTillAborted(long time) {
+            if (!isAborted()) {
+                try {
+                    wait(time);
+                } catch (InterruptedException e) {
+                    // swallow and return state of aborted
+                }
+            }
+
+            return isAborted();
+        }
+
+        public void abortWorkItem(long id) {
+            setAborted(true);
+        }
+
+        public synchronized boolean isAborted() {
+            return aborted;
+        }
+
+        private synchronized void setAborted(boolean aborted) {
+            this.aborted = aborted;
+            notifyAll();
+        }
+
+        public void completeWorkItem(long id, Map<String, Object> results) {
+            this.results = results;
+            setCompleted(true);
+            this.setCompleteCounter(this.getCompleteCounter() + 1);
+        }
+
+        private synchronized void setCompleted(boolean completed) {
+            this.completed = completed;
+            notifyAll();
+        }
+
+        public synchronized boolean isCompleted() {
+            return completed;
+        }
+
+        public Map<String, Object> getResults() {
+            return results;
+        }
+
+        public void registerWorkItemHandler(String workItemName, WorkItemHandler handler) {
+        }
+
+        public int getCompleteCounter() {
+            return completeCounter;
+        }
+
+        public void setCompleteCounter(int completeCounter) {
+            this.completeCounter = completeCounter;
+        }
+    }
+}

--- a/jbpm-human-task/jbpm-human-task-mina/src/main/java/org/jbpm/process/workitem/wsht/AsyncMinaHTWorkItemHandler.java
+++ b/jbpm-human-task/jbpm-human-task-mina/src/main/java/org/jbpm/process/workitem/wsht/AsyncMinaHTWorkItemHandler.java
@@ -32,6 +32,17 @@ public class AsyncMinaHTWorkItemHandler extends AsyncGenericHTWorkItemHandler{
         super(session);
         init();
     }
+    
+    public AsyncMinaHTWorkItemHandler(KnowledgeRuntime session, boolean owningSessionOnly) {
+        super(session, owningSessionOnly);
+        init();
+    }
+    
+    public AsyncMinaHTWorkItemHandler(AsyncTaskService client, KnowledgeRuntime session, boolean owningSessionOnly) {
+        super(session, owningSessionOnly);
+        setClient(client);
+        init();
+    }
 
     public AsyncMinaHTWorkItemHandler(KnowledgeRuntime session, OnErrorAction action) {
         super(session, action);

--- a/jbpm-human-task/jbpm-human-task-mina/src/main/java/org/jbpm/process/workitem/wsht/MinaHTWorkItemHandler.java
+++ b/jbpm-human-task/jbpm-human-task-mina/src/main/java/org/jbpm/process/workitem/wsht/MinaHTWorkItemHandler.java
@@ -30,9 +30,24 @@ public class MinaHTWorkItemHandler extends GenericHTWorkItemHandler{
         super(session);
         init();
     }
+    
+    public MinaHTWorkItemHandler(KnowledgeRuntime session, boolean owningSessionOnly) {
+        super(session, owningSessionOnly);
+        init();
+    }
 
     public MinaHTWorkItemHandler(KnowledgeRuntime session, OnErrorAction action) {
         super(session, action);
+        init();
+    }
+    
+    public MinaHTWorkItemHandler(TaskService client, KnowledgeRuntime session) {
+        super(client, session);
+        init();
+    }
+    
+    public MinaHTWorkItemHandler(TaskService client, KnowledgeRuntime session, boolean owningSessionOnly) {
+        super(client, session, owningSessionOnly);
         init();
     }
     

--- a/jbpm-human-task/jbpm-human-task-mina/src/test/java/org/jbpm/process/workitem/wsht/mina/MinaMultipleHandlersTest.java
+++ b/jbpm-human-task/jbpm-human-task-mina/src/test/java/org/jbpm/process/workitem/wsht/mina/MinaMultipleHandlersTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2012 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.wsht.mina;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.process.instance.impl.WorkItemImpl;
+import org.drools.runtime.process.WorkItemHandler;
+import org.drools.runtime.process.WorkItemManager;
+import org.jbpm.process.workitem.wsht.AbstractHTWorkItemHandler;
+import org.jbpm.process.workitem.wsht.AsyncGenericHTWorkItemHandler;
+import org.jbpm.process.workitem.wsht.AsyncMinaHTWorkItemHandler;
+import org.jbpm.process.workitem.wsht.GenericHTWorkItemHandler;
+import org.jbpm.process.workitem.wsht.MinaHTWorkItemHandler;
+import org.jbpm.task.AsyncTaskService;
+import org.jbpm.task.BaseTest;
+import org.jbpm.task.Status;
+import org.jbpm.task.TaskService;
+import org.jbpm.task.TestStatefulKnowledgeSession;
+import org.jbpm.task.query.TaskSummary;
+import org.jbpm.task.service.TaskServer;
+import org.jbpm.task.service.mina.MinaTaskServer;
+import org.jbpm.task.service.responsehandlers.BlockingTaskOperationResponseHandler;
+import org.jbpm.task.service.responsehandlers.BlockingTaskSummaryResponseHandler;
+import org.jbpm.task.utils.OnErrorAction;
+import org.junit.Test;
+
+public class MinaMultipleHandlersTest extends BaseTest {
+
+    private TaskService client;
+    private AsyncTaskService clientAsync;
+    private TaskServer server;
+    
+    private List<AbstractHTWorkItemHandler> handlers = new ArrayList<AbstractHTWorkItemHandler>();
+    @Override
+    protected void setUp() throws Exception {
+       super.setUp();
+       server = new MinaTaskServer(taskService);
+       Thread thread = new Thread(server);
+       thread.start();
+       System.out.println("Waiting for the MinaTask Server to come up");
+       while (!server.isRunning()) {
+           System.out.print(".");
+           Thread.sleep(50);
+       }
+       
+    }
+
+    protected void tearDown() throws Exception {
+        if (client != null) {
+            client.disconnect();
+        }
+        
+        if (clientAsync != null) {
+            clientAsync.disconnect();
+        }
+        
+        for (AbstractHTWorkItemHandler handler : handlers) {
+            if (handler instanceof GenericHTWorkItemHandler) {
+                ((GenericHTWorkItemHandler) handler).dispose();
+            } else if (handler instanceof AsyncGenericHTWorkItemHandler) {
+                ((AsyncGenericHTWorkItemHandler) handler).dispose();
+            }
+        }
+        handlers.clear();
+        server.stop();
+        
+        super.tearDown();
+    }
+    
+    @Test
+    public void testCompleteTaskMultipleSessionsSync() throws Exception {
+        TestStatefulKnowledgeSession ksession = new TestStatefulKnowledgeSession();
+        
+        MinaHTWorkItemHandler handler = new MinaHTWorkItemHandler(ksession, true);
+        handlers.add(handler);
+
+        client = handler.getClient();
+        TestWorkItemManager manager = new TestWorkItemManager();
+        ksession.setWorkItemManager(manager);
+        WorkItemImpl workItem = new WorkItemImpl();
+        workItem.setName("Human Task");
+        workItem.setParameter("TaskName", "TaskName");
+        workItem.setParameter("Comment", "Comment");
+        workItem.setParameter("Priority", "10");
+        workItem.setParameter("ActorId", "Darth Vader");
+        workItem.setProcessInstanceId(10);
+        handler.executeWorkItem(workItem, manager);
+        
+        TestStatefulKnowledgeSession ksession2 = new TestStatefulKnowledgeSession(10);
+        MinaHTWorkItemHandler handler2 = new MinaHTWorkItemHandler("testConnector", null, ksession2, OnErrorAction.LOG);
+        handlers.add(handler2);
+        handler2.setOwningSessionOnly(true);
+
+        TestWorkItemManager manager2 = new TestWorkItemManager();
+        ksession2.setWorkItemManager(manager2);
+        WorkItemImpl workItem2 = new WorkItemImpl();
+        workItem2.setName("Human Task");
+        workItem2.setParameter("TaskName", "TaskName");
+        workItem2.setParameter("Comment", "Comment");
+        workItem2.setParameter("Priority", "10");
+        workItem2.setParameter("ActorId", "Darth Vader");
+        workItem2.setProcessInstanceId(10);
+        handler2.executeWorkItem(workItem2, manager2);
+
+        
+        List<TaskSummary> tasks = client.getTasksAssignedAsPotentialOwner("Darth Vader", "en-UK");
+        assertEquals(2, tasks.size());
+        TaskSummary task = tasks.get(0);
+        // ensure we get first task
+        if (task.getProcessSessionId() == 10) {
+            task = tasks.get(1);
+        }
+        assertEquals("TaskName", task.getName());
+        assertEquals(10, task.getPriority());
+        assertEquals("Comment", task.getDescription());
+        assertEquals(Status.Reserved, task.getStatus());
+        assertEquals("Darth Vader", task.getActualOwner().getId());
+        assertEquals(10, task.getProcessInstanceId());
+
+        client.start(task.getId(), "Darth Vader");
+        client.complete(task.getId(), "Darth Vader", null);
+        
+        Thread.sleep(1000);
+        
+        assertEquals(1, manager.getCompleteCounter());
+        assertEquals(0, manager2.getCompleteCounter());
+    }
+    
+    @Test
+    public void testCompleteTaskMultipleSessionsASync() throws Exception {
+        TestStatefulKnowledgeSession ksession = new TestStatefulKnowledgeSession();
+        
+        AsyncMinaHTWorkItemHandler handler = new AsyncMinaHTWorkItemHandler(ksession, true);
+        handlers.add(handler);
+
+        clientAsync = handler.getClient();
+        TestWorkItemManager manager = new TestWorkItemManager();
+        ksession.setWorkItemManager(manager);
+        WorkItemImpl workItem = new WorkItemImpl();
+        workItem.setName("Human Task");
+        workItem.setParameter("TaskName", "TaskName");
+        workItem.setParameter("Comment", "Comment");
+        workItem.setParameter("Priority", "10");
+        workItem.setParameter("ActorId", "Darth Vader");
+        workItem.setProcessInstanceId(10);
+        handler.executeWorkItem(workItem, manager);
+        
+        TestStatefulKnowledgeSession ksession2 = new TestStatefulKnowledgeSession(10);
+        AsyncMinaHTWorkItemHandler handler2 = new AsyncMinaHTWorkItemHandler("testConnector", null, ksession2, OnErrorAction.LOG);
+        handler2.setOwningSessionOnly(true);
+        handlers.add(handler2);
+
+        TestWorkItemManager manager2 = new TestWorkItemManager();
+        ksession2.setWorkItemManager(manager2);
+        WorkItemImpl workItem2 = new WorkItemImpl();
+        workItem2.setName("Human Task");
+        workItem2.setParameter("TaskName", "TaskName");
+        workItem2.setParameter("Comment", "Comment");
+        workItem2.setParameter("Priority", "10");
+        workItem2.setParameter("ActorId", "Darth Vader");
+        workItem2.setProcessInstanceId(10);
+        handler2.executeWorkItem(workItem2, manager2);
+
+        Thread.sleep(1000);
+        
+        BlockingTaskSummaryResponseHandler reshanlder = new BlockingTaskSummaryResponseHandler();
+        clientAsync.getTasksAssignedAsPotentialOwner("Darth Vader", "en-UK", reshanlder);
+        List<TaskSummary> tasks = reshanlder.getResults();
+        assertEquals(2, tasks.size());
+        TaskSummary task = tasks.get(0);
+        // ensure we get first task
+        if (task.getProcessSessionId() == 10) {
+            task = tasks.get(1);
+        }
+        assertEquals("TaskName", task.getName());
+        assertEquals(10, task.getPriority());
+        assertEquals("Comment", task.getDescription());
+        assertEquals(Status.Reserved, task.getStatus());
+        assertEquals("Darth Vader", task.getActualOwner().getId());
+        assertEquals(10, task.getProcessInstanceId());
+
+
+        BlockingTaskOperationResponseHandler resOpHandler = new BlockingTaskOperationResponseHandler();
+        clientAsync.start(task.getId(), "Darth Vader", resOpHandler);
+        resOpHandler.waitTillDone(5000);
+        
+        resOpHandler = new BlockingTaskOperationResponseHandler();
+        clientAsync.complete(task.getId(), "Darth Vader", null, resOpHandler);
+        resOpHandler.waitTillDone(5000);
+        
+        Thread.sleep(2000);
+
+        assertEquals(1, manager.getCompleteCounter());
+        assertEquals(0, manager2.getCompleteCounter());
+        
+        
+    }
+    
+    private class TestWorkItemManager implements WorkItemManager {
+
+        private volatile int completeCounter = 0;
+        private volatile boolean completed;
+        private volatile boolean aborted;
+        private volatile Map<String, Object> results;
+
+        public synchronized boolean waitTillCompleted(long time) {
+            if (!isCompleted()) {
+                try {
+                    wait(time);
+                } catch (InterruptedException e) {
+                    // swallow and return state of completed
+                }
+            }
+
+            return isCompleted();
+        }
+
+        public synchronized boolean waitTillAborted(long time) {
+            if (!isAborted()) {
+                try {
+                    wait(time);
+                } catch (InterruptedException e) {
+                    // swallow and return state of aborted
+                }
+            }
+
+            return isAborted();
+        }
+
+        public void abortWorkItem(long id) {
+            setAborted(true);
+        }
+
+        public synchronized boolean isAborted() {
+            return aborted;
+        }
+
+        private synchronized void setAborted(boolean aborted) {
+            this.aborted = aborted;
+            notifyAll();
+        }
+
+        public void completeWorkItem(long id, Map<String, Object> results) {
+            this.results = results;
+            setCompleted(true);
+            this.setCompleteCounter(this.getCompleteCounter() + 1);
+        }
+
+        private synchronized void setCompleted(boolean completed) {
+            this.completed = completed;
+            notifyAll();
+        }
+
+        public synchronized boolean isCompleted() {
+            return completed;
+        }
+
+        public Map<String, Object> getResults() {
+            return results;
+        }
+
+        public void registerWorkItemHandler(String workItemName, WorkItemHandler handler) {
+        }
+
+        public int getCompleteCounter() {
+            return completeCounter;
+        }
+
+        public void setCompleteCounter(int completeCounter) {
+            this.completeCounter = completeCounter;
+        }
+    }
+}

--- a/jbpm-human-task/jbpm-human-task-mina/src/test/java/org/jbpm/task/service/persistence/variable/VariablePersistenceStrategiesASyncHTTest.java
+++ b/jbpm-human-task/jbpm-human-task-mina/src/test/java/org/jbpm/task/service/persistence/variable/VariablePersistenceStrategiesASyncHTTest.java
@@ -166,7 +166,7 @@ public class VariablePersistenceStrategiesASyncHTTest extends BaseTest {
         Task task = getTaskResponseHandler.getTask();
         
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
         
@@ -226,7 +226,7 @@ public class VariablePersistenceStrategiesASyncHTTest extends BaseTest {
         Task task = getTaskResponseHandler.getTask();
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
         
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -296,7 +296,7 @@ public class VariablePersistenceStrategiesASyncHTTest extends BaseTest {
         getClient().getTask(taskSummary.getId(),getTaskResponseHandler);
         Task task = getTaskResponseHandler.getTask();
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -371,7 +371,7 @@ public class VariablePersistenceStrategiesASyncHTTest extends BaseTest {
         Task task = getTaskResponseHandler.getTask();
 
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -433,7 +433,7 @@ public class VariablePersistenceStrategiesASyncHTTest extends BaseTest {
         Task task = getTaskResponseHandler.getTask();
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
 
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -503,7 +503,7 @@ public class VariablePersistenceStrategiesASyncHTTest extends BaseTest {
         getClient().getTask(taskSummary.getId(),getTaskResponseHandler);
         Task task = getTaskResponseHandler.getTask();
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -580,7 +580,7 @@ public class VariablePersistenceStrategiesASyncHTTest extends BaseTest {
         Task task = getTaskResponseHandler.getTask();
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
         
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -645,7 +645,7 @@ public class VariablePersistenceStrategiesASyncHTTest extends BaseTest {
         getClient().getTask(taskSummary.getId(),getTaskResponseHandler);
         Task task = getTaskResponseHandler.getTask();
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 
@@ -722,7 +722,7 @@ public class VariablePersistenceStrategiesASyncHTTest extends BaseTest {
         getClient().getTask(taskSummary.getId(),getTaskResponseHandler);
         Task task = getTaskResponseHandler.getTask();
         assertEquals(AccessType.Inline, task.getTaskData().getDocumentAccessType());
-        assertEquals(task.getTaskData().getProcessSessionId(), TestStatefulKnowledgeSession.testSessionId);
+        assertEquals(task.getTaskData().getProcessSessionId(), ksession.getId());
         long contentId = task.getTaskData().getDocumentContentId();
         assertTrue(contentId != -1);
 


### PR DESCRIPTION
...er registration

Provides configuration option to inform HT handlers to react only on tasks that belong to session that is used by the handler to avoid duplicated completion of a task in situation where:
- multiple sessions are used
- handlers register to receive notification for all tasks (-1)

Be default it is turned off so it's backward compatible
