### PR TITLE
JBPM-3512 - Allow developer-defined correlationId in addition to process...

### DIFF
--- a/jbpm-bam/src/main/java/org/jbpm/process/audit/JPAProcessInstanceDbLog.java
+++ b/jbpm-bam/src/main/java/org/jbpm/process/audit/JPAProcessInstanceDbLog.java
@@ -126,6 +126,18 @@ public class JPAProcessInstanceDbLog {
         }
     }
     
+    public static List<ProcessInstanceLog> findProcessInstancesByBusinessKey(String businessKey) {
+        EntityManager em = getEntityManager();
+        boolean newTx = joinTransaction(em);
+        try {
+            return (List<ProcessInstanceLog>) getEntityManager()
+            .createQuery("FROM ProcessInstanceLog p WHERE p.businessKey = :businessKey order by p.id")
+                .setParameter("businessKey", businessKey).getResultList();
+        } finally {
+            closeEntityManager(em, newTx);
+        }
+    }
+    
     @SuppressWarnings("unchecked")
     public static List<ProcessInstanceLog> findSubProcessInstances(long processInstanceId) {
         EntityManager em = getEntityManager();

--- a/jbpm-bam/src/main/java/org/jbpm/process/audit/JPAWorkingMemoryDbLogger.java
+++ b/jbpm-bam/src/main/java/org/jbpm/process/audit/JPAWorkingMemoryDbLogger.java
@@ -43,6 +43,7 @@ import org.kie.runtime.Environment;
 import org.kie.runtime.EnvironmentName;
 import org.kie.runtime.KnowledgeRuntime;
 import org.jbpm.process.audit.event.ExtendedRuleFlowLogEvent;
+import org.jbpm.process.instance.ProcessInstance;
 import org.jbpm.process.instance.impl.ProcessInstanceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,6 +116,7 @@ public class JPAWorkingMemoryDbLogger extends WorkingMemoryLogger {
         ProcessInstanceLog log = new ProcessInstanceLog(processEvent.getProcessInstanceId(), processEvent.getProcessId());
         if (processEvent instanceof ExtendedRuleFlowLogEvent) {
             log.setParentProcessInstanceId(((ExtendedRuleFlowLogEvent) processEvent).getParentProcessInstanceId());
+            log.setBusinessKey(((ExtendedRuleFlowLogEvent) processEvent).getBusinessKey());
         }
         persist(log);
     }
@@ -274,7 +276,8 @@ public class JPAWorkingMemoryDbLogger extends WorkingMemoryLogger {
         LogEvent logEvent =  new ExtendedRuleFlowLogEvent( LogEvent.BEFORE_RULEFLOW_CREATED,
                 event.getProcessInstance().getProcessId(),
                 event.getProcessInstance().getProcessName(),
-                event.getProcessInstance().getId(), parentProcessInstanceId) ;
+                event.getProcessInstance().getId(), parentProcessInstanceId,
+                ((ProcessInstance)event.getProcessInstance()).getBusinessKey()) ;
         
         // filters are not available from super class, TODO make fireLogEvent protected instead of private in WorkinMemoryLogger
         logEventCreated( logEvent );

--- a/jbpm-bam/src/main/java/org/jbpm/process/audit/ProcessInstanceLog.java
+++ b/jbpm-bam/src/main/java/org/jbpm/process/audit/ProcessInstanceLog.java
@@ -53,6 +53,8 @@ public class ProcessInstanceLog implements Serializable {
     private long parentProcessInstanceId;
     @Column(nullable=true)
     private String outcome;
+    @Column(nullable=true)
+    private String businessKey;
     
     ProcessInstanceLog() {
     }
@@ -187,5 +189,13 @@ public class ProcessInstanceLog implements Serializable {
 
 	public void setOutcome(String errorCode) {
         this.outcome = errorCode;
+    }
+
+    public String getBusinessKey() {
+        return businessKey;
+    }
+
+    public void setBusinessKey(String businessKey) {
+        this.businessKey = businessKey;
     }
 }

--- a/jbpm-bam/src/main/java/org/jbpm/process/audit/event/ExtendedRuleFlowLogEvent.java
+++ b/jbpm-bam/src/main/java/org/jbpm/process/audit/event/ExtendedRuleFlowLogEvent.java
@@ -22,10 +22,13 @@ public class ExtendedRuleFlowLogEvent extends RuleFlowLogEvent {
     private long parentProcessInstanceId;
     private String outcome;
     private int processInstanceState;
+    private String businessKey;
     
-    public ExtendedRuleFlowLogEvent(int type, String processId, String processName, long processInstanceId, long parentProcessInstanceId) {
+    public ExtendedRuleFlowLogEvent(int type, String processId, String processName, 
+            long processInstanceId, long parentProcessInstanceId, String businessKey) {
         super(type, processId, processName, processInstanceId);
         this.parentProcessInstanceId = parentProcessInstanceId;
+        this.businessKey = businessKey;
        
     }
 
@@ -57,5 +60,13 @@ public class ExtendedRuleFlowLogEvent extends RuleFlowLogEvent {
 
     protected void setProcessInstanceState(int processInstanceState) {
         this.processInstanceState = processInstanceState;
+    }
+
+    public String getBusinessKey() {
+        return businessKey;
+    }
+
+    public void setBusinessKey(String businessKey) {
+        this.businessKey = businessKey;
     }
 }

--- a/jbpm-flow/src/main/java/org/jbpm/process/StatefulProcessSession.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/StatefulProcessSession.java
@@ -352,4 +352,23 @@ public class StatefulProcessSession implements StatefulKnowledgeSession, Interna
 		throw new UnsupportedOperationException();
 	}
 
+    @Override
+    public ProcessInstance startProcess(String processId, String businessKey,
+            Map<String, Object> parameters) {
+        
+        return processRuntime.startProcess(processId, businessKey, parameters);
+    }
+
+    @Override
+    public ProcessInstance createProcessInstance(String processId,
+            String businessKey, Map<String, Object> parameters) {
+        return processRuntime.createProcessInstance(processId, businessKey, parameters);
+    }
+
+    @Override
+    public ProcessInstance getProcessInstance(String businessKey) {
+        
+        return processRuntime.getProcessInstance(businessKey);
+    }
+
 }

--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/AbstractProcessInstanceFactory.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/AbstractProcessInstanceFactory.java
@@ -26,12 +26,13 @@ import org.jbpm.process.instance.context.variable.VariableScopeInstance;
 
 public abstract class AbstractProcessInstanceFactory implements ProcessInstanceFactory {
 	
-	public ProcessInstance createProcessInstance(Process process,
+	public ProcessInstance createProcessInstance(Process process, String businessKey,
 			                                     InternalKnowledgeRuntime kruntime,
 			                                     Map<String, Object> parameters) {
 		ProcessInstance processInstance = (ProcessInstance) createProcessInstance();
 		processInstance.setKnowledgeRuntime( kruntime );
         processInstance.setProcess( process );
+        processInstance.setBusinessKey(businessKey);
         
         ((InternalProcessRuntime) kruntime.getProcessRuntime()).getProcessInstanceManager()
     		.addProcessInstance( processInstance );

--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstance.java
@@ -45,4 +45,8 @@ public interface ProcessInstance extends org.kie.runtime.process.ProcessInstance
     void start();
     
     String getOutcome();
+    
+    void setBusinessKey(String businessKey);
+    
+    String getBusinessKey();
 }

--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstanceFactory.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstanceFactory.java
@@ -27,6 +27,6 @@ import org.kie.definition.process.Process;
  */
 public interface ProcessInstanceFactory {
     
-    ProcessInstance createProcessInstance(Process process, InternalKnowledgeRuntime kruntime, Map<String, Object> parameters);
+    ProcessInstance createProcessInstance(Process process, String businesKey, InternalKnowledgeRuntime kruntime, Map<String, Object> parameters);
 
 }

--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstanceManager.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstanceManager.java
@@ -24,6 +24,8 @@ public interface ProcessInstanceManager {
 
     ProcessInstance getProcessInstance(long id);
     
+    ProcessInstance getProcessInstance(String businessKey);
+    
     Collection<ProcessInstance> getProcessInstances();
 
     void addProcessInstance(ProcessInstance processInstance);

--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeImpl.java
@@ -130,10 +130,15 @@ public class ProcessRuntimeImpl implements InternalProcessRuntime {
     public ProcessInstance startProcess(final String processId) {
         return startProcess(processId, null);
     }
-
+    
     public ProcessInstance startProcess(String processId,
+            Map<String, Object> parameters) {
+        return startProcess(processId, null, parameters);
+    }
+
+    public ProcessInstance startProcess(String processId, String businessKey,
                                         Map<String, Object> parameters) {
-    	ProcessInstance processInstance = createProcessInstance(processId, parameters);
+    	ProcessInstance processInstance = createProcessInstance(processId, businessKey, parameters);
         if ( processInstance != null ) {
             // start process instance
         	return startProcessInstance(processInstance.getId());
@@ -141,7 +146,11 @@ public class ProcessRuntimeImpl implements InternalProcessRuntime {
         return null;
     }
     
-    public ProcessInstance createProcessInstance(String processId,
+    public ProcessInstance createProcessInstance(String processId,  Map<String, Object> parameters) {
+        return createProcessInstance(processId, null, parameters);
+    }
+    
+    public ProcessInstance createProcessInstance(String processId, String businessKey,
                                                  Map<String, Object> parameters) {
         try {
             kruntime.startOperation();
@@ -152,7 +161,7 @@ public class ProcessRuntimeImpl implements InternalProcessRuntime {
             if ( process == null ) {
                 throw new IllegalArgumentException( "Unknown process ID: " + processId );
             }
-            return startProcess( process, parameters );
+            return startProcess( process, businessKey, parameters );
         } finally {
         	kruntime.endOperation();
         }
@@ -174,15 +183,16 @@ public class ProcessRuntimeImpl implements InternalProcessRuntime {
         }
     }
 
-    private org.jbpm.process.instance.ProcessInstance startProcess(final Process process,
+    private org.jbpm.process.instance.ProcessInstance startProcess(final Process process, String businessKey,
                                          Map<String, Object> parameters) {
         ProcessInstanceFactory conf = ProcessInstanceFactoryRegistry.INSTANCE.getProcessInstanceFactory( process );
         if ( conf == null ) {
             throw new IllegalArgumentException( "Illegal process type: " + process.getClass() );
         }
-        return conf.createProcessInstance( process,
+        org.jbpm.process.instance.ProcessInstance pi = conf.createProcessInstance( process, businessKey, 
         								   kruntime,
                                            parameters );
+        return pi;
     }
 
     public ProcessInstanceManager getProcessInstanceManager() {
@@ -203,6 +213,10 @@ public class ProcessRuntimeImpl implements InternalProcessRuntime {
 
     public ProcessInstance getProcessInstance(long id) {
         return processInstanceManager.getProcessInstance( id );
+    }
+    
+    public ProcessInstance getProcessInstance(String businessKey) {
+        return processInstanceManager.getProcessInstance( businessKey );
     }
 
     public void removeProcessInstance(ProcessInstance processInstance) {

--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/DefaultProcessInstanceManager.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/DefaultProcessInstanceManager.java
@@ -28,6 +28,7 @@ import org.jbpm.process.instance.ProcessInstanceManager;
 public class DefaultProcessInstanceManager implements ProcessInstanceManager {
 
     private Map<Long, ProcessInstance> processInstances = new ConcurrentHashMap<Long, ProcessInstance>();
+    private Map<String, ProcessInstance> processInstancesByBusinessKey = new ConcurrentHashMap<String, ProcessInstance>();
     private AtomicLong processCounter = new AtomicLong(0);
 
     public void addProcessInstance(ProcessInstance processInstance) {
@@ -37,6 +38,10 @@ public class DefaultProcessInstanceManager implements ProcessInstanceManager {
     
     public void internalAddProcessInstance(ProcessInstance processInstance) {
     	processInstances.put(((ProcessInstance)processInstance).getId(), processInstance);
+    	String businessKey = ((org.jbpm.process.instance.ProcessInstance)processInstance).getBusinessKey();
+    	if (businessKey != null) {
+    	    processInstancesByBusinessKey.put(businessKey, processInstance);
+    	}    	
     }
 
     public Collection<ProcessInstance> getProcessInstances() {
@@ -53,6 +58,10 @@ public class DefaultProcessInstanceManager implements ProcessInstanceManager {
 
     public void internalRemoveProcessInstance(ProcessInstance processInstance) {
         processInstances.remove(((ProcessInstance)processInstance).getId());
+        String businessKey = ((org.jbpm.process.instance.ProcessInstance)processInstance).getBusinessKey();
+        if (businessKey != null) {
+            processInstancesByBusinessKey.remove(businessKey);
+        }
     }
     
     public void clearProcessInstances() {
@@ -61,5 +70,10 @@ public class DefaultProcessInstanceManager implements ProcessInstanceManager {
 
     public void clearProcessInstancesState() {
         
+    }
+
+    public ProcessInstance getProcessInstance(String businessKey) {
+        
+        return processInstancesByBusinessKey.get(businessKey);
     }
 }

--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/ProcessInstanceImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/ProcessInstanceImpl.java
@@ -42,6 +42,7 @@ public abstract class ProcessInstanceImpl implements ProcessInstance, Serializab
 	
 	private long id;
     private String processId;
+    private String businessKey;
     private transient Process process;
     private int state = STATE_PENDING;
     private Map<String, ContextInstance> contextInstances = new HashMap<String, ContextInstance>();
@@ -236,6 +237,14 @@ public abstract class ProcessInstanceImpl implements ProcessInstance, Serializab
 
     public String getOutcome() {
         return outcome;
+    }
+
+    public String getBusinessKey() {
+        return businessKey;
+    }
+
+    public void setBusinessKey(String businessKey) {
+        this.businessKey = businessKey;
     }
     
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/task/TestStatefulKnowledgeSession.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/task/TestStatefulKnowledgeSession.java
@@ -257,4 +257,21 @@ public class TestStatefulKnowledgeSession implements StatefulKnowledgeSession {
 	public int getId() {
 		return testSessionId; 
 	}
+
+    @Override
+    public ProcessInstance startProcess(String processId, String businessKey,
+            Map<String, Object> parameters) {
+        return null;
+    }
+
+    @Override
+    public ProcessInstance createProcessInstance(String processId,
+            String businessKey, Map<String, Object> parameters) {
+        return null;
+    }
+
+    @Override
+    public ProcessInstance getProcessInstance(String businessKey) {
+        return null;
+    }
 }

--- a/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/JpaProcessPersistenceContext.java
+++ b/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/JpaProcessPersistenceContext.java
@@ -38,5 +38,18 @@ public class JpaProcessPersistenceContext extends JpaPersistenceContext
                                                type );
         return (List<Long>) processInstancesForEvent.getResultList();
     }
+
+    public Long getProcessInstanceByBusinessKey(String businessKey) {
+        Query processInstanceByBusinessKey = getEntityManager().createNamedQuery( "ProcessInstanceByBusinessKey" );
+        processInstanceByBusinessKey.setFlushMode(FlushModeType.COMMIT);
+        processInstanceByBusinessKey.setParameter( "businessKey", businessKey );
+                 
+        try {
+            return (Long) processInstanceByBusinessKey.getSingleResult();
+        } catch (Exception e) {
+            return null;
+        }
+        
+    }
     
 }

--- a/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/MapBasedProcessPersistenceContext.java
+++ b/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/MapBasedProcessPersistenceContext.java
@@ -16,11 +16,13 @@ public class MapBasedProcessPersistenceContext extends MapBasedPersistenceContex
     
     private ProcessStorage storage;
     private Map<Long, ProcessInstanceInfo> processes;
+    private Map<String, Long> processesIdByBusinessKey;
 
     public MapBasedProcessPersistenceContext(ProcessStorage storage) {
         super( storage );
         this.storage = storage;
         this.processes = new HashMap<Long, ProcessInstanceInfo>();
+        this.processesIdByBusinessKey = new HashMap<String, Long>();
     }
 
     public void persist(ProcessInstanceInfo processInstanceInfo) {
@@ -28,6 +30,7 @@ public class MapBasedProcessPersistenceContext extends MapBasedPersistenceContex
             processInstanceInfo.setId( storage.getNextProcessInstanceId() );
         }
         processes.put( processInstanceInfo.getId(), processInstanceInfo );
+        processesIdByBusinessKey.put(processInstanceInfo.getBusinessKey(), processInstanceInfo.getId());
     }
 
     public ProcessInstanceInfo findProcessInstanceInfo(Long processId) {
@@ -58,5 +61,9 @@ public class MapBasedProcessPersistenceContext extends MapBasedPersistenceContex
 
     public void clearStoredProcessInstances() {
         processes.clear();
+    }
+
+    public Long getProcessInstanceByBusinessKey(String businessKey) {        
+        return processesIdByBusinessKey.get(businessKey);        
     }
 }

--- a/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/ProcessPersistenceContext.java
+++ b/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/ProcessPersistenceContext.java
@@ -16,4 +16,6 @@ public interface ProcessPersistenceContext
     void remove(ProcessInstanceInfo processInstanceInfo);
 
     List<Long> getProcessInstancesWaitingForEvent(String type);
+    
+    Long getProcessInstanceByBusinessKey(String businessKey);
 }

--- a/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/processinstance/JPAProcessInstanceManager.java
+++ b/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/processinstance/JPAProcessInstanceManager.java
@@ -149,4 +149,16 @@ public class JPAProcessInstanceManager
         }
     }
 
+    @Override
+    public ProcessInstance getProcessInstance(String businessKey) {
+        ProcessPersistenceContext context = ((ProcessPersistenceContextManager) kruntime.getEnvironment().get( EnvironmentName.PERSISTENCE_CONTEXT_MANAGER )).getProcessPersistenceContext();
+        
+        Long id = context.getProcessInstanceByBusinessKey(businessKey);
+        if (id == null) {
+            return null;
+        }
+        
+        return getProcessInstance(id);
+    }
+
 }

--- a/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/processinstance/ProcessInstanceInfo.java
+++ b/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/processinstance/ProcessInstanceInfo.java
@@ -19,6 +19,7 @@ import org.kie.runtime.process.ProcessInstance;
 
 @Entity
 @SequenceGenerator(name="processInstanceInfoIdSeq", sequenceName="PROCESS_INSTANCE_INFO_ID_SEQ")
+@Table(uniqueConstraints={@UniqueConstraint(columnNames="BUSINESS_KEY")})
 public class ProcessInstanceInfo{
 
     @Id
@@ -30,11 +31,13 @@ public class ProcessInstanceInfo{
     @Column(name = "OPTLOCK")
     private int                               version;
 
-    private String                            processId;
+    private String                            processId;    
     private Date                              startDate;
     private Date                              lastReadDate;
     private Date                              lastModificationDate;
     private int                               state;
+    @Column(name="BUSINESS_KEY")
+    private String                            businessKey;
     
     @Lob
     @Column(length=2147483647)
@@ -132,6 +135,7 @@ public class ProcessInstanceInfo{
                 ProcessInstanceMarshaller marshaller = getMarshallerFromContext( context );
                 context.wm = ((StatefulKnowledgeSessionImpl) kruntime).getInternalWorkingMemory();
                 processInstance = marshaller.readProcessInstance(context);
+                ((org.jbpm.process.instance.ProcessInstance)processInstance).setBusinessKey(getBusinessKey());
                 context.close();
             } catch ( IOException e ) {
                 e.printStackTrace();
@@ -155,6 +159,7 @@ public class ProcessInstanceInfo{
         // saves the processInstance type first
         stream.writeUTF( processInstanceType );
     }
+   
 
     /**
      * Adding @PrePersist breaks things, because: <ul>
@@ -208,6 +213,7 @@ public class ProcessInstanceInfo{
             for ( String type : processInstance.getEventTypes() ) {
                 eventTypes.add( type );
             }
+            this.businessKey = ((org.jbpm.process.instance.ProcessInstance)processInstance).getBusinessKey();
         }
     }
 
@@ -228,6 +234,9 @@ public class ProcessInstanceInfo{
             return false;
         }
         if ( (this.processId == null) ? (other.processId != null) : !this.processId.equals( other.processId ) ) {
+            return false;
+        }
+        if ( (this.businessKey == null) ? (other.businessKey != null) : !this.businessKey.equals( other.businessKey ) ) {
             return false;
         }
         if ( this.startDate != other.startDate && (this.startDate == null || !this.startDate.equals( other.startDate )) ) {
@@ -265,6 +274,7 @@ public class ProcessInstanceInfo{
         hash = 61 * hash + (this.processInstanceId != null ? this.processInstanceId.hashCode() : 0);
         hash = 61 * hash + this.version;
         hash = 61 * hash + (this.processId != null ? this.processId.hashCode() : 0);
+        hash = 61 * hash + (this.businessKey != null ? this.businessKey.hashCode() : 0);
         hash = 61 * hash + (this.startDate != null ? this.startDate.hashCode() : 0);
         hash = 61 * hash + (this.lastReadDate != null ? this.lastReadDate.hashCode() : 0);
         hash = 61 * hash + (this.lastModificationDate != null ? this.lastModificationDate.hashCode() : 0);
@@ -298,5 +308,13 @@ public class ProcessInstanceInfo{
     
     public void setEnv(Environment env) { 
         this.env = env;
+    }
+
+    public String getBusinessKey() {
+        return businessKey;
+    }
+
+    public void setBusinessKey(String businessKey) {
+        this.businessKey = businessKey;
     }
 }

--- a/jbpm-persistence-jpa/src/main/resources/META-INF/JBPMorm.xml
+++ b/jbpm-persistence-jpa/src/main/resources/META-INF/JBPMorm.xml
@@ -16,4 +16,15 @@ where
           </query>
       </named-query>
       
+            <named-query name="ProcessInstanceByBusinessKey">
+          <query>
+select 
+    processInstanceInfo.processInstanceId
+from 
+    ProcessInstanceInfo processInstanceInfo 
+where
+    processInstanceInfo.businessKey = :businessKey
+          </query>
+      </named-query>
+      
 </entity-mappings>

--- a/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/processinstance/ParameterMappingTest.java
+++ b/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/processinstance/ParameterMappingTest.java
@@ -145,6 +145,19 @@ public class ParameterMappingTest extends JbpmTestCase {
         assertTrue(listener.isProcessCompleted(SUBPROCESS_ID));
         assertTrue(listener.isProcessCompleted(PROCESS_ID));
     }
+    
+    @Test
+    public void testProcessWithBusinessKey() throws Exception {
+        Map<String, Object> mapping = new HashMap<String, Object>();
+        mapping.put("type", "default");
+
+        ksession.startProcess(PROCESS_ID, "myBusinessKey", mapping);
+
+        assertTrue(listener.isProcessStarted(PROCESS_ID));
+        assertTrue(listener.isProcessStarted(SUBPROCESS_ID));
+        assertTrue(listener.isProcessCompleted(SUBPROCESS_ID));
+        assertTrue(listener.isProcessCompleted(PROCESS_ID));
+    }
 
     
     public static class ProcessListener extends DefaultProcessEventListener {

--- a/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/session/GetProcessInstancesTest.java
+++ b/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/session/GetProcessInstancesTest.java
@@ -12,6 +12,7 @@ import javax.transaction.UserTransaction;
 
 import org.jbpm.persistence.JbpmTestCase;
 import org.jbpm.persistence.processinstance.JPAProcessInstanceManager;
+import org.jbpm.process.instance.ProcessInstance;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,6 +71,27 @@ public class GetProcessInstancesTest extends JbpmTestCase {
         ksession.dispose();
 
         assertProcessInstancesExist(processId);
+    }
+    
+    @Test
+    public void create2ProcessInstancesByBusinessKey() throws Exception {
+        long[] processId = new long[2];
+
+        StatefulKnowledgeSession ksession = reloadKnowledgeSession();
+        processId[0] = ksession.createProcessInstance("org.jbpm.processinstance.helloworld", "businessKey1", null).getId();
+        processId[1] = ksession.createProcessInstance("org.jbpm.processinstance.helloworld", "businessKey2", null).getId();
+        ksession.dispose();
+
+        assertProcessInstancesExist(processId);
+        ksession = reloadKnowledgeSession();
+        ProcessInstance pi = (ProcessInstance)ksession.getProcessInstance("businessKey1");
+        assertNotNull(pi);
+        assertEquals("businessKey1", pi.getBusinessKey());
+        pi = (ProcessInstance)ksession.getProcessInstance("businessKey2");
+        ksession.startProcessInstance(processId[0]);
+        assertNotNull(pi);
+        assertEquals("businessKey2", pi.getBusinessKey());
+        ksession.startProcessInstance(processId[1]);
     }
 
     @Test

--- a/jbpm-services/droolsjbpm-knowledge-services/src/main/java/org/droolsjbpm/services/impl/helpers/StatefulKnowledgeSessionDelegate.java
+++ b/jbpm-services/droolsjbpm-knowledge-services/src/main/java/org/droolsjbpm/services/impl/helpers/StatefulKnowledgeSessionDelegate.java
@@ -359,5 +359,22 @@ public class StatefulKnowledgeSessionDelegate implements StatefulKnowledgeSessio
         ksession.fireUntilHalt(af);
     }
 
+    @Override
+    public ProcessInstance startProcess(String processId, String businessKey,
+            Map<String, Object> parameters) {
+        return ksession.startProcess(processId, businessKey, parameters);
+    }
+
+    @Override
+    public ProcessInstance createProcessInstance(String processId,
+            String businessKey, Map<String, Object> parameters) {
+        return createProcessInstance(processId, businessKey, parameters);
+    }
+
+    @Override
+    public ProcessInstance getProcessInstance(String businessKey) {
+        return getProcessInstance(businessKey);
+    }
+
   
 }

--- a/jbpm-services/jbpm-human-task-workitems/src/test/java/org/jbpm/task/test/TestStatefulKnowledgeSession.java
+++ b/jbpm-services/jbpm-human-task-workitems/src/test/java/org/jbpm/task/test/TestStatefulKnowledgeSession.java
@@ -251,4 +251,24 @@ public class TestStatefulKnowledgeSession implements StatefulKnowledgeSession {
     @Override
     public void delete(FactHandle fh) {
     }
+
+    @Override
+    public ProcessInstance startProcess(String processId, String businessKey,
+            Map<String, Object> parameters) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ProcessInstance createProcessInstance(String processId,
+            String businessKey, Map<String, Object> parameters) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ProcessInstance getProcessInstance(String businessKey) {
+        // TODO Auto-generated method stub
+        return null;
+    }
 }

--- a/jbpm-test/src/test/java/org/jbpm/persistence/StartProcessWithBusinessKeyTest.java
+++ b/jbpm-test/src/test/java/org/jbpm/persistence/StartProcessWithBusinessKeyTest.java
@@ -1,0 +1,209 @@
+package org.jbpm.persistence;
+
+import java.util.List;
+
+import org.jbpm.process.audit.JPAProcessInstanceDbLog;
+import org.jbpm.process.audit.ProcessInstanceLog;
+import org.jbpm.task.TaskService;
+import org.jbpm.task.query.TaskSummary;
+import org.jbpm.test.JbpmJUnitTestCase;
+import org.junit.Test;
+import org.kie.runtime.StatefulKnowledgeSession;
+import org.kie.runtime.process.ProcessInstance;
+
+public class StartProcessWithBusinessKeyTest extends JbpmJUnitTestCase {
+	
+	public StartProcessWithBusinessKeyTest() {
+	    super(true);
+        this.setPersistence(true);
+	}
+	
+	@Test
+    public void testProcessWithBusinessKey() {
+        StatefulKnowledgeSession ksession = createKnowledgeSession("humantask.bpmn");
+        TaskService taskService = getTaskService(ksession);
+        
+        ProcessInstance processInstance = ksession.startProcess("com.sample.bpmn.hello", "mybusinesskey", null);
+
+        assertProcessInstanceActive(processInstance.getId(), ksession);
+        assertNodeTriggered(processInstance.getId(), "Start", "Task 1");
+        
+        List<ProcessInstanceLog> logs = JPAProcessInstanceDbLog.findProcessInstancesByBusinessKey("mybusinesskey");
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        
+        assertEquals(processInstance.getId(), logs.get(0).getProcessInstanceId());
+        
+        // let john execute Task 1
+        List<TaskSummary> list = taskService.getTasksAssignedAsPotentialOwner("john", "en-UK");
+        TaskSummary task = list.get(0);
+        System.out.println("John is executing task " + task.getName());
+        taskService.start(task.getId(), "john");
+        taskService.complete(task.getId(), "john", null);
+
+        assertNodeTriggered(processInstance.getId(), "Task 2");
+        
+        ProcessInstance processInstanceCopy = ksession.getProcessInstance("mybusinesskey");
+        assertNotNull(processInstanceCopy);
+        assertEquals(processInstance.getId(), processInstanceCopy.getId());
+        
+        // let mary execute Task 2
+        list = taskService.getTasksAssignedAsPotentialOwner("mary", "en-UK");
+        task = list.get(0);
+        System.out.println("Mary is executing task " + task.getName());
+        taskService.start(task.getId(), "mary");
+        taskService.complete(task.getId(), "mary", null);
+
+        assertNodeTriggered(processInstance.getId(), "End");
+        assertProcessInstanceCompleted(processInstance.getId(), ksession);
+        
+        logs = JPAProcessInstanceDbLog.findProcessInstancesByBusinessKey("mybusinesskey");
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        
+        assertEquals(processInstance.getId(), logs.get(0).getProcessInstanceId());
+        assertEquals(org.jbpm.process.instance.ProcessInstance.STATE_COMPLETED, logs.get(0).getStatus());
+    }
+
+	@Test
+    public void testProcessWithBusinessKeyFailOnDuplicatedBusinessKey() {
+        StatefulKnowledgeSession ksession = createKnowledgeSession("humantask.bpmn");
+        TaskService taskService = getTaskService(ksession);
+        
+        ProcessInstance processInstance = ksession.startProcess("com.sample.bpmn.hello", "mybusinesskey", null);
+
+        assertProcessInstanceActive(processInstance.getId(), ksession);
+        assertNodeTriggered(processInstance.getId(), "Start", "Task 1");
+        
+        List<ProcessInstanceLog> logs = JPAProcessInstanceDbLog.findProcessInstancesByBusinessKey("mybusinesskey");
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        
+        assertEquals(processInstance.getId(), logs.get(0).getProcessInstanceId());
+        
+        try {
+            ksession.startProcess("com.sample.bpmn.hello", "mybusinesskey", null);
+            fail("Cannot have duplicated business key running at the same time");
+        } catch (Exception e) {
+            
+        }
+        
+        // let john execute Task 1
+        List<TaskSummary> list = taskService.getTasksAssignedAsPotentialOwner("john", "en-UK");
+        TaskSummary task = list.get(0);
+        System.out.println("John is executing task " + task.getName());
+        taskService.start(task.getId(), "john");
+        taskService.complete(task.getId(), "john", null);
+
+        assertNodeTriggered(processInstance.getId(), "Task 2");
+        
+        ProcessInstance processInstanceCopy = ksession.getProcessInstance("mybusinesskey");
+        assertNotNull(processInstanceCopy);
+        assertEquals(processInstance.getId(), processInstanceCopy.getId());
+        
+        // let mary execute Task 2
+        list = taskService.getTasksAssignedAsPotentialOwner("mary", "en-UK");
+        task = list.get(0);
+        System.out.println("Mary is executing task " + task.getName());
+        taskService.start(task.getId(), "mary");
+        taskService.complete(task.getId(), "mary", null);
+
+        assertNodeTriggered(processInstance.getId(), "End");
+        assertProcessInstanceCompleted(processInstance.getId(), ksession);
+        
+        logs = JPAProcessInstanceDbLog.findProcessInstancesByBusinessKey("mybusinesskey");
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        
+        assertEquals(processInstance.getId(), logs.get(0).getProcessInstanceId());
+        assertEquals(org.jbpm.process.instance.ProcessInstance.STATE_COMPLETED, logs.get(0).getStatus());
+    }
+	
+	@Test
+    public void testProcessesWithSameBusinessKeyNotInParallel() {
+        StatefulKnowledgeSession ksession = createKnowledgeSession("humantask.bpmn");
+        TaskService taskService = getTaskService(ksession);
+        
+        ProcessInstance processInstance = ksession.startProcess("com.sample.bpmn.hello", "mybusinesskey", null);
+
+        assertProcessInstanceActive(processInstance.getId(), ksession);
+        assertNodeTriggered(processInstance.getId(), "Start", "Task 1");
+        
+        List<ProcessInstanceLog> logs = JPAProcessInstanceDbLog.findProcessInstancesByBusinessKey("mybusinesskey");
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        
+        assertEquals(processInstance.getId(), logs.get(0).getProcessInstanceId());       
+        
+        // let john execute Task 1
+        List<TaskSummary> list = taskService.getTasksAssignedAsPotentialOwner("john", "en-UK");
+        TaskSummary task = list.get(0);
+        System.out.println("John is executing task " + task.getName());
+        taskService.start(task.getId(), "john");
+        taskService.complete(task.getId(), "john", null);
+
+        assertNodeTriggered(processInstance.getId(), "Task 2");
+        
+        ProcessInstance processInstanceCopy = ksession.getProcessInstance("mybusinesskey");
+        assertNotNull(processInstanceCopy);
+        assertEquals(processInstance.getId(), processInstanceCopy.getId());
+        
+        // let mary execute Task 2
+        list = taskService.getTasksAssignedAsPotentialOwner("mary", "en-UK");
+        task = list.get(0);
+        System.out.println("Mary is executing task " + task.getName());
+        taskService.start(task.getId(), "mary");
+        taskService.complete(task.getId(), "mary", null);
+
+        assertNodeTriggered(processInstance.getId(), "End");
+        assertProcessInstanceCompleted(processInstance.getId(), ksession);
+        
+        logs = JPAProcessInstanceDbLog.findProcessInstancesByBusinessKey("mybusinesskey");
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        
+        assertEquals(processInstance.getId(), logs.get(0).getProcessInstanceId());
+        assertEquals(org.jbpm.process.instance.ProcessInstance.STATE_COMPLETED, logs.get(0).getStatus());
+        
+        processInstance = ksession.startProcess("com.sample.bpmn.hello", "mybusinesskey", null);
+
+        assertProcessInstanceActive(processInstance.getId(), ksession);
+        assertNodeTriggered(processInstance.getId(), "Start", "Task 1");
+        
+        logs = JPAProcessInstanceDbLog.findProcessInstancesByBusinessKey("mybusinesskey");
+        assertNotNull(logs);
+        assertEquals(2, logs.size());
+        
+        assertEquals(processInstance.getId(), logs.get(1).getProcessInstanceId());       
+        
+        // let john execute Task 1
+        list = taskService.getTasksAssignedAsPotentialOwner("john", "en-UK");
+        task = list.get(0);
+        System.out.println("John is executing task " + task.getName());
+        taskService.start(task.getId(), "john");
+        taskService.complete(task.getId(), "john", null);
+
+        assertNodeTriggered(processInstance.getId(), "Task 2");
+        
+        processInstanceCopy = ksession.getProcessInstance("mybusinesskey");
+        assertNotNull(processInstanceCopy);
+        assertEquals(processInstance.getId(), processInstanceCopy.getId());
+        
+        // let mary execute Task 2
+        list = taskService.getTasksAssignedAsPotentialOwner("mary", "en-UK");
+        task = list.get(0);
+        System.out.println("Mary is executing task " + task.getName());
+        taskService.start(task.getId(), "mary");
+        taskService.complete(task.getId(), "mary", null);
+
+        assertNodeTriggered(processInstance.getId(), "End");
+        assertProcessInstanceCompleted(processInstance.getId(), ksession);
+        
+        logs = JPAProcessInstanceDbLog.findProcessInstancesByBusinessKey("mybusinesskey");
+        assertNotNull(logs);
+        assertEquals(2, logs.size());
+        
+        assertEquals(processInstance.getId(), logs.get(1).getProcessInstanceId());
+        assertEquals(org.jbpm.process.instance.ProcessInstance.STATE_COMPLETED, logs.get(0).getStatus());
+    }
+}


### PR DESCRIPTION
...InstanceId
pull requests (3/3 as it goes through kie-api, drools-\* and jbpm-\* modules) that allows to assign user defined business key while starting process and then to get access to it using same business key, including bam data. Business key should be unique on runtime meaning only one instance can have given business key however bam method returns list for the same business key as there might be a need to have same business key used in different process engines, etc
