### PR TITLE
Make human task service work with OpenJPA

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/Attachment.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/Attachment.java
@@ -31,11 +31,10 @@ import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 
 @Entity
-@SequenceGenerator(name="attachmentIdSeq", sequenceName="ATTACHMENT_ID_SEQ", allocationSize=1)
 public class Attachment implements Externalizable {
     
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO, generator="attachmentIdSeq")
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private long   id;
 
     /**


### PR DESCRIPTION
I patched human-task-service-core to make it work with OpenJPA. I do not include the full patch here but I will if someone is interested.

This pull request only shows the first step I had to do: OpenJPA (JPA in generell?) does not allow to use AUTO generation type together with a custom sequence generator. I therefore removed the generator.

This seams to work well in OpenJPA and Hibernate.
