### PR TITLE
JBPM-3813 Process Instance Diagram in jBPM Console shows wrong multiple ...

### DIFF
--- a/jbpm-bam/src/main/java/org/jbpm/process/audit/JPAProcessInstanceDbLog.java
+++ b/jbpm-bam/src/main/java/org/jbpm/process/audit/JPAProcessInstanceDbLog.java
@@ -144,7 +144,7 @@ public class JPAProcessInstanceDbLog {
         EntityManager em = getEntityManager();
         UserTransaction ut = joinTransaction(em);
         List<NodeInstanceLog> result = getEntityManager()
-            .createQuery("FROM NodeInstanceLog n WHERE n.processInstanceId = :processInstanceId ORDER BY date")
+            .createQuery("FROM NodeInstanceLog n WHERE n.processInstanceId = :processInstanceId ORDER BY date, type")
                 .setParameter("processInstanceId", processInstanceId).getResultList();
         closeEntityManager(em, ut);
         return result;
@@ -155,7 +155,7 @@ public class JPAProcessInstanceDbLog {
         EntityManager em = getEntityManager();
         UserTransaction ut = joinTransaction(em);
         List<NodeInstanceLog> result = getEntityManager()
-            .createQuery("FROM NodeInstanceLog n WHERE n.processInstanceId = :processInstanceId AND n.nodeId = :nodeId ORDER BY date")
+            .createQuery("FROM NodeInstanceLog n WHERE n.processInstanceId = :processInstanceId AND n.nodeId = :nodeId ORDER BY date, type")
                 .setParameter("processInstanceId", processInstanceId)
                 .setParameter("nodeId", nodeId).getResultList();
         closeEntityManager(em, ut);


### PR DESCRIPTION
Process Instance Diagram in jBPM Console shows wrong multiple markers due to the ordering of JPAProcessInstanceDbLog.findNodeInstances()
https://issues.jboss.org/browse/JBPM-3813

This pull request is a candidate fix which ensures that an ENTER log comes before an EXIT log. But I'm not sure if I'm right about assuming 'order by type' gives asc order in time line.
