### PR TITLE
DROOLS-139: Infinispan based Drools and jBPM persistence

### DIFF
--- a/jbpm-persistence-infinispan/pom.xml
+++ b/jbpm-persistence-infinispan/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jbpm</groupId>
+    <artifactId>jbpm</artifactId>
+    <version>6.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jbpm-persistence-infinispan</artifactId>
+
+  <name>jBPM :: Infinispan Persistence</name>
+  <description>jBPM Infinispan Persistence</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-flow-builder</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-persistence-infinispan</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-persistence-jpa</artifactId>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.btm</groupId>
+      <artifactId>btm</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-persistence-infinispan</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-persistence-jpa</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-core</artifactId>
+      <version>3.6.2</version><!-- TODO see how to connect -->
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>false</filtering>
+      </testResource>
+      <testResource>
+        <directory>src/test/filtered-resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+
+    <plugins>
+      <plugin>
+        <!--  ensure that db files are deleted before _any_ run 
+              otherwise we get tests failing because of leftover db's -->
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${basedir}</directory>
+              <includes>
+                <include>btm*</include>
+              </includes>
+            </fileset>
+            <fileset><directory>org.drools.persistence.info.EntityHolder</directory></fileset>
+            <fileset><directory>org.jbpm.persistence.processinstance.objects.NonSerializableClass</directory></fileset>
+            <fileset><directory>org.jbpm.persistence.session.objects.MyEntity</directory></fileset>
+            <fileset><directory>org.jbpm.persistence.session.objects.MyEntityMethods</directory></fileset>
+            <fileset><directory>org.jbpm.persistence.session.objects.MyEntityOnlyFields</directory></fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/InfinispanProcessPersistenceContext.java
+++ b/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/InfinispanProcessPersistenceContext.java
@@ -1,0 +1,142 @@
+package org.jbpm.persistence;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.persistence.infinispan.InfinispanPersistenceContext;
+import org.infinispan.Cache;
+import org.jbpm.persistence.correlation.CorrelationKeyInfo;
+import org.jbpm.persistence.processinstance.ProcessEntityHolder;
+import org.jbpm.persistence.processinstance.ProcessInstanceInfo;
+import org.kie.internal.process.CorrelationKey;
+
+public class InfinispanProcessPersistenceContext extends InfinispanPersistenceContext
+    implements
+    ProcessPersistenceContext {
+
+	private static long PROCESSINSTANCEINFO_KEY = 1;
+	private static long CORRELATIONKEYINFO_KEY = 1;
+	private static final Object keyObject = new Object();
+
+    public InfinispanProcessPersistenceContext(Cache<String, Object> cache ) {
+        super( cache );
+    }
+
+    public void persist(ProcessInstanceInfo processInstanceInfo) {
+    	String id = generateProcessInstanceInfoId(processInstanceInfo);
+        getCache().put( id, new ProcessEntityHolder(id, processInstanceInfo) );
+    }
+
+    public ProcessInstanceInfo findProcessInstanceInfo(Long processInstanceId) {
+    	String key = inferProcessInstanceInfoId(processInstanceId);
+        ProcessEntityHolder holder = (ProcessEntityHolder) getCache().get( key );
+        if (holder == null) {
+        	return null;
+        }
+		return holder.getProcessInstanceInfo();
+    }
+
+	public void remove(ProcessInstanceInfo processInstanceInfo) {
+        getCache().remove( generateProcessInstanceInfoId(processInstanceInfo) );
+        getCache().evict( generateProcessInstanceInfoId(processInstanceInfo) );
+        List<CorrelationKeyInfo> correlations = getCorrelationKeysByProcessInstanceId(processInstanceInfo.getId());
+        if (correlations != null) {
+            for (CorrelationKeyInfo key : correlations) {
+                getCache().remove(generateCorrelationKeyInfoId(key));
+            }
+        }
+    }
+
+    private String generateCorrelationKeyInfoId(CorrelationKeyInfo info) {
+    	if (info != null && info.getId() <= 0) {
+    		synchronized (keyObject) {
+    			while (getCache().containsKey("correlationInfo" + CORRELATIONKEYINFO_KEY)) {
+    				CORRELATIONKEYINFO_KEY++;
+    			}
+    		}
+    		try {
+	    		java.lang.reflect.Field idField = CorrelationKeyInfo.class.getField("id");
+	    		idField.setAccessible(true);
+	    		idField.set(info, CORRELATIONKEYINFO_KEY);
+    		} catch (Exception e) {
+    			//TODO
+    		}
+    	}
+    	return "correlationInfo" + info.getId();
+	}
+
+    private String generateProcessInstanceInfoId(ProcessInstanceInfo info) {
+    	if (info != null && (info.getId() == null || info.getId() <= 0)) {
+    		synchronized (keyObject) {
+    			while (getCache().containsKey(inferProcessInstanceInfoId(PROCESSINSTANCEINFO_KEY))) {
+    				PROCESSINSTANCEINFO_KEY++;
+    			}
+    		}
+			info.setId(PROCESSINSTANCEINFO_KEY);
+    	}
+    	return inferProcessInstanceInfoId(info.getId());
+	}
+
+    private String inferProcessInstanceInfoId(Long processInstanceId) {
+		return "processInstanceInfo" + processInstanceId;
+	}
+
+	private List<CorrelationKeyInfo> getCorrelationKeysByProcessInstanceId(Long pId) {
+		Cache<String, Object> cache = getCache();
+		List<CorrelationKeyInfo> retval = new ArrayList<CorrelationKeyInfo>();
+		for (String key : cache.keySet()) {
+			if (key.startsWith("correlationInfo")) {
+				ProcessEntityHolder holder = (ProcessEntityHolder) cache.get(key);
+				if (pId.equals(holder.getProcessInstanceId())) {
+					retval.add(holder.getCorrelationKeyInfo());
+				}
+			}
+		}
+		return retval;
+	}
+
+    public List<Long> getProcessInstancesWaitingForEvent(String type) {
+    	Cache<String, Object> cache = getCache();
+    	List<Long> retval = new ArrayList<Long>();
+    	for (String key : cache.keySet()) {
+    		if (key.startsWith("processInstanceInfo")) {
+    			ProcessEntityHolder holder = (ProcessEntityHolder) cache.get(key);
+    			if (holder != null && holder.getProcessInstanceEventTypes() != null) {
+    				if (holder.getProcessInstanceEventTypes().contains(type)) {
+    					retval.add(holder.getProcessInstanceId());
+    				}
+    			}
+    		}
+    	}
+		return retval;
+    }
+
+    @Override
+    public void persist(CorrelationKeyInfo correlationKeyInfo) {
+        Long processInstanceId = getProcessInstanceByCorrelationKey(correlationKeyInfo);
+        if (processInstanceId != null) {
+            throw new RuntimeException(correlationKeyInfo + " already exists");
+        }
+    	String id = generateCorrelationKeyInfoId(correlationKeyInfo);
+        getCache().put( id, new ProcessEntityHolder(id, correlationKeyInfo) );
+    }
+
+    @Override
+    public Long getProcessInstanceByCorrelationKey(CorrelationKey correlationKey) {
+    	String propertiesString = ProcessEntityHolder.generateString(correlationKey.getProperties());
+    	Cache<String, Object> cache = getCache();
+    	List<Long> retval = new ArrayList<Long>();
+    	for (String key : cache.keySet()) {
+    		if (key.startsWith("correlationInfo")) {
+    			ProcessEntityHolder holder = (ProcessEntityHolder) cache.get(key);
+    			if (holder.getCorrelationKeyId() == correlationKey.getProperties().size()) {
+    				if (holder.getCorrelationKeyProperties().contains(propertiesString)) {
+    					retval.add(holder.getProcessInstanceId());
+    				}
+    			}
+    		}
+    	}
+    	return (retval.size() == 1) ? retval.iterator().next() : null;
+    }
+    
+}

--- a/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/InfinispanProcessPersistenceContextManager.java
+++ b/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/InfinispanProcessPersistenceContextManager.java
@@ -1,0 +1,18 @@
+package org.jbpm.persistence;
+
+import org.drools.persistence.infinispan.InfinispanPersistenceContextManager;
+import org.kie.api.runtime.Environment;
+
+public class InfinispanProcessPersistenceContextManager extends InfinispanPersistenceContextManager
+    implements
+    ProcessPersistenceContextManager {
+
+    public InfinispanProcessPersistenceContextManager(Environment env) {
+        super( env );
+    }
+
+    public ProcessPersistenceContext getProcessPersistenceContext() {
+        return new InfinispanProcessPersistenceContext( cmdScopedCache );
+    }
+
+}

--- a/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/ManualPersistProcessInterceptor.java
+++ b/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/ManualPersistProcessInterceptor.java
@@ -1,0 +1,100 @@
+package org.jbpm.persistence;
+
+import java.util.Collection;
+
+import org.drools.core.command.CommandService;
+import org.drools.core.command.impl.AbstractInterceptor;
+import org.drools.core.command.impl.GenericCommand;
+import org.drools.core.command.runtime.process.CompleteWorkItemCommand;
+import org.drools.core.command.runtime.process.CreateProcessInstanceCommand;
+import org.drools.core.command.runtime.process.SignalEventCommand;
+import org.drools.core.command.runtime.process.StartProcessCommand;
+import org.drools.core.command.runtime.process.StartProcessInstanceCommand;
+import org.drools.core.command.runtime.rule.FireAllRulesCommand;
+import org.drools.persistence.SingleSessionCommandService;
+import org.jbpm.persistence.processinstance.ProcessInstanceInfo;
+import org.jbpm.process.instance.ProcessInstance;
+import org.kie.api.command.Command;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.command.Context;
+
+public class ManualPersistProcessInterceptor extends AbstractInterceptor {
+
+	private final SingleSessionCommandService interceptedService;
+
+	public ManualPersistProcessInterceptor(SingleSessionCommandService interceptedService) {
+		this.interceptedService = interceptedService;
+	}
+
+	@Override
+	public <T> T execute(Command<T> command) {
+		RuntimeException error = null;
+		T result = null;
+		try {
+			result = executeNext(command);
+		} catch (RuntimeException e) {
+			//still try to save
+			error = e;
+		}
+		try {
+			java.lang.reflect.Field jpmField = SingleSessionCommandService.class.getDeclaredField("jpm");
+	    	jpmField.setAccessible(true);
+	    	Object jpm = jpmField.get(interceptedService);
+	    	java.lang.reflect.Field ksessionField = SingleSessionCommandService.class.getDeclaredField("ksession");
+	    	ksessionField.setAccessible(true);
+	    	Object ksession = ksessionField.get(interceptedService);
+	    	if (error == null && isValidCommand(command)) {
+	    		executeNext(new PersistProcessCommand(jpm, ksession));
+	    	}
+		} catch (Exception e) {
+			throw new RuntimeException("Couldn't force persistence of process instance info", e);
+		}
+		if (error != null) {
+			throw error;
+		}
+		return result;
+	}
+	
+	protected boolean isValidCommand(Command<?> command) {
+		return (command instanceof StartProcessCommand) ||
+			   (command instanceof CreateProcessInstanceCommand) ||
+			   (command instanceof StartProcessInstanceCommand) ||
+			   (command instanceof SignalEventCommand) ||
+			   (command instanceof CompleteWorkItemCommand) ||
+			   (command instanceof FireAllRulesCommand);
+	}
+	
+	public static class PersistProcessCommand implements GenericCommand<Void> {
+		
+		private final ProcessPersistenceContext persistenceContext;
+		private final KieSession ksession;
+		
+		public PersistProcessCommand(Object jpm, Object ksession) {
+			this.persistenceContext = ((ProcessPersistenceContextManager) jpm).getProcessPersistenceContext();
+			this.ksession = (KieSession) ksession;
+		}
+		
+		@Override
+		public Void execute(Context context) {
+			Collection<?> processInstances = ksession.getProcessInstances();
+			for (Object obj : processInstances) {
+				ProcessInstance instance = (ProcessInstance) obj;
+				boolean notCompeted = instance.getState() != ProcessInstance.STATE_COMPLETED;
+				boolean notAborted = instance.getState() != ProcessInstance.STATE_ABORTED;
+				boolean hasId = instance.getId() > 0;
+				if (hasId && notCompeted && notAborted) {
+					ProcessInstanceInfo info = new ProcessInstanceInfo(instance, ksession.getEnvironment());
+					info.setId(instance.getId());
+					info.update();
+					persistenceContext.persist(info);
+				}
+			}
+			return null;
+		}
+	}
+
+	public CommandService getInterceptedService() {
+		return interceptedService;
+	}
+
+}

--- a/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/processinstance/InfinispanProcessInstanceManager.java
+++ b/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/processinstance/InfinispanProcessInstanceManager.java
@@ -1,0 +1,207 @@
+package org.jbpm.persistence.processinstance;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.drools.core.common.InternalKnowledgeRuntime;
+import org.jbpm.persistence.ProcessPersistenceContext;
+import org.jbpm.persistence.ProcessPersistenceContextManager;
+import org.jbpm.persistence.correlation.CorrelationKeyInfo;
+import org.jbpm.process.instance.InternalProcessRuntime;
+import org.jbpm.process.instance.ProcessInstanceManager;
+import org.jbpm.process.instance.impl.ProcessInstanceImpl;
+import org.jbpm.process.instance.timer.TimerManager;
+import org.jbpm.workflow.instance.node.StateBasedNodeInstance;
+import org.jbpm.workflow.instance.node.TimerNodeInstance;
+import org.kie.api.definition.process.Process;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.api.runtime.process.WorkflowProcessInstance;
+import org.kie.internal.process.CorrelationKey;
+import org.kie.internal.runtime.manager.InternalRuntimeManager;
+import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
+
+/**
+ * This is an implementation of the {@link ProcessInstanceManager} that uses Infinispan.
+ * </p>
+ * What's important to remember here is that we have a jbpm-console which has 1 static (stateful) knowledge session
+ * which is used by multiple threads: each request sent to the jbpm-console is picked up in it's own thread. 
+ * </p>
+ * This means that multiple threads can be using the same instance of this class. 
+ */
+public class InfinispanProcessInstanceManager
+    implements
+    ProcessInstanceManager {
+
+    private InternalKnowledgeRuntime kruntime;
+    // In a scenario in which 1000's of processes are running daily,
+    //   lazy initialization is more costly than eager initialization
+    private transient Map<Long, ProcessInstance> processInstances = new ConcurrentHashMap<Long, ProcessInstance>();
+
+    
+    public void setKnowledgeRuntime(InternalKnowledgeRuntime kruntime) {
+        this.kruntime = kruntime;
+    }
+
+    public void addProcessInstance(ProcessInstance processInstance, CorrelationKey correlationKey) {
+        ProcessInstanceInfo processInstanceInfo = new ProcessInstanceInfo( processInstance, this.kruntime.getEnvironment() );
+        ProcessPersistenceContext context 
+            = ((ProcessPersistenceContextManager) this.kruntime.getEnvironment()
+                    .get( EnvironmentName.PERSISTENCE_CONTEXT_MANAGER ))
+                    .getProcessPersistenceContext();
+        context.persist( processInstanceInfo );
+        
+        ((org.jbpm.process.instance.ProcessInstance) processInstance).setId( processInstanceInfo.getId() );
+        processInstanceInfo.updateLastReadDate();
+        // persist correlation if exists
+        if (correlationKey != null) {
+            CorrelationKeyInfo correlationKeyInfo = (CorrelationKeyInfo) correlationKey;
+            correlationKeyInfo.setProcessInstanceId(processInstanceInfo.getId());
+            context.persist(correlationKeyInfo);
+        }
+        internalAddProcessInstance(processInstance);
+    }
+    
+    public void internalAddProcessInstance(ProcessInstance processInstance) {
+        if( ((ConcurrentHashMap<Long, ProcessInstance>) processInstances)
+                .putIfAbsent(processInstance.getId(), processInstance) 
+                != null ) { 
+            throw new ConcurrentModificationException(
+                    "Duplicate process instance [" + processInstance.getProcessId() + "/" + processInstance.getId() + "]"
+                    + " added to process instance manager." );
+        }
+    }
+
+    public ProcessInstance getProcessInstance(long id) {
+        return getProcessInstance(id, false);
+    }
+
+    public ProcessInstance getProcessInstance(long id, boolean readOnly) {
+        InternalRuntimeManager manager = (InternalRuntimeManager) kruntime.getEnvironment().get("RuntimeManager");
+        if (manager != null) {
+            manager.validate((KieSession) kruntime, ProcessInstanceIdContext.get(id));
+        }
+    	ProcessPersistenceContextManager ppcm 
+	    = (ProcessPersistenceContextManager) this.kruntime.getEnvironment().get( EnvironmentName.PERSISTENCE_CONTEXT_MANAGER );
+    		ppcm.beginCommandScopedEntityManager();
+	
+    	ProcessPersistenceContext context = ppcm.getProcessPersistenceContext();
+    	
+        org.jbpm.process.instance.ProcessInstance processInstance = null;
+        processInstance = (org.jbpm.process.instance.ProcessInstance) this.processInstances.get(id);
+        if (processInstance != null) {
+        	if (processInstance.getKnowledgeRuntime() == null) {
+        		processInstance.setKnowledgeRuntime( kruntime );
+        		((ProcessInstanceImpl) processInstance).reconnect();
+        	} 
+        	/*if (processInstance.getParentProcessInstanceId() > 0) {
+        		context.persist(new ProcessInstanceInfo(processInstance, this.kruntime.getEnvironment()));
+        	}*/
+            return processInstance;
+        }
+
+    	// Make sure that the cmd scoped entity manager has started
+        ProcessInstanceInfo processInstanceInfo = context.findProcessInstanceInfo( id );
+        if ( processInstanceInfo == null ) {
+            return null;
+        }
+        if (!readOnly) {
+        	processInstanceInfo.updateLastReadDate();
+        }
+        processInstance = (org.jbpm.process.instance.ProcessInstance)
+        	processInstanceInfo.getProcessInstance(kruntime, this.kruntime.getEnvironment(), readOnly);
+        processInstance.setId(processInstanceInfo.getId());
+        if (((ProcessInstanceImpl) processInstance).getProcessXml() == null) {
+	        Process process = kruntime.getKieBase().getProcess( processInstance.getProcessId() );
+	        if ( process == null ) {
+	            throw new IllegalArgumentException( "Could not find process " + processInstance.getProcessId() );
+	        }
+	        processInstance.setProcess( process );
+        }
+        if ( processInstance.getKnowledgeRuntime() == null ) {
+            Long parentProcessInstanceId = (Long) ((ProcessInstanceImpl) processInstance).getMetaData().get("ParentProcessInstanceId");
+            if (parentProcessInstanceId != null) {
+                kruntime.getProcessInstance(parentProcessInstanceId);
+            }
+            processInstance.setKnowledgeRuntime( kruntime );
+            ((ProcessInstanceImpl) processInstance).reconnect();
+        }
+        //((ConcurrentHashMap<Long, ProcessInstance>) this.processInstances).putIfAbsent(processInstance.getId(), processInstance);
+        return processInstance;
+    }
+
+    public Collection<ProcessInstance> getProcessInstances() {
+        return Collections.unmodifiableCollection(processInstances.values());
+    }
+
+    public void removeProcessInstance(ProcessInstance processInstance) {
+        ProcessPersistenceContext context = ((ProcessPersistenceContextManager) 
+        		this.kruntime.getEnvironment().get( EnvironmentName.PERSISTENCE_CONTEXT_MANAGER )).
+        		getProcessPersistenceContext();
+        ProcessInstanceInfo processInstanceInfo = context.findProcessInstanceInfo( processInstance.getId() );
+        
+        if ( processInstanceInfo != null ) {
+            context.remove( processInstanceInfo );
+        }
+        internalRemoveProcessInstance(processInstance);
+    }
+
+    public void internalRemoveProcessInstance(ProcessInstance processInstance) {
+    	processInstances.remove( processInstance.getId() );
+    }
+    
+    public void clearProcessInstances() {
+    	for (ProcessInstance processInstance: new ArrayList<ProcessInstance>(processInstances.values())) {
+            ((ProcessInstanceImpl) processInstance).disconnect();
+        }
+    }
+
+    public void clearProcessInstancesState() {
+        try {
+            // at this point only timers are considered as state that needs to be cleared
+            TimerManager timerManager = ((InternalProcessRuntime)kruntime.getProcessRuntime()).getTimerManager();
+            
+            for (ProcessInstance processInstance: new ArrayList<ProcessInstance>(getProcessInstances())) {
+                WorkflowProcessInstance pi = ((WorkflowProcessInstance) processInstance);
+                
+                for (org.kie.api.runtime.process.NodeInstance nodeInstance : pi.getNodeInstances()) {
+                    if (nodeInstance instanceof TimerNodeInstance){
+                        if (((TimerNodeInstance)nodeInstance).getTimerInstance() != null) {
+                            timerManager.cancelTimer(((TimerNodeInstance)nodeInstance).getTimerInstance().getId());
+                        }
+                    } else if (nodeInstance instanceof StateBasedNodeInstance) {
+                        List<Long> timerIds = ((StateBasedNodeInstance) nodeInstance).getTimerInstances();
+                        if (timerIds != null) {
+                            for (Long id: timerIds) {
+                                timerManager.cancelTimer(id);
+                            }
+                        }
+                    }
+                }
+                
+            }
+        } catch (Exception e) {
+            // catch everything here to make sure it will not break any following 
+            // logic to allow complete clean up 
+        }
+    }
+
+    @Override
+    public ProcessInstance getProcessInstance(CorrelationKey correlationKey) {
+        ProcessPersistenceContext context = ((ProcessPersistenceContextManager) this.kruntime.getEnvironment()
+                .get( EnvironmentName.PERSISTENCE_CONTEXT_MANAGER ))
+                .getProcessPersistenceContext();
+        Long processInstanceId = context.getProcessInstanceByCorrelationKey(correlationKey);
+        if (processInstanceId == null) {
+            return null;
+        }
+        return getProcessInstance(processInstanceId);
+    }
+
+}

--- a/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/processinstance/InfinispanProcessInstanceManagerFactory.java
+++ b/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/processinstance/InfinispanProcessInstanceManagerFactory.java
@@ -1,0 +1,15 @@
+package org.jbpm.persistence.processinstance;
+
+import org.drools.core.common.InternalKnowledgeRuntime;
+import org.jbpm.process.instance.ProcessInstanceManager;
+import org.jbpm.process.instance.ProcessInstanceManagerFactory;
+
+public class InfinispanProcessInstanceManagerFactory implements ProcessInstanceManagerFactory {
+
+	public ProcessInstanceManager createProcessInstanceManager(InternalKnowledgeRuntime kruntime) {
+		InfinispanProcessInstanceManager result = new InfinispanProcessInstanceManager();
+		result.setKnowledgeRuntime(kruntime);
+		return result;
+	}
+
+}

--- a/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/processinstance/InfinispanSignalManager.java
+++ b/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/processinstance/InfinispanSignalManager.java
@@ -1,0 +1,43 @@
+package org.jbpm.persistence.processinstance;
+
+import java.util.List;
+
+import org.drools.core.common.InternalKnowledgeRuntime;
+import org.jbpm.persistence.ProcessPersistenceContext;
+import org.jbpm.persistence.ProcessPersistenceContextManager;
+import org.jbpm.process.instance.event.DefaultSignalManager;
+import org.kie.api.runtime.EnvironmentName;
+
+public class InfinispanSignalManager extends DefaultSignalManager {
+
+    public InfinispanSignalManager(InternalKnowledgeRuntime kruntime) {
+        super(kruntime);
+    }
+    
+    public void signalEvent(String type,
+                            Object event) {
+        for ( long id : getProcessInstancesForEvent( type ) ) {
+            try {
+                getKnowledgeRuntime().getProcessInstance( id );
+            } catch (IllegalStateException e) {
+                // IllegalStateException can be thrown when using RuntimeManager
+                // and invalid ksession was used for given context
+            }
+        }
+        super.signalEvent( type,
+                           event );
+    }
+
+    private List<Long> getProcessInstancesForEvent(String type) {
+//        EntityManager em = (EntityManager) getKnowledgeRuntime().getEnvironment().get( EnvironmentName.CMD_SCOPED_ENTITY_MANAGER );
+//        Query processInstancesForEvent = em.createNamedQuery( "ProcessInstancesWaitingForEvent" );
+//        processInstancesForEvent.setFlushMode(FlushModeType.COMMIT);
+//        processInstancesForEvent.setParameter( "type",
+//                                               type );
+//        List<Long> list = (List<Long>) processInstancesForEvent.getResultList();
+//        return list;
+        ProcessPersistenceContext context = ((ProcessPersistenceContextManager) getKnowledgeRuntime().getEnvironment().get( EnvironmentName.PERSISTENCE_CONTEXT_MANAGER )).getProcessPersistenceContext();
+        return context.getProcessInstancesWaitingForEvent(type);
+    }
+
+}

--- a/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/processinstance/InfinispanSignalManagerFactory.java
+++ b/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/processinstance/InfinispanSignalManagerFactory.java
@@ -1,0 +1,13 @@
+package org.jbpm.persistence.processinstance;
+
+import org.drools.core.common.InternalKnowledgeRuntime;
+import org.jbpm.process.instance.event.SignalManager;
+import org.jbpm.process.instance.event.SignalManagerFactory;
+
+public class InfinispanSignalManagerFactory implements SignalManagerFactory {
+
+	public SignalManager createSignalManager(InternalKnowledgeRuntime kruntime) {
+		return new InfinispanSignalManager(kruntime);
+	}
+
+}

--- a/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/processinstance/ProcessEntityHolder.java
+++ b/jbpm-persistence-infinispan/src/main/java/org/jbpm/persistence/processinstance/ProcessEntityHolder.java
@@ -1,0 +1,263 @@
+package org.jbpm.persistence.processinstance;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.Entity;
+
+import org.drools.persistence.info.EntityHolder;
+import org.drools.persistence.info.SessionInfo;
+import org.drools.persistence.info.WorkItemInfo;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.infinispan.util.Base64;
+import org.jbpm.persistence.correlation.CorrelationKeyInfo;
+import org.jbpm.persistence.correlation.CorrelationPropertyInfo;
+import org.kie.internal.process.CorrelationProperty;
+
+@Entity
+@Indexed
+public class ProcessEntityHolder extends EntityHolder {
+
+	@Field
+	private String processInstanceEventTypes;
+	@Field
+	private Long processInstanceId;
+	@Field
+	private Date processInstanceLastModificationDate;
+	@Field
+	private Date processInstanceLastReadDate;
+	@Field
+	private String processId;
+	@Field
+	private String processInstanceByteArray;
+	@Field
+	private Date processInstanceStartDate;
+	@Field
+	private Integer processInstanceState;
+	@Field
+	private Integer processInstanceVersion;
+	@Field
+	private long correlationKeyId;
+	@Field
+	private String correlationKeyName;
+	@Field
+	private String correlationKeyProperties;
+
+	public ProcessEntityHolder(String key, SessionInfo sessionInfo) {
+		super(key, sessionInfo);
+	}
+
+	public ProcessEntityHolder(String key, WorkItemInfo workItemInfo) {
+		super(key, workItemInfo);
+	}
+	
+	public ProcessEntityHolder(String key, ProcessInstanceInfo processInstanceInfo) {
+		super(key, "processInstanceInfo");
+		this.processInstanceEventTypes = generateString(processInstanceInfo.getEventTypes());
+		this.processInstanceId = processInstanceInfo.getId();
+		this.processInstanceLastModificationDate = processInstanceInfo.getLastModificationDate();
+		this.processInstanceLastReadDate = processInstanceInfo.getLastReadDate();
+		this.processId = processInstanceInfo.getProcessId();
+		processInstanceInfo.update();
+		this.processInstanceByteArray = Base64.encodeBytes(processInstanceInfo.getProcessInstanceByteArray());
+		this.processInstanceStartDate = processInstanceInfo.getStartDate();
+		this.processInstanceState = processInstanceInfo.getState();
+		this.processInstanceVersion = processInstanceInfo.getVersion();
+	}
+	
+	public ProcessEntityHolder(String key, CorrelationKeyInfo correlationKeyInfo) {
+		super(key, "correlationInfo");
+		this.correlationKeyId = correlationKeyInfo.getId() == 0 ? correlationKeyInfo.getProperties().size() : correlationKeyInfo.getId();
+		this.correlationKeyName = correlationKeyInfo.getName();
+		this.processInstanceId = correlationKeyInfo.getProcessInstanceId();
+		this.correlationKeyProperties = generateString(correlationKeyInfo.getProperties());
+	}
+
+	private void set(Object obj, String fieldName, Object value) {
+		java.lang.reflect.Field field;
+		try {
+			field = obj.getClass().getDeclaredField(fieldName);
+			field.setAccessible(true);
+			field.set(obj, value);
+		} catch (Exception e) {
+			throw new RuntimeException("Cant set field " + fieldName, e);
+		}
+	}
+	
+	public ProcessInstanceInfo getProcessInstanceInfo() {
+		ProcessInstanceInfo info = new ProcessInstanceInfo();
+		info.setId(this.processInstanceId);
+		set(info, "lastModificationDate", this.processInstanceLastModificationDate);
+		set(info, "lastReadDate", this.processInstanceLastReadDate);
+		set(info, "processId", this.processId);
+		set(info, "processInstanceByteArray", Base64.decode(this.processInstanceByteArray));
+		set(info, "startDate", this.processInstanceStartDate);
+		set(info, "state", this.processInstanceState);
+		set(info, "version", this.processInstanceVersion);
+		set(info, "eventTypes", toSet(this.processInstanceEventTypes));
+		return info;
+	}
+	
+	public CorrelationKeyInfo getCorrelationKeyInfo() {
+		CorrelationKeyInfo info = new CorrelationKeyInfo();
+		info.setName(this.correlationKeyName);
+		info.setProcessInstanceId(this.processInstanceId);
+		List<CorrelationPropertyInfo> props = toProperties(this.correlationKeyProperties);
+		for (CorrelationPropertyInfo prop : props) {
+			info.addProperty(prop);
+		}
+		set(info, "id", this.correlationKeyId);
+		return info;
+	}
+
+	public static String generateString(List<CorrelationProperty<?>> properties) {
+		StringBuilder sb = new StringBuilder();
+		if (properties != null) {
+			for (Iterator<CorrelationProperty<?>> iter = properties.iterator(); iter.hasNext();) {
+				CorrelationProperty<?> cp = iter.next();
+				sb.append(cp.getName()).append("=").append(cp.getValue());
+				if (iter.hasNext()) {
+					sb.append(",");
+				}
+			}
+		}
+		return sb.toString();
+	}
+	
+	public static String generateString(Set<String> setOfStrings) {
+		StringBuilder sb = new StringBuilder();
+		if (setOfStrings != null) {
+			for (Iterator<String> iter = setOfStrings.iterator(); iter.hasNext(); ) {
+				sb.append(iter.next());
+				if (iter.hasNext()) {
+					sb.append(",");
+				}
+			}
+		}
+		return sb.toString();
+	}
+
+	public static Set<String> toSet(String setOfStringsString) {
+		if (setOfStringsString != null) {
+			String[] splitted = setOfStringsString.split(",");
+			return new HashSet<String>(Arrays.asList(splitted));
+		} else {
+			return new HashSet<String>();
+		}
+	}
+	
+	public static List<CorrelationPropertyInfo> toProperties(String properties) {
+		String[] props = properties.split(",");
+		List<CorrelationPropertyInfo> retval = new ArrayList<CorrelationPropertyInfo>(props.length);
+		for (String prop : props) {
+			String[] sub = prop.split("=");
+			String key = sub[0];
+			String value = sub[1];
+			retval.add(new CorrelationPropertyInfo(key, value));
+		}
+		return retval;
+	}
+
+	public String getProcessInstanceEventTypes() {
+		return processInstanceEventTypes;
+	}
+
+	public void setProcessInstanceEventTypes(String processInstanceEventTypes) {
+		this.processInstanceEventTypes = processInstanceEventTypes;
+	}
+
+	public Date getProcessInstanceLastModificationDate() {
+		return processInstanceLastModificationDate;
+	}
+
+	public void setProcessInstanceLastModificationDate(
+			Date processInstanceLastModificationDate) {
+		this.processInstanceLastModificationDate = processInstanceLastModificationDate;
+	}
+
+	public Date getProcessInstanceLastReadDate() {
+		return processInstanceLastReadDate;
+	}
+
+	public void setProcessInstanceLastReadDate(Date processInstanceLastReadDate) {
+		this.processInstanceLastReadDate = processInstanceLastReadDate;
+	}
+
+	public String getProcessId() {
+		return processId;
+	}
+
+	public void setProcessId(String processId) {
+		this.processId = processId;
+	}
+
+	public String getProcessInstanceByteArray() {
+		return processInstanceByteArray;
+	}
+
+	public void setProcessInstanceByteArray(String processInstanceByteArray) {
+		this.processInstanceByteArray = processInstanceByteArray;
+	}
+
+	public Date getProcessInstanceStartDate() {
+		return processInstanceStartDate;
+	}
+
+	public void setProcessInstanceStartDate(Date processInstanceStartDate) {
+		this.processInstanceStartDate = processInstanceStartDate;
+	}
+
+	public Integer getProcessInstanceState() {
+		return processInstanceState;
+	}
+
+	public void setProcessInstanceState(Integer processInstanceState) {
+		this.processInstanceState = processInstanceState;
+	}
+
+	public Integer getProcessInstanceVersion() {
+		return processInstanceVersion;
+	}
+
+	public void setProcessInstanceVersion(Integer processInstanceVersion) {
+		this.processInstanceVersion = processInstanceVersion;
+	}
+
+	public Long getProcessInstanceId() {
+		return processInstanceId;
+	}
+	
+	public void setProcessInstanceId(Long processInstanceId) {
+		this.processInstanceId = processInstanceId;
+	}
+
+	public long getCorrelationKeyId() {
+		return correlationKeyId;
+	}
+
+	public void setCorrelationKeyId(long correlationKeyId) {
+		this.correlationKeyId = correlationKeyId;
+	}
+
+	public String getCorrelationKeyName() {
+		return correlationKeyName;
+	}
+
+	public void setCorrelationKeyName(String correlationKeyName) {
+		this.correlationKeyName = correlationKeyName;
+	}
+
+	public String getCorrelationKeyProperties() {
+		return correlationKeyProperties;
+	}
+
+	public void setCorrelationKeyProperties(String correlationKeyProperties) {
+		this.correlationKeyProperties = correlationKeyProperties;
+	}
+}

--- a/jbpm-persistence-infinispan/src/test/filtered-resources/datasource.properties
+++ b/jbpm-persistence-infinispan/src/test/filtered-resources/datasource.properties
@@ -1,0 +1,11 @@
+
+allowLocalTransactions=true
+# JDBC/Database properties that are set in the maven pom
+#
+#   the below variable names (i.e. "${maven.datasource.classname}) are
+# automagically replaced with their values (defined in the pom.xml)
+# because of the fact that <filtering> is set to true in for the
+# src/test/resources directory in the pom.
+#
+makeBaseDb=false
+testMarshalling=true

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/correlation/CorrelationPersistenceTest.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/correlation/CorrelationPersistenceTest.java
@@ -1,0 +1,108 @@
+package org.jbpm.persistence.correlation;
+
+import static org.jbpm.persistence.util.PersistenceUtil.JBPM_PERSISTENCE_UNIT_NAME;
+import static org.jbpm.persistence.util.PersistenceUtil.cleanUp;
+import static org.jbpm.persistence.util.PersistenceUtil.setupWithPoolingDataSource;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.naming.InitialContext;
+import javax.transaction.UserTransaction;
+
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.jbpm.persistence.InfinispanProcessPersistenceContext;
+import org.jbpm.persistence.processinstance.ProcessEntityHolder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.internal.KieInternalServices;
+import org.kie.internal.process.CorrelationKeyFactory;
+
+public class CorrelationPersistenceTest {
+    
+    private HashMap<String, Object> context;
+    
+    @Before
+    public void before() throws Exception {
+        context = setupWithPoolingDataSource(JBPM_PERSISTENCE_UNIT_NAME, false);
+        CorrelationKeyFactory factory = KieInternalServices.Factory.get().newCorrelationKeyFactory();
+        // populate table with test data
+        DefaultCacheManager cm = (DefaultCacheManager) context.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
+        UserTransaction ut = InitialContext.doLookup("java:comp/UserTransaction");
+        ut.begin();
+        Cache <String, Object> cache = cm.getCache("jbpm-configured-cache");
+
+        cache.put("correlationInfo1", new ProcessEntityHolder("correlationInfo1", (CorrelationKeyInfo) factory.newCorrelationKey("test123")));
+
+        List<String> props = new ArrayList<String>();
+        props.add("test123");
+        props.add("123test");
+        cache.put("correlationInfo2", new ProcessEntityHolder("correlationInfo2", (CorrelationKeyInfo) factory.newCorrelationKey(props)));
+        
+        ut.commit();
+    }
+    
+    @After
+    public void after() {  
+        try {
+            DefaultCacheManager cm = (DefaultCacheManager) context.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
+            UserTransaction ut = InitialContext.doLookup("java:comp/UserTransaction");
+            ut.begin();
+            Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+            cache.clear();
+            ut.commit();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        cleanUp(context);
+    }
+
+    @Test
+    public void testCreateCorrelation() throws Exception {
+        DefaultCacheManager cm = (DefaultCacheManager) context.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
+        Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+        
+        CorrelationKeyInfo correlationKey = new CorrelationKeyInfo();
+        correlationKey.addProperty(new CorrelationPropertyInfo("", "test123"));
+        Long processInstance = new InfinispanProcessPersistenceContext(cache).getProcessInstanceByCorrelationKey(correlationKey);
+        
+        assertNotNull(processInstance);
+        assertEquals(correlationKey.getProcessInstanceId(), processInstance.longValue());
+    }
+    
+    @Test
+    public void testCreateCorrelationMultiValueDoesNotMatch() throws Exception {
+        DefaultCacheManager cm = (DefaultCacheManager) context.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
+        Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+
+        CorrelationKeyInfo correlationKey = new CorrelationKeyInfo();
+        correlationKey.addProperty(new CorrelationPropertyInfo("", "asdf"));
+        Long processInstance = new InfinispanProcessPersistenceContext(cache).getProcessInstanceByCorrelationKey(correlationKey);
+        
+        assertNull(processInstance);
+    }
+    
+    @Test
+    public void testCreateCorrelationMultiValueDoesMatch() throws Exception {
+        DefaultCacheManager cm = (DefaultCacheManager) context.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
+        Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+        
+        CorrelationKeyFactory factory = KieInternalServices.Factory.get().newCorrelationKeyFactory();
+        List<String> props = new ArrayList<String>();
+        props.add("test123");
+        props.add("123test");
+        CorrelationKeyInfo correlationKey = (CorrelationKeyInfo) factory.newCorrelationKey(props);
+
+        Long processInstance = new InfinispanProcessPersistenceContext(cache).getProcessInstanceByCorrelationKey(correlationKey);
+        
+        assertNotNull(processInstance);
+        assertEquals(correlationKey.getProcessInstanceId(), processInstance.longValue());
+    }
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/map/impl/InfinispanBasedPersistenceTest.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/map/impl/InfinispanBasedPersistenceTest.java
@@ -1,0 +1,100 @@
+package org.jbpm.persistence.map.impl;
+
+import static org.jbpm.persistence.util.PersistenceUtil.JBPM_PERSISTENCE_UNIT_NAME;
+import static org.jbpm.persistence.util.PersistenceUtil.cleanUp;
+import static org.jbpm.persistence.util.PersistenceUtil.createEnvironment;
+import static org.kie.api.runtime.EnvironmentName.ENTITY_MANAGER_FACTORY;
+
+import java.util.HashMap;
+import java.util.Set;
+
+import org.drools.persistence.jta.JtaTransactionManager;
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.jbpm.persistence.util.PersistenceUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+public class InfinispanBasedPersistenceTest extends MapPersistenceTest {
+
+    private HashMap<String, Object> context;
+    private DefaultCacheManager cm;
+    private JtaTransactionManager txm;
+    private boolean useTransactions = false;
+    
+    @Before
+    public void setUp() throws Exception {
+        context = PersistenceUtil.setupWithPoolingDataSource(JBPM_PERSISTENCE_UNIT_NAME);
+        cm = (DefaultCacheManager) context.get(ENTITY_MANAGER_FACTORY);
+        
+        useTransactions = false;
+        Environment env = createEnvironment(context);
+        Object tm = env.get( EnvironmentName.TRANSACTION_MANAGER );
+        this.txm = new JtaTransactionManager( env.get( EnvironmentName.TRANSACTION ),
+            env.get( EnvironmentName.TRANSACTION_SYNCHRONIZATION_REGISTRY ),
+            tm );
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+       cleanUp(context); 
+    }
+    
+    @Override
+    protected StatefulKnowledgeSession createSession(KnowledgeBase kbase) {
+        return InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, createEnvironment(context) );
+    }
+
+    @Override
+    protected StatefulKnowledgeSession disposeAndReloadSession(StatefulKnowledgeSession ksession, int ksessionId,
+                                                               KnowledgeBase kbase) {
+        ksession.dispose();
+        return InfinispanKnowledgeService.loadStatefulKnowledgeSession( ksessionId, kbase, null, createEnvironment(context) );
+    }
+
+    @Override
+    protected int getProcessInstancesCount() {
+    	boolean txOwner = false;
+        if( useTransactions ) { 
+            txOwner = txm.begin();
+        }
+        Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+        Set<String> keyset = cache.keySet();
+        int size = 0;
+        for (String key : keyset) {
+        	if (key.startsWith("processInstanceInfo")) {
+        		size++;
+        	}
+        }
+        if( useTransactions ) { 
+            txm.commit(txOwner);
+        }
+        return size;
+    }
+
+    @Override
+    protected int getKnowledgeSessionsCount() {
+    	boolean txOwner = false;
+        if( useTransactions ) { 
+            txOwner = txm.begin();
+        }
+        Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+        Set<String> keyset = cache.keySet();
+        int size = 0;
+        for (String key : keyset) {
+        	if (key.startsWith("sessionInfo")) {
+        		size++;
+        	}
+        }
+        if( useTransactions ) { 
+            txm.commit(txOwner);
+        }
+        return size;
+    }
+
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/processinstance/ParameterMappingTest.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/processinstance/ParameterMappingTest.java
@@ -1,0 +1,165 @@
+package org.jbpm.persistence.processinstance;
+
+import static org.jbpm.persistence.util.PersistenceUtil.JBPM_PERSISTENCE_UNIT_NAME;
+import static org.jbpm.persistence.util.PersistenceUtil.cleanUp;
+import static org.jbpm.persistence.util.PersistenceUtil.createEnvironment;
+import static org.jbpm.persistence.util.PersistenceUtil.setupWithPoolingDataSource;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jbpm.persistence.util.LoggingPrintStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.api.event.process.DefaultProcessEventListener;
+import org.kie.api.event.process.ProcessCompletedEvent;
+import org.kie.api.event.process.ProcessStartedEvent;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.kie.api.io.ResourceType;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.api.runtime.Environment;
+
+public class ParameterMappingTest {
+    
+    private HashMap<String, Object> context;
+    
+    private static final String PROCESS_ID = "org.jbpm.processinstance.subprocess";
+    private static final String SUBPROCESS_ID = "org.jbpm.processinstance.helloworld";
+    private StatefulKnowledgeSession ksession;
+    private ProcessListener listener;
+
+    // Want to see the System.out output? Set the debug level for console in log4j.xml to DEBUG.
+    static { 
+        System.setOut(new LoggingPrintStream(System.out));
+    }
+    
+    @Before
+    public void before() {
+        context = setupWithPoolingDataSource(JBPM_PERSISTENCE_UNIT_NAME, false);
+        Environment env = createEnvironment(context);
+
+        ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession(createKnowledgeBase(), null, env);
+        assertTrue("Valid KnowledgeSession could not be created.", ksession != null && ksession.getId() > 0);
+
+        listener = new ProcessListener();
+        ksession.addEventListener(listener);
+    }
+
+    private KnowledgeBase createKnowledgeBase() {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add(ResourceFactory.newClassPathResource("processinstance/Subprocess.rf"), ResourceType.DRF);
+        kbuilder.add(ResourceFactory.newClassPathResource("processinstance/HelloWorld.rf"), ResourceType.DRF);
+    
+        return kbuilder.newKnowledgeBase();
+    }
+
+    @After
+    public void after() {
+        if (ksession != null) {
+            ksession.dispose();
+        }
+        cleanUp(context);
+    }
+
+    //org.jbpm.processinstance.subprocess
+    @Test
+    public void testChangingVariableByScript() throws Exception {
+        Map<String, Object> mapping = new HashMap<String, Object>();
+        mapping.put("type", "script");
+        mapping.put("var", "value");
+
+        ksession.startProcess(PROCESS_ID, mapping);
+
+        assertTrue(listener.isProcessStarted(PROCESS_ID));
+        assertTrue(listener.isProcessStarted(SUBPROCESS_ID));
+        assertTrue(listener.isProcessCompleted(SUBPROCESS_ID));
+        assertTrue(listener.isProcessCompleted(PROCESS_ID));
+    }
+
+    @Test
+    public void testChangingVariableByEvent() throws Exception {
+        Map<String, Object> mapping = new HashMap<String, Object>();
+        mapping.put("type", "event");
+        mapping.put("var", "value");
+
+        ksession.startProcess(PROCESS_ID, mapping).getId();
+        ksession.signalEvent("pass", "new value");
+
+        assertTrue(listener.isProcessStarted(PROCESS_ID));
+        assertTrue(listener.isProcessStarted(SUBPROCESS_ID));
+        assertTrue(listener.isProcessCompleted(SUBPROCESS_ID));
+        assertTrue(listener.isProcessCompleted(PROCESS_ID));
+    }
+
+    @Test
+    public void testChangingVariableByEventSignalWithProcessId() throws Exception {
+        Map<String, Object> mapping = new HashMap<String, Object>();
+        mapping.put("type", "event");
+        mapping.put("var", "value");
+
+        long processId = ksession.startProcess(PROCESS_ID, mapping).getId();
+        ksession.signalEvent("pass", "new value", processId);
+
+        assertTrue(listener.isProcessStarted(PROCESS_ID));
+        assertTrue(listener.isProcessStarted(SUBPROCESS_ID));
+        assertTrue(listener.isProcessCompleted(SUBPROCESS_ID));
+        assertTrue(listener.isProcessCompleted(PROCESS_ID));
+    }
+
+    @Test
+    public void testNotChangingVariable() throws Exception {
+        Map<String, Object> mapping = new HashMap<String, Object>();
+        mapping.put("type", "default");
+        mapping.put("var", "value");
+
+        ksession.startProcess(PROCESS_ID, mapping);
+
+        assertTrue(listener.isProcessStarted(PROCESS_ID));
+        assertTrue(listener.isProcessStarted(SUBPROCESS_ID));
+        assertTrue(listener.isProcessCompleted(SUBPROCESS_ID));
+        assertTrue(listener.isProcessCompleted(PROCESS_ID));
+    }
+
+    @Test
+    public void testNotSettingVariable() throws Exception {
+        Map<String, Object> mapping = new HashMap<String, Object>();
+        mapping.put("type", "default");
+
+        ksession.startProcess(PROCESS_ID, mapping);
+
+        assertTrue(listener.isProcessStarted(PROCESS_ID));
+        assertTrue(listener.isProcessStarted(SUBPROCESS_ID));
+        assertTrue(listener.isProcessCompleted(SUBPROCESS_ID));
+        assertTrue(listener.isProcessCompleted(PROCESS_ID));
+    }
+
+    
+    public static class ProcessListener extends DefaultProcessEventListener {
+        private final List<String> processesStarted = new ArrayList<String>();
+        private final List<String> processesCompleted = new ArrayList<String>();
+
+        public void afterProcessStarted(ProcessStartedEvent event) {
+            processesStarted.add(event.getProcessInstance().getProcessId());
+        }
+
+        public void afterProcessCompleted(ProcessCompletedEvent event) {
+            processesCompleted.add(event.getProcessInstance().getProcessId());
+        }
+
+        public boolean isProcessStarted(String processId) {
+            return processesStarted.contains(processId);
+        }
+
+        public boolean isProcessCompleted(String processId) {
+            return processesCompleted.contains(processId);
+        }
+    }
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/processinstance/ProcessInstanceResolverStrategyTest.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/processinstance/ProcessInstanceResolverStrategyTest.java
@@ -1,0 +1,151 @@
+package org.jbpm.persistence.processinstance;
+
+import static org.jbpm.persistence.util.PersistenceUtil.JBPM_PERSISTENCE_UNIT_NAME;
+import static org.jbpm.persistence.util.PersistenceUtil.cleanUp;
+import static org.jbpm.persistence.util.PersistenceUtil.setupWithPoolingDataSource;
+import static org.kie.api.runtime.EnvironmentName.ENTITY_MANAGER_FACTORY;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.transaction.UserTransaction;
+
+import org.drools.core.io.impl.ClassPathResource;
+import org.drools.core.marshalling.impl.ClassObjectMarshallingStrategyAcceptor;
+import org.drools.core.marshalling.impl.SerializablePlaceholderResolverStrategy;
+import org.drools.persistence.infinispan.marshaller.InfinispanPlaceholderResolverStrategy;
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.jbpm.marshalling.impl.ProcessInstanceResolverStrategy;
+import org.jbpm.persistence.processinstance.objects.NonSerializableClass;
+import org.jbpm.persistence.util.PersistenceUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.api.io.ResourceType;
+import org.kie.api.marshalling.ObjectMarshallingStrategy;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.api.runtime.process.WorkflowProcessInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProcessInstanceResolverStrategyTest {
+
+    private static Logger logger = LoggerFactory.getLogger(ProcessInstanceResolverStrategyTest.class);
+    
+    private HashMap<String, Object> context;
+    private StatefulKnowledgeSession ksession;
+
+    private static final String RF_FILE = "SimpleProcess.rf";
+    private final static String PROCESS_ID = "org.jbpm.persistence.TestProcess";
+    private final static String VAR_NAME = "persistVar";
+   
+    @Before
+    public void before() { 
+        context = setupWithPoolingDataSource(JBPM_PERSISTENCE_UNIT_NAME, false);
+        
+        // load up the knowledge base
+        Environment env = PersistenceUtil.createEnvironment(context);
+        env.set(EnvironmentName.OBJECT_MARSHALLING_STRATEGIES, new ObjectMarshallingStrategy[] {
+                new ProcessInstanceResolverStrategy(),
+                new InfinispanPlaceholderResolverStrategy(env),
+                new SerializablePlaceholderResolverStrategy(ClassObjectMarshallingStrategyAcceptor.DEFAULT) }
+                );
+        KnowledgeBase kbase = loadKnowledgeBase();
+
+        // create session
+        ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession(kbase, null, env);
+        Assert.assertTrue("Valid KnowledgeSession could not be created.", ksession != null && ksession.getId() > 0);
+    }
+    
+    private KnowledgeBase loadKnowledgeBase() { 
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( new ClassPathResource( RF_FILE ), ResourceType.DRF );
+        KnowledgeBase kbase = kbuilder.newKnowledgeBase();
+        return kbase;
+    }
+    
+    
+    @After
+    public void after() {
+        if( ksession != null ) { 
+            ksession.dispose();
+        }
+        cleanUp(context);
+    }
+
+    @Test
+    public void testWithDatabaseAndStartProcess() throws Exception {
+        // Create variable
+        Map<String, Object> params = new HashMap<String, Object>();
+        NonSerializableClass processVar = new NonSerializableClass();
+        processVar.setString("1234567890");
+        params.put(VAR_NAME, processVar);
+        params.put("logger", logger);
+
+        // Persist variable
+        DefaultCacheManager cm = (DefaultCacheManager) context.get(ENTITY_MANAGER_FACTORY);
+        Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+        UserTransaction ut = (UserTransaction) cache.getAdvancedCache().getTransactionManager();
+        ut.begin();
+        processVar.setId("nonSerializable1");
+        cache.put("nonSerializable1", processVar);
+        ut.commit();
+
+        // Generate, insert, and start process
+        ProcessInstance processInstance = ksession.startProcess(PROCESS_ID, params);
+
+        // Test resuls
+        Assert.assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
+        processVar = (NonSerializableClass) ((WorkflowProcessInstance) processInstance).getVariable(VAR_NAME);
+        Assert.assertNotNull(processVar);
+    }
+
+    @Test
+    public void testWithDatabaseAndStartProcessInstance() throws Exception {
+        // Create variable
+        Map<String, Object> params = new HashMap<String, Object>();
+        NonSerializableClass processVar = new NonSerializableClass();
+        processVar.setString("1234567890");
+        params.put(VAR_NAME, processVar);
+    
+        // Persist variable
+        DefaultCacheManager cm = (DefaultCacheManager) context.get(ENTITY_MANAGER_FACTORY);
+        Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+        UserTransaction ut = (UserTransaction) cache.getAdvancedCache().getTransactionManager();
+        ut.begin();
+        processVar.setId("nonSerializable2");
+        cache.put("nonSerializable2", processVar);
+        ut.commit();
+    
+        // Create process,
+        ProcessInstance processInstance = ksession.createProcessInstance(PROCESS_ID, params);
+        long processInstanceId = processInstance.getId();
+        Assert.assertTrue(processInstanceId > 0);
+        Assert.assertEquals(ProcessInstance.STATE_PENDING, processInstance.getState());
+
+        // insert process,
+        ut.begin();
+        ksession.insert(processInstance);
+   
+        // and start process
+        ksession.startProcessInstance(processInstanceId);
+        ksession.fireAllRules();
+        ut.commit();
+    
+        // Test results
+        processInstance = ksession.getProcessInstance(processInstanceId);
+        Assert.assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
+        processVar = (NonSerializableClass) ((WorkflowProcessInstance) processInstance).getVariable(VAR_NAME);
+        Assert.assertNotNull(processVar);
+    }
+
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/processinstance/objects/NonSerializableClass.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/processinstance/objects/NonSerializableClass.java
@@ -1,0 +1,44 @@
+package org.jbpm.persistence.processinstance.objects;
+
+import java.util.Date;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
+@Entity
+@Indexed
+public class NonSerializableClass {
+    
+	@Id @DocumentId @Field
+	private String id;
+	@Field
+	private String someString;
+	@SuppressWarnings("unused")
+	@Field
+    private Date creationDate;
+
+	public NonSerializableClass() { 
+	    creationDate = new Date();
+	}
+	
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getSomeString() {
+		return someString;
+	}
+
+	public void setString(String someString) {
+		this.someString = someString;
+	}
+
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/GetProcessInstancesTest.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/GetProcessInstancesTest.java
@@ -1,0 +1,184 @@
+package org.jbpm.persistence.session;
+
+import static org.jbpm.persistence.util.PersistenceUtil.JBPM_PERSISTENCE_UNIT_NAME;
+import static org.jbpm.persistence.util.PersistenceUtil.cleanUp;
+import static org.jbpm.persistence.util.PersistenceUtil.createEnvironment;
+import static org.jbpm.persistence.util.PersistenceUtil.setupWithPoolingDataSource;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+
+import javax.naming.InitialContext;
+import javax.transaction.UserTransaction;
+
+import org.jbpm.persistence.processinstance.InfinispanProcessInstanceManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.kie.api.io.ResourceType;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.api.runtime.Environment;
+
+/**
+ * This test looks at the behavior of the  {@link InfinispanProcessInstanceManager} 
+ * with regards to created (but not started) process instances 
+ * and whether the process instances are available or not after creation.
+ */
+public class GetProcessInstancesTest {
+    
+    private HashMap<String, Object> context;
+    
+    private Environment env;
+    private KnowledgeBase kbase;
+    private int sessionId;
+
+    @Before
+    public void setUp() throws Exception {
+        context = setupWithPoolingDataSource(JBPM_PERSISTENCE_UNIT_NAME);
+        env = createEnvironment(context);
+
+        kbase = createBase();
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession(kbase, null, env);
+        sessionId = ksession.getId();
+        ksession.dispose();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        cleanUp(context);
+    }
+
+    @Test
+    public void getEmptyProcessInstances() throws Exception {
+        StatefulKnowledgeSession ksession = reloadKnowledgeSession();
+        assertEquals(0, ksession.getProcessInstances().size());
+        ksession.dispose();
+    }
+
+    @Test
+    public void create2ProcessInstances() throws Exception {
+        long[] processId = new long[2];
+
+        StatefulKnowledgeSession ksession = reloadKnowledgeSession();
+        processId[0] = ksession.createProcessInstance("org.jbpm.processinstance.helloworld", null).getId();
+        processId[1] = ksession.createProcessInstance("org.jbpm.processinstance.helloworld", null).getId();
+        ksession.dispose();
+
+        assertProcessInstancesExist(processId);
+    }
+
+    @Test
+    public void create2ProcessInstancesInsideTransaction() throws Exception {
+        long[] processId = new long[2];
+
+        UserTransaction ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        
+        StatefulKnowledgeSession ksession = reloadKnowledgeSession();
+        processId[0] = ksession.createProcessInstance("org.jbpm.processinstance.helloworld", null).getId();
+        processId[1] = ksession.createProcessInstance("org.jbpm.processinstance.helloworld", null).getId();
+        assertEquals(2, ksession.getProcessInstances().size());
+        
+        // process instance manager cache flushed on tx
+        ut.commit();
+        assertEquals(0, ksession.getProcessInstances().size());
+
+        ksession = reloadKnowledgeSession(ksession);
+        assertEquals(0, ksession.getProcessInstances().size());
+        ksession.dispose();
+        
+        assertProcessInstancesExist(processId);
+    }
+
+    @Test
+    public void noProcessInstancesLeftAfterRollback() throws Exception {
+        long[] notProcess = new long[2];
+
+        UserTransaction ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        
+        StatefulKnowledgeSession ksession = reloadKnowledgeSession();
+        notProcess[0] = ksession.createProcessInstance("org.jbpm.processinstance.helloworld", null).getId();
+        notProcess[1] = ksession.createProcessInstance("org.jbpm.processinstance.helloworld", null).getId();
+        assertEquals(2, ksession.getProcessInstances().size());
+        
+        ut.rollback();
+        // Validate that proc inst mgr cache is also flushed on rollback
+        assertEquals(0, ksession.getProcessInstances().size());
+
+        ksession = reloadKnowledgeSession(ksession);
+        assertEquals(0, ksession.getProcessInstances().size());
+        ksession.dispose();
+        
+        assertProcessInstancesNotExist(notProcess);
+    }
+
+    @Test
+    public void noProcessInstancesLeftWithPreTxKSessionAndRollback() throws Exception {
+        long[] notProcess = new long[4];
+
+        StatefulKnowledgeSession ksession = reloadKnowledgeSession();
+        
+        UserTransaction ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        
+        notProcess[0] = ksession.createProcessInstance("org.jbpm.processinstance.helloworld", null).getId();
+        notProcess[1] = ksession.createProcessInstance("org.jbpm.processinstance.helloworld", null).getId();
+        
+        ut.rollback();
+        // Validate that proc inst mgr cache is also flushed on rollback
+        assertEquals(0, ksession.getProcessInstances().size());
+
+        ksession = reloadKnowledgeSession(ksession);
+        assertEquals(0, ksession.getProcessInstances().size());
+        ksession.dispose();
+        
+        assertProcessInstancesNotExist(notProcess);
+    }
+
+   
+    /**
+     * Helper functions
+     */
+    
+    private void assertProcessInstancesExist(long[] processId) {
+        StatefulKnowledgeSession ksession = reloadKnowledgeSession();
+
+        for (long id : processId) {
+            assertNotNull("Process instance " + id + " should not exist!", ksession.getProcessInstance(id));
+        }
+    }
+
+    private void assertProcessInstancesNotExist(long[] processId) {
+        StatefulKnowledgeSession ksession = reloadKnowledgeSession();
+
+        for (long id : processId) {
+            assertNull(ksession.getProcessInstance(id));
+        }
+    }
+
+    private KnowledgeBase createBase() {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add(ResourceFactory.newClassPathResource("processinstance/HelloWorld.rf"), ResourceType.DRF);
+        assertFalse(kbuilder.getErrors().toString(), kbuilder.hasErrors());
+
+        return kbuilder.newKnowledgeBase();
+    }
+    
+    private StatefulKnowledgeSession reloadKnowledgeSession() {
+        return InfinispanKnowledgeService.loadStatefulKnowledgeSession(sessionId, kbase, null, env);
+    }
+
+    private StatefulKnowledgeSession reloadKnowledgeSession(StatefulKnowledgeSession ksession) {
+        ksession.dispose();
+        return reloadKnowledgeSession();
+    }
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/PersistentStatefulSessionTest.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/PersistentStatefulSessionTest.java
@@ -1,0 +1,662 @@
+package org.jbpm.persistence.session;
+
+import static org.jbpm.persistence.util.PersistenceUtil.JBPM_PERSISTENCE_UNIT_NAME;
+import static org.jbpm.persistence.util.PersistenceUtil.cleanUp;
+import static org.jbpm.persistence.util.PersistenceUtil.createEnvironment;
+import static org.jbpm.persistence.util.PersistenceUtil.setupWithPoolingDataSource;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.naming.InitialContext;
+import javax.transaction.UserTransaction;
+
+import org.drools.core.io.impl.ClassPathResource;
+import org.jbpm.persistence.session.objects.TestWorkItemHandler;
+import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderError;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.api.event.process.ProcessCompletedEvent;
+import org.kie.api.event.process.ProcessEvent;
+import org.kie.api.event.process.ProcessEventListener;
+import org.kie.api.event.process.ProcessNodeLeftEvent;
+import org.kie.api.event.process.ProcessNodeTriggeredEvent;
+import org.kie.api.event.process.ProcessStartedEvent;
+import org.kie.api.event.process.ProcessVariableChangedEvent;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.kie.api.io.ResourceType;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.api.runtime.process.WorkItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PersistentStatefulSessionTest {
+
+    private static Logger logger = LoggerFactory.getLogger(PersistentStatefulSessionTest.class);
+    
+    private HashMap<String, Object> context;
+    private Environment env;
+
+    @Rule
+    public TestName testName = new TestName();
+    
+    @Before
+    public void setUp() throws Exception {
+        String methodName = testName.getMethodName();
+        // Rules marshalling uses ObjectTypeNodes which screw up marshalling. 
+        if( "testLocalTransactionPerStatement".equals(methodName) 
+            || "testUserTransactions".equals(methodName) 
+            || "testPersistenceRuleSet".equals(methodName)
+            || "testSetFocus".equals(methodName)
+            // Constraints in ruleflows are rules as well (I'm guessing?), so OTN's again.. 
+            || "testPersistenceState".equals(methodName) ) { 
+            context = setupWithPoolingDataSource(JBPM_PERSISTENCE_UNIT_NAME, false);
+        }
+        else { 
+            context = setupWithPoolingDataSource(JBPM_PERSISTENCE_UNIT_NAME);
+        }
+        
+        env = createEnvironment(context);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        cleanUp(context);
+    }
+
+    private static String ruleString = ""
+        + "package org.drools.test\n"
+        + "global java.util.List list\n"
+        + "rule rule1\n"
+        + "when\n"
+        + "  Integer(intValue > 0)\n"
+        + "then\n"
+        + "  list.add( 1 );\n"
+        + "end\n"
+        + "\n";
+        
+    @Test
+    public void testLocalTransactionPerStatement() {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( ruleString.getBytes() ),
+                      ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        List<?> list = new ArrayList<Object>();
+
+        ksession.setGlobal( "list",
+                            list );
+
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.insert( 3 );
+
+        ksession.fireAllRules();
+
+        assertEquals( 3,
+                      list.size() );
+
+    }
+
+    @Test
+    public void testUserTransactions() throws Exception {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource(ruleString.getBytes()),
+                      ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        UserTransaction ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        ut.commit();
+
+        List<?> list = new ArrayList<Object>();
+
+        // insert and commit
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.setGlobal( "list",
+                            list );
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.fireAllRules();
+        ut.commit();
+
+        // insert and rollback
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.insert( 3 );
+        ut.rollback();
+
+        // check we rolled back the state changes from the 3rd insert
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();        
+        ksession.fireAllRules();
+        ut.commit();
+        assertEquals( 2,
+                      list.size() );
+
+        // insert and commit
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.insert( 3 );
+        ksession.insert( 4 );
+        ut.commit();
+
+        ksession.fireAllRules();
+        
+        assertEquals( 4, 
+        			  list.size() );
+
+        // rollback again, this is testing that we can do consecutive rollbacks and commits without issue
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.insert( 5 );
+        ksession.insert( 6 );
+        ut.rollback();
+
+        ksession.fireAllRules();
+
+        assertEquals( 4,
+                      list.size() );
+        
+        // now load the ksession
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( ksession.getId(), kbase, null, env );
+        
+        ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        ksession.insert( 7 );
+        ksession.insert( 8 );
+        ut.commit();
+
+        ksession.fireAllRules();
+
+        assertEquals( 6,
+                      list.size() );
+    }
+
+    @Test
+    public void testPersistenceWorkItems() {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( new ClassPathResource( "WorkItemsProcess.rf" ),
+                      ResourceType.DRF );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        int origNumObjects = ksession.getObjects().size();
+        int id = ksession.getId();
+        
+        ProcessInstance processInstance = ksession.startProcess( "org.drools.test.TestProcess" );
+        ksession.insert( "TestString" );
+        logger.debug( "Started process instance " + processInstance.getId() );
+
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(),
+                                                       null );
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(),
+                                                       null );
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(),
+                                                       null );
+
+        workItem = handler.getWorkItem();
+        assertNull( workItem );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertEquals( origNumObjects + 1,
+                      ksession.getObjects().size() );
+        for ( Object o : ksession.getObjects() ) {
+            logger.debug( o.toString() );
+        }
+        assertNull( processInstance );
+
+    }
+    
+    @Test
+    public void testPersistenceWorkItems2() throws Exception {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( new ClassPathResource( "WorkItemsProcess.rf" ), ResourceType.DRF );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        int id = ksession.getId();
+        
+        UserTransaction ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        
+        ProcessInstance processInstance = ksession.startProcess( "org.drools.test.TestProcess" );
+        ksession.insert( "TestString" );
+        logger.debug( "Started process instance " + processInstance.getId() );
+
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(),
+                                                       null );
+        
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ut.commit();
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(),
+                                                       null );
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(),
+                                                       null );
+
+        workItem = handler.getWorkItem();
+        assertNull( workItem );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertEquals( 1,
+                      ksession.getObjects().size() );
+        for ( Object o : ksession.getObjects() ) {
+            logger.debug( o.toString() );
+        }
+        assertNull( processInstance );
+
+    }
+    
+    @Test
+    public void testPersistenceWorkItems3() {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( new ClassPathResource( "WorkItemsProcess.rf" ),
+                      ResourceType.DRF );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        ksession.getWorkItemManager().registerWorkItemHandler("MyWork", new SystemOutWorkItemHandler());
+        ProcessInstance processInstance = ksession.startProcess( "org.drools.test.TestProcess" );
+        ksession.insert( "TestString" );
+        assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
+    }
+    
+    @Test
+    public void testPersistenceState() {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( new ClassPathResource( "StateProcess.rf" ), ResourceType.DRF );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        int id = ksession.getId();
+        
+        ProcessInstance processInstance = ksession.startProcess( "org.drools.test.TestProcess" );
+        logger.debug( "Started process instance " + processInstance.getId() );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ksession.insert(new ArrayList<Object>());
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNull( processInstance );
+    }
+    
+    @Test
+    public void testPersistenceRuleSet() {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( new ClassPathResource( "RuleSetProcess.rf" ),
+                      ResourceType.DRF );
+        kbuilder.add( new ClassPathResource( "RuleSetRules.drl" ),
+                      ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        int id = ksession.getId();
+        
+        ksession.insert(new ArrayList<Object>());
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ProcessInstance processInstance = ksession.startProcess( "org.drools.test.TestProcess" );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ksession.fireAllRules();
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNull( processInstance );
+    }
+    
+    @Test
+    public void testPersistenceEvents() {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( new ClassPathResource( "EventsProcess.rf" ),
+                      ResourceType.DRF );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        int id = ksession.getId();
+        
+        ProcessInstance processInstance = ksession.startProcess( "org.drools.test.TestProcess" );
+        logger.debug( "Started process instance " + processInstance.getId() );
+
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(), null );
+        
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession.signalEvent("MyEvent1", null, processInstance.getId());
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession.signalEvent("MyEvent2", null, processInstance.getId());
+        
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNull( processInstance );
+    }
+    
+    @Test
+    public void testProcessListener() {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( new ClassPathResource( "WorkItemsProcess.rf" ),
+                      ResourceType.DRF );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        final List<ProcessEvent> events = new ArrayList<ProcessEvent>();
+        ProcessEventListener listener = new ProcessEventListener() {
+            public void afterNodeLeft(ProcessNodeLeftEvent event) {
+                logger.debug("After node left: " + event.getNodeInstance().getNodeName());
+                events.add(event);              
+            }
+            public void afterNodeTriggered(ProcessNodeTriggeredEvent event) {
+                logger.debug("After node triggered: " + event.getNodeInstance().getNodeName());
+                events.add(event);              
+            }
+            public void afterProcessCompleted(ProcessCompletedEvent event) {
+                logger.debug("After process completed");
+                events.add(event);              
+            }
+            public void afterProcessStarted(ProcessStartedEvent event) {
+                logger.debug("After process started");
+                events.add(event);              
+            }
+            public void beforeNodeLeft(ProcessNodeLeftEvent event) {
+                logger.debug("Before node left: " + event.getNodeInstance().getNodeName());
+                events.add(event);              
+            }
+            public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {
+                logger.debug("Before node triggered: " + event.getNodeInstance().getNodeName());
+                events.add(event);              
+            }
+            public void beforeProcessCompleted(ProcessCompletedEvent event) {
+                logger.debug("Before process completed");
+                events.add(event);              
+            }
+            public void beforeProcessStarted(ProcessStartedEvent event) {
+                logger.debug("Before process started");
+                events.add(event);              
+            }
+            public void afterVariableChanged(ProcessVariableChangedEvent event) {
+                logger.debug("After Variable Changed");
+                events.add(event);  
+            }
+            public void beforeVariableChanged(ProcessVariableChangedEvent event) {
+                logger.debug("Before Variable Changed");
+                events.add(event); 
+            }
+        };
+        ksession.addEventListener(listener);
+        
+        ProcessInstance processInstance = ksession.startProcess( "org.drools.test.TestProcess" );
+        logger.debug( "Started process instance " + processInstance.getId() );
+        
+        assertEquals(12, events.size());
+        assertTrue(events.get(0) instanceof ProcessStartedEvent);
+        assertTrue(events.get(1) instanceof ProcessNodeTriggeredEvent);
+        assertTrue(events.get(2) instanceof ProcessNodeLeftEvent);
+        assertTrue(events.get(3) instanceof ProcessNodeTriggeredEvent);
+        assertTrue(events.get(4) instanceof ProcessNodeLeftEvent);
+        assertTrue(events.get(5) instanceof ProcessNodeTriggeredEvent);
+        assertTrue(events.get(6) instanceof ProcessNodeTriggeredEvent);
+        assertTrue(events.get(7) instanceof ProcessNodeLeftEvent);
+        assertTrue(events.get(8) instanceof ProcessNodeTriggeredEvent);
+        assertTrue(events.get(9) instanceof ProcessNodeLeftEvent);
+        assertTrue(events.get(10) instanceof ProcessNodeTriggeredEvent);
+        assertTrue(events.get(11) instanceof ProcessStartedEvent);
+        
+        ksession.removeEventListener(listener);
+        events.clear();
+        
+        processInstance = ksession.startProcess( "org.drools.test.TestProcess" );
+        logger.debug( "Started process instance " + processInstance.getId() );
+        
+        assertTrue(events.isEmpty());
+    }
+
+    @Test
+    public void testPersistenceSubProcess() {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( new ClassPathResource( "SuperProcess.rf" ),
+                      ResourceType.DRF );
+        kbuilder.add( new ClassPathResource( "SubProcess.rf" ),
+                      ResourceType.DRF );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        int id = ksession.getId();
+        
+        ProcessInstance processInstance = ksession.startProcess( "com.sample.SuperProcess" );
+        logger.debug( "Started process instance " + processInstance.getId() );
+
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(),
+                                                       null );
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(),
+                                                       null );
+
+        workItem = handler.getWorkItem();
+        assertNull( workItem );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNull( "Process did not complete.", processInstance );
+    }
+    
+    @Test
+    public void testPersistenceVariables() {
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( new ClassPathResource( "VariablesProcess.rf" ), ResourceType.DRF );
+        for (KnowledgeBuilderError error: kbuilder.getErrors()) {
+            logger.debug(error.toString());
+        }
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        int id = ksession.getId();
+
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("name", "John Doe");
+        ProcessInstance processInstance = ksession.startProcess( "org.drools.test.TestProcess", parameters );
+
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+        assertEquals( "John Doe", workItem.getParameter("name"));
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(), null );
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+        assertEquals( "John Doe", workItem.getParameter("text"));
+        
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNotNull( processInstance );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(), null );
+
+        workItem = handler.getWorkItem();
+        assertNull( workItem );
+
+        ksession = InfinispanKnowledgeService.loadStatefulKnowledgeSession( id, kbase, null, env );
+        processInstance = ksession.getProcessInstance( processInstance.getId() );
+        assertNull( processInstance );
+    }
+
+    @Test
+    public void testSetFocus() {
+        String str = "";
+        str += "package org.drools.test\n";
+        str += "global java.util.List list\n";
+        str += "rule rule1\n";
+        str += "agenda-group \"badfocus\"";
+        str += "when\n";
+        str += "  Integer(intValue > 0)\n";
+        str += "then\n";
+        str += "  list.add( 1 );\n";
+        str += "end\n";
+        str += "\n";
+
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newByteArrayResource( str.getBytes() ),
+                      ResourceType.DRL );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+
+        if ( kbuilder.hasErrors() ) {
+            fail( kbuilder.getErrors().toString() );
+        }
+
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        StatefulKnowledgeSession ksession = InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+        List<?> list = new ArrayList<Object>();
+
+        ksession.setGlobal( "list",
+                            list );
+
+        ksession.insert( 1 );
+        ksession.insert( 2 );
+        ksession.insert( 3 );
+        ksession.getAgenda().getAgendaGroup("badfocus").setFocus();
+
+        ksession.fireAllRules();
+
+        assertEquals( 3,
+                      list.size() );
+    }
+
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/SingleSessionCommandServiceTest.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/SingleSessionCommandServiceTest.java
@@ -1,0 +1,834 @@
+package org.jbpm.persistence.session;
+
+import static org.jbpm.persistence.util.PersistenceUtil.JBPM_PERSISTENCE_UNIT_NAME;
+import static org.jbpm.persistence.util.PersistenceUtil.cleanUp;
+import static org.jbpm.persistence.util.PersistenceUtil.createEnvironment;
+import static org.jbpm.persistence.util.PersistenceUtil.setupWithPoolingDataSource;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Properties;
+
+import javax.naming.InitialContext;
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+import org.apache.log4j.xml.DOMConfigurator;
+import org.drools.compiler.compiler.PackageBuilder;
+import org.drools.core.RuleBase;
+import org.drools.core.RuleBaseFactory;
+import org.drools.core.SessionConfiguration;
+import org.drools.core.TimerJobFactoryType;
+import org.drools.core.command.impl.CommandBasedStatefulKnowledgeSession;
+import org.drools.core.command.runtime.process.CompleteWorkItemCommand;
+import org.drools.core.command.runtime.process.GetProcessInstanceCommand;
+import org.drools.core.command.runtime.process.StartProcessCommand;
+import org.drools.core.definitions.impl.KnowledgePackageImp;
+import org.drools.core.process.core.Work;
+import org.drools.core.process.core.impl.WorkImpl;
+import org.drools.core.rule.Package;
+import org.drools.persistence.SingleSessionCommandService;
+import org.drools.persistence.infinispan.ManualPersistInterceptor;
+import org.drools.persistence.infinispan.processinstance.InfinispanWorkItemManagerFactory;
+import org.drools.persistence.jpa.JpaJDKTimerService;
+import org.drools.persistence.jta.JtaTransactionManager;
+import org.infinispan.manager.DefaultCacheManager;
+import org.jbpm.compiler.ProcessBuilderImpl;
+import org.jbpm.persistence.InfinispanProcessPersistenceContextManager;
+import org.jbpm.persistence.ManualPersistProcessInterceptor;
+import org.jbpm.persistence.processinstance.InfinispanProcessInstanceManagerFactory;
+import org.jbpm.persistence.processinstance.InfinispanSignalManagerFactory;
+import org.jbpm.persistence.session.objects.TestWorkItemHandler;
+import org.jbpm.process.core.timer.Timer;
+import org.jbpm.ruleflow.core.RuleFlowProcess;
+import org.jbpm.ruleflow.instance.RuleFlowProcessInstance;
+import org.jbpm.workflow.core.Node;
+import org.jbpm.workflow.core.impl.ConnectionImpl;
+import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
+import org.jbpm.workflow.core.node.ActionNode;
+import org.jbpm.workflow.core.node.EndNode;
+import org.jbpm.workflow.core.node.StartNode;
+import org.jbpm.workflow.core.node.SubProcessNode;
+import org.jbpm.workflow.core.node.TimerNode;
+import org.jbpm.workflow.core.node.WorkItemNode;
+import org.jbpm.workflow.instance.node.SubProcessNodeInstance;
+import org.junit.After;
+import org.junit.Test;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.conf.TimerJobFactoryOption;
+import org.kie.api.runtime.process.NodeInstance;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.definition.KnowledgePackage;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+
+public class SingleSessionCommandServiceTest {
+
+	private HashMap<String, Object> context;
+	private Environment env;
+    
+    static {
+		DOMConfigurator.configure(SingleSessionCommandServiceTest.class.getResource("/log4j.xml"));
+    }
+    
+    public void setUp() {
+        String testMethodName = Thread.currentThread().getStackTrace()[2].getMethodName();
+        if( testMethodName.startsWith("testPersistenceTimer") ) { 
+            context = setupWithPoolingDataSource(JBPM_PERSISTENCE_UNIT_NAME, false);
+        }
+        else { 
+            context = setupWithPoolingDataSource(JBPM_PERSISTENCE_UNIT_NAME);
+        }
+        env = createEnvironment(context);
+        env.set(EnvironmentName.PERSISTENCE_CONTEXT_MANAGER, new InfinispanProcessPersistenceContextManager(env));
+        env.set(EnvironmentName.TRANSACTION_MANAGER, 
+        		new JtaTransactionManager(env.get(EnvironmentName.TRANSACTION), 
+        				env.get(EnvironmentName.TRANSACTION_SYNCHRONIZATION_REGISTRY), 
+        				env.get(EnvironmentName.TRANSACTION_MANAGER)
+        		)
+        );
+        
+    }
+
+    @After
+    public void tearDown() {
+        cleanUp(context);
+    }
+
+    @Test
+    public void testPersistenceWorkItems() throws Exception {
+        setUp();
+        
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        Collection<KnowledgePackage> kpkgs = getProcessWorkItems();
+        kbase.addKnowledgePackages( kpkgs );
+
+        Properties properties = new Properties();
+        properties.setProperty( "drools.commandService",
+                                SingleSessionCommandService.class.getName() );
+        properties.setProperty( "drools.processInstanceManagerFactory",
+                                InfinispanProcessInstanceManagerFactory.class.getName() );
+        properties.setProperty( "drools.workItemManagerFactory",
+                                InfinispanWorkItemManagerFactory.class.getName() );
+        properties.setProperty( "drools.processSignalManagerFactory",
+                                InfinispanSignalManagerFactory.class.getName() );
+        properties.setProperty( "drools.timerService",
+                                JpaJDKTimerService.class.getName() );
+        SessionConfiguration config = new SessionConfiguration( properties );
+
+        SingleSessionCommandService service = createSingleSessionCommandService( kbase,
+                                                                               config,
+                                                                               env );
+        int sessionId = service.getSessionId();
+
+        StartProcessCommand startProcessCommand = new StartProcessCommand();
+        startProcessCommand.setProcessId( "org.drools.test.TestProcess" );
+        ProcessInstance processInstance = service.execute( startProcessCommand );
+        System.out.println( "Started process instance " + processInstance.getId() );
+
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        GetProcessInstanceCommand getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstance.getId() );
+        processInstance = service.execute( getProcessInstanceCommand );
+        assertNotNull( processInstance );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        CompleteWorkItemCommand completeWorkItemCommand = new CompleteWorkItemCommand();
+        completeWorkItemCommand.setWorkItemId( workItem.getId() );
+        service.execute( completeWorkItemCommand );
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstance.getId() );
+        processInstance = service.execute( getProcessInstanceCommand );
+        assertNotNull( processInstance );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        completeWorkItemCommand = new CompleteWorkItemCommand();
+        completeWorkItemCommand.setWorkItemId( workItem.getId() );
+        service.execute( completeWorkItemCommand );
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstance.getId() );
+        processInstance = service.execute( getProcessInstanceCommand );
+        assertNotNull( processInstance );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        completeWorkItemCommand = new CompleteWorkItemCommand();
+        completeWorkItemCommand.setWorkItemId( workItem.getId() );
+        service.execute( completeWorkItemCommand );
+
+        workItem = handler.getWorkItem();
+        assertNull( workItem );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstance.getId() );
+        processInstance = service.execute( getProcessInstanceCommand );
+        assertNull( processInstance );
+        service.dispose();
+    }
+    
+    @Test
+    public void testPersistenceWorkItemsUserTransaction() throws Exception {
+        setUp();
+        
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        Collection<KnowledgePackage> kpkgs = getProcessWorkItems();
+        kbase.addKnowledgePackages( kpkgs );
+
+        Properties properties = new Properties();
+        properties.setProperty( "drools.commandService",
+                                SingleSessionCommandService.class.getName() );
+        properties.setProperty( "drools.processInstanceManagerFactory",
+                                InfinispanProcessInstanceManagerFactory.class.getName() );
+        properties.setProperty( "drools.workItemManagerFactory",
+                                InfinispanWorkItemManagerFactory.class.getName() );
+        properties.setProperty( "drools.processSignalManagerFactory",
+                                InfinispanSignalManagerFactory.class.getName() );
+        properties.setProperty( "drools.timerService",
+                                JpaJDKTimerService.class.getName() );
+        SessionConfiguration config = new SessionConfiguration( properties );
+
+        SingleSessionCommandService service = createSingleSessionCommandService( kbase,
+                                                                               config,
+                                                                               env );
+        int sessionId = service.getSessionId();
+
+        UserTransaction ut = (UserTransaction) new InitialContext().lookup( "java:comp/UserTransaction" );
+        ut.begin();
+        StartProcessCommand startProcessCommand = new StartProcessCommand();
+        startProcessCommand.setProcessId( "org.drools.test.TestProcess" );
+        ProcessInstance processInstance = service.execute( startProcessCommand );
+        System.out.println( "Started process instance " + processInstance.getId() );
+        ut.commit();
+
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        ut.begin();
+        GetProcessInstanceCommand getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstance.getId() );
+        processInstance = service.execute( getProcessInstanceCommand );
+        assertNotNull( processInstance );
+        ut.commit();
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        ut.begin();
+        CompleteWorkItemCommand completeWorkItemCommand = new CompleteWorkItemCommand();
+        completeWorkItemCommand.setWorkItemId( workItem.getId() );
+        service.execute( completeWorkItemCommand );
+        ut.commit();
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        ut.begin();
+        getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstance.getId() );
+        processInstance = service.execute( getProcessInstanceCommand );
+        ut.commit();
+        assertNotNull( processInstance );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        ut.begin();
+        completeWorkItemCommand = new CompleteWorkItemCommand();
+        completeWorkItemCommand.setWorkItemId( workItem.getId() );
+        service.execute( completeWorkItemCommand );
+        ut.commit();
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        ut.begin();
+        getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstance.getId() );
+        processInstance = service.execute( getProcessInstanceCommand );
+        ut.commit();
+        assertNotNull( processInstance );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        ut.begin();
+        completeWorkItemCommand = new CompleteWorkItemCommand();
+        completeWorkItemCommand.setWorkItemId( workItem.getId() );
+        service.execute( completeWorkItemCommand );
+        ut.commit();
+
+        workItem = handler.getWorkItem();
+        assertNull( workItem );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        ut.begin();
+        getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstance.getId() );
+        processInstance = service.execute( getProcessInstanceCommand );
+        ut.commit();
+        assertNull( processInstance );
+        service.dispose();
+    }
+
+	private Collection<KnowledgePackage> getProcessWorkItems() {
+        RuleFlowProcess process = new RuleFlowProcess();
+        process.setId( "org.drools.test.TestProcess" );
+        process.setName( "TestProcess" );
+        process.setPackageName( "org.drools.test" );
+        StartNode start = new StartNode();
+        start.setId( 1 );
+        start.setName( "Start" );
+        process.addNode( start );
+        ActionNode actionNode = new ActionNode();
+        actionNode.setId( 2 );
+        actionNode.setName( "Action" );
+        DroolsConsequenceAction action = new DroolsConsequenceAction();
+        action.setDialect( "java" );
+        action.setConsequence( "System.out.println(\"Executed action\");" );
+        actionNode.setAction( action );
+        process.addNode( actionNode );
+        new ConnectionImpl( start,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            actionNode,
+                            Node.CONNECTION_DEFAULT_TYPE );
+        WorkItemNode workItemNode = new WorkItemNode();
+        workItemNode.setId( 3 );
+        workItemNode.setName( "WorkItem1" );
+        Work work = new WorkImpl();
+        work.setName( "MyWork" );
+        workItemNode.setWork( work );
+        process.addNode( workItemNode );
+        new ConnectionImpl( actionNode,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            workItemNode,
+                            Node.CONNECTION_DEFAULT_TYPE );
+        WorkItemNode workItemNode2 = new WorkItemNode();
+        workItemNode2.setId( 4 );
+        workItemNode2.setName( "WorkItem2" );
+        work = new WorkImpl();
+        work.setName( "MyWork" );
+        workItemNode2.setWork( work );
+        process.addNode( workItemNode2 );
+        new ConnectionImpl( workItemNode,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            workItemNode2,
+                            Node.CONNECTION_DEFAULT_TYPE );
+        WorkItemNode workItemNode3 = new WorkItemNode();
+        workItemNode3.setId( 5 );
+        workItemNode3.setName( "WorkItem3" );
+        work = new WorkImpl();
+        work.setName( "MyWork" );
+        workItemNode3.setWork( work );
+        process.addNode( workItemNode3 );
+        new ConnectionImpl( workItemNode2,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            workItemNode3,
+                            Node.CONNECTION_DEFAULT_TYPE );
+        EndNode end = new EndNode();
+        end.setId( 6 );
+        end.setName( "End" );
+        process.addNode( end );
+        new ConnectionImpl( workItemNode3,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            end,
+                            Node.CONNECTION_DEFAULT_TYPE );
+
+        PackageBuilder packageBuilder = new PackageBuilder();
+        ProcessBuilderImpl processBuilder = new ProcessBuilderImpl( packageBuilder );
+        processBuilder.buildProcess( process,
+                                     null );
+        List<KnowledgePackage> list = new ArrayList<KnowledgePackage>();
+        list.add( new KnowledgePackageImp( packageBuilder.getPackage() ) );
+        return list;
+    }
+
+    @Test
+    public void testPersistenceSubProcess() {
+        setUp();
+        
+        Properties properties = new Properties();
+        properties.setProperty( "drools.commandService",
+                                SingleSessionCommandService.class.getName() );
+        properties.setProperty( "drools.processInstanceManagerFactory",
+                                InfinispanProcessInstanceManagerFactory.class.getName() );
+        properties.setProperty( "drools.workItemManagerFactory",
+                                InfinispanWorkItemManagerFactory.class.getName() );
+        properties.setProperty( "drools.processSignalManagerFactory",
+                                InfinispanSignalManagerFactory.class.getName() );
+        properties.setProperty( "drools.timerService",
+                                JpaJDKTimerService.class.getName() );
+        SessionConfiguration config = new SessionConfiguration( properties );
+
+        RuleBase ruleBase = RuleBaseFactory.newRuleBase();
+        Package pkg = getProcessSubProcess();
+        ruleBase.addPackage( pkg );
+
+        SingleSessionCommandService service = createSingleSessionCommandService( ruleBase,
+                                                                               config,
+                                                                               env );
+        int sessionId = service.getSessionId();
+        StartProcessCommand startProcessCommand = new StartProcessCommand();
+        startProcessCommand.setProcessId( "org.drools.test.TestProcess" );
+        RuleFlowProcessInstance processInstance = (RuleFlowProcessInstance) service.execute( startProcessCommand );
+        System.out.println( "Started process instance " + processInstance.getId() );
+        long processInstanceId = processInstance.getId();
+
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+        		                                   ruleBase,
+                                                   config,
+                                                   env );
+        GetProcessInstanceCommand getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstanceId );
+        processInstance = (RuleFlowProcessInstance) service.execute( getProcessInstanceCommand );
+        assertNotNull( processInstance );
+
+        Collection<NodeInstance> nodeInstances = processInstance.getNodeInstances();
+        assertEquals( 1,
+                      nodeInstances.size() );
+        SubProcessNodeInstance subProcessNodeInstance = (SubProcessNodeInstance) nodeInstances.iterator().next();
+        long subProcessInstanceId = subProcessNodeInstance.getProcessInstanceId();
+        getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( subProcessInstanceId );
+        RuleFlowProcessInstance subProcessInstance = (RuleFlowProcessInstance) service.execute( getProcessInstanceCommand );
+        assertNotNull( subProcessInstance );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   ruleBase,
+                                                   config,
+                                                   env );
+        CompleteWorkItemCommand completeWorkItemCommand = new CompleteWorkItemCommand();
+        completeWorkItemCommand.setWorkItemId( workItem.getId() );
+        service.execute( completeWorkItemCommand );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   ruleBase,
+                                                   config,
+                                                   env );
+        getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( subProcessInstanceId );
+        subProcessInstance = (RuleFlowProcessInstance) service.execute( getProcessInstanceCommand );
+        assertNull( subProcessInstance );
+
+        getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstanceId );
+        processInstance = (RuleFlowProcessInstance) service.execute( getProcessInstanceCommand );
+        assertNull( processInstance );
+        service.dispose();
+    }
+
+	private Package getProcessSubProcess() {
+        RuleFlowProcess process = new RuleFlowProcess();
+        process.setId( "org.drools.test.TestProcess" );
+        process.setName( "TestProcess" );
+        process.setPackageName( "org.drools.test" );
+        
+        StartNode start = new StartNode();
+        start.setId( 1 );
+        start.setName( "Start" );
+        process.addNode( start );
+        
+        ActionNode actionNode = new ActionNode();
+        actionNode.setId( 2 );
+        actionNode.setName( "Action" );
+        
+        DroolsConsequenceAction action = new DroolsConsequenceAction();
+        action.setDialect( "java" );
+        action.setConsequence( "System.out.println(\"Executed action\");" );
+        actionNode.setAction( action );
+        process.addNode( actionNode );
+        
+        new ConnectionImpl( start,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            actionNode,
+                            Node.CONNECTION_DEFAULT_TYPE );
+        
+        SubProcessNode subProcessNode = new SubProcessNode();
+        subProcessNode.setId( 3 );
+        subProcessNode.setName( "SubProcess" );
+        subProcessNode.setProcessId( "org.drools.test.SubProcess" );
+        process.addNode( subProcessNode );
+        
+        new ConnectionImpl( actionNode,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            subProcessNode,
+                            Node.CONNECTION_DEFAULT_TYPE );
+        
+        EndNode end = new EndNode();
+        end.setId( 4 );
+        end.setName( "End" );
+        process.addNode( end );
+        
+        new ConnectionImpl( subProcessNode,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            end,
+                            Node.CONNECTION_DEFAULT_TYPE );
+
+        PackageBuilder packageBuilder = new PackageBuilder();
+        ProcessBuilderImpl processBuilder = new ProcessBuilderImpl( packageBuilder );
+        processBuilder.buildProcess( process,
+                                     null );
+
+        process = new RuleFlowProcess();
+        process.setId( "org.drools.test.SubProcess" );
+        process.setName( "SubProcess" );
+        process.setPackageName( "org.drools.test" );
+        
+        start = new StartNode();
+        start.setId( 1 );
+        start.setName( "Start" );
+        process.addNode( start );
+        
+        actionNode = new ActionNode();
+        actionNode.setId( 2 );
+        actionNode.setName( "Action" );
+        
+        action = new DroolsConsequenceAction();
+        action.setDialect( "java" );
+        action.setConsequence( "System.out.println(\"Executed action\");" );
+        actionNode.setAction( action );
+        process.addNode( actionNode );
+        
+        new ConnectionImpl( start,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            actionNode,
+                            Node.CONNECTION_DEFAULT_TYPE );
+        
+        WorkItemNode workItemNode = new WorkItemNode();
+        workItemNode.setId( 3 );
+        workItemNode.setName( "WorkItem1" );
+        
+        Work work = new WorkImpl();
+        work.setName( "MyWork" );
+        workItemNode.setWork( work );
+        process.addNode( workItemNode );
+        
+        new ConnectionImpl( actionNode,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            workItemNode,
+                            Node.CONNECTION_DEFAULT_TYPE );
+        
+        end = new EndNode();
+        end.setId( 6 );
+        end.setName( "End" );
+        process.addNode( end );
+        
+        new ConnectionImpl( workItemNode,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            end,
+                            Node.CONNECTION_DEFAULT_TYPE );
+
+        processBuilder.buildProcess( process,
+                                     null );
+        return packageBuilder.getPackage();
+    }
+
+    @Test
+    public void testPersistenceTimer() throws Exception {
+        setUp();
+        
+        Properties properties = new Properties();
+        properties.setProperty( "drools.commandService",
+                                SingleSessionCommandService.class.getName() );
+        properties.setProperty( "drools.processInstanceManagerFactory",
+                                InfinispanProcessInstanceManagerFactory.class.getName() );
+        properties.setProperty( "drools.workItemManagerFactory",
+                                InfinispanWorkItemManagerFactory.class.getName() );
+        properties.setProperty( "drools.processSignalManagerFactory",
+                                InfinispanSignalManagerFactory.class.getName() );
+        
+        SessionConfiguration config = new SessionConfiguration( properties );
+        config.setOption( TimerJobFactoryOption.get(TimerJobFactoryType.JPA.getId()) );
+
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        Collection<KnowledgePackage> kpkgs = getProcessTimer();
+        kbase.addKnowledgePackages( kpkgs );
+
+        SingleSessionCommandService service = createSingleSessionCommandService( kbase,
+                                                                               config,
+                                                                               env );
+        int sessionId = service.getSessionId();
+        StartProcessCommand startProcessCommand = new StartProcessCommand();
+        startProcessCommand.setProcessId( "org.drools.test.TestProcess" );
+        ProcessInstance processInstance = service.execute( startProcessCommand );
+        System.out.println( "Started process instance " + processInstance.getId() );
+        
+        
+        Thread.sleep( 500 );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        GetProcessInstanceCommand getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstance.getId() );
+        processInstance = service.execute( getProcessInstanceCommand );
+        assertNotNull( processInstance );
+        service.dispose();
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        Thread.sleep( 5000 );
+        getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstance.getId() );
+        processInstance = service.execute( getProcessInstanceCommand );
+        assertNull( processInstance );
+    }
+
+	private List<KnowledgePackage> getProcessTimer() {
+        RuleFlowProcess process = new RuleFlowProcess();
+        process.setId( "org.drools.test.TestProcess" );
+        process.setName( "TestProcess" );
+        process.setPackageName( "org.drools.test" );
+        StartNode start = new StartNode();
+        start.setId( 1 );
+        start.setName( "Start" );
+        process.addNode( start );
+        TimerNode timerNode = new TimerNode();
+        timerNode.setId( 2 );
+        timerNode.setName( "Timer" );
+        Timer timer = new Timer();
+        timer.setDelay( "2000" );
+        timerNode.setTimer( timer );
+        process.addNode( timerNode );
+        new ConnectionImpl( start,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            timerNode,
+                            Node.CONNECTION_DEFAULT_TYPE );
+        ActionNode actionNode = new ActionNode();
+        actionNode.setId( 3 );
+        actionNode.setName( "Action" );
+        DroolsConsequenceAction action = new DroolsConsequenceAction();
+        action.setDialect( "java" );
+        action.setConsequence( "System.out.println(\"Executed action\");" );
+        actionNode.setAction( action );
+        process.addNode( actionNode );
+        new ConnectionImpl( timerNode,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            actionNode,
+                            Node.CONNECTION_DEFAULT_TYPE );
+        EndNode end = new EndNode();
+        end.setId( 6 );
+        end.setName( "End" );
+        process.addNode( end );
+        new ConnectionImpl( actionNode,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            end,
+                            Node.CONNECTION_DEFAULT_TYPE );
+
+        PackageBuilder packageBuilder = new PackageBuilder();
+        ProcessBuilderImpl processBuilder = new ProcessBuilderImpl( packageBuilder );
+        processBuilder.buildProcess( process,
+                                     null );
+        List<KnowledgePackage> list = new ArrayList<KnowledgePackage>();
+        list.add( new KnowledgePackageImp( packageBuilder.getPackage() ) );
+        return list;
+    }
+
+    @Test
+    public void testPersistenceTimer2() throws Exception {
+        setUp();
+        
+        Properties properties = new Properties();
+        properties.setProperty( "drools.commandService",
+                                SingleSessionCommandService.class.getName() );
+        properties.setProperty( "drools.processInstanceManagerFactory",
+                                InfinispanProcessInstanceManagerFactory.class.getName() );
+        properties.setProperty( "drools.workItemManagerFactory",
+                                InfinispanWorkItemManagerFactory.class.getName() );
+        properties.setProperty( "drools.processSignalManagerFactory",
+                                InfinispanSignalManagerFactory.class.getName() );
+
+        SessionConfiguration config = new SessionConfiguration( properties );
+        config.setOption( TimerJobFactoryOption.get(TimerJobFactoryType.JPA.getId()) );
+        
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        Collection<KnowledgePackage> kpkgs = getProcessTimer2();
+        kbase.addKnowledgePackages( kpkgs );
+
+        SingleSessionCommandService service = createSingleSessionCommandService( kbase,
+                                                                               config,
+                                                                               env );
+        int sessionId = service.getSessionId();
+        StartProcessCommand startProcessCommand = new StartProcessCommand();
+        startProcessCommand.setProcessId( "org.drools.test.TestProcess" );
+        ProcessInstance processInstance = service.execute( startProcessCommand );
+        System.out.println( "Started process instance " + processInstance.getId() );
+
+        Thread.sleep( 2000 );
+
+        service = createSingleSessionCommandService( sessionId,
+                                                   kbase,
+                                                   config,
+                                                   env );
+        GetProcessInstanceCommand getProcessInstanceCommand = new GetProcessInstanceCommand();
+        getProcessInstanceCommand.setProcessInstanceId( processInstance.getId() );
+        processInstance = service.execute( getProcessInstanceCommand );
+        assertNull( processInstance );
+    }
+
+	private List<KnowledgePackage> getProcessTimer2() {
+        RuleFlowProcess process = new RuleFlowProcess();
+        process.setId( "org.drools.test.TestProcess" );
+        process.setName( "TestProcess" );
+        process.setPackageName( "org.drools.test" );
+        StartNode start = new StartNode();
+        start.setId( 1 );
+        start.setName( "Start" );
+        process.addNode( start );
+        TimerNode timerNode = new TimerNode();
+        timerNode.setId( 2 );
+        timerNode.setName( "Timer" );
+        Timer timer = new Timer();
+        timer.setDelay( "0" );
+        timerNode.setTimer( timer );
+        process.addNode( timerNode );
+        new ConnectionImpl( start,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            timerNode,
+                            Node.CONNECTION_DEFAULT_TYPE );
+        ActionNode actionNode = new ActionNode();
+        actionNode.setId( 3 );
+        actionNode.setName( "Action" );
+        DroolsConsequenceAction action = new DroolsConsequenceAction();
+        action.setDialect( "java" );
+        action.setConsequence( "try { Thread.sleep(1000); } catch (Throwable t) {} System.out.println(\"Executed action\");" );
+        actionNode.setAction( action );
+        process.addNode( actionNode );
+        new ConnectionImpl( timerNode,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            actionNode,
+                            Node.CONNECTION_DEFAULT_TYPE );
+        EndNode end = new EndNode();
+        end.setId( 6 );
+        end.setName( "End" );
+        process.addNode( end );
+        new ConnectionImpl( actionNode,
+                            Node.CONNECTION_DEFAULT_TYPE,
+                            end,
+                            Node.CONNECTION_DEFAULT_TYPE );
+
+        PackageBuilder packageBuilder = new PackageBuilder();
+        ProcessBuilderImpl processBuilder = new ProcessBuilderImpl( packageBuilder );
+        processBuilder.buildProcess( process,
+                                     null );
+        List<KnowledgePackage> list = new ArrayList<KnowledgePackage>();
+        list.add( new KnowledgePackageImp( packageBuilder.getPackage() ) );
+        return list;
+    }
+
+	private SingleSessionCommandService createSingleSessionCommandService(KnowledgeBase kbase, SessionConfiguration conf, Environment env) {
+		SingleSessionCommandService service = new SingleSessionCommandService(kbase, conf, env);
+		service.addInterceptor(new ManualPersistInterceptor(service));
+		service.addInterceptor(new ManualPersistProcessInterceptor(service));
+		return service;
+	}
+
+	private SingleSessionCommandService createSingleSessionCommandService(int sessionId, KnowledgeBase kbase, SessionConfiguration conf, Environment env) {
+		SingleSessionCommandService service = new SingleSessionCommandService(sessionId, kbase, conf, env);
+		service.addInterceptor(new ManualPersistInterceptor(service));
+		service.addInterceptor(new ManualPersistProcessInterceptor(service));
+		return service;
+	}
+
+	private SingleSessionCommandService createSingleSessionCommandService(RuleBase ruleBase, SessionConfiguration conf, Environment env) {
+		SingleSessionCommandService service = new SingleSessionCommandService(ruleBase, conf, env);
+		service.addInterceptor(new ManualPersistInterceptor(service));
+		service.addInterceptor(new ManualPersistProcessInterceptor(service));
+		return service;
+	}
+
+	private SingleSessionCommandService createSingleSessionCommandService(int sessionId, RuleBase ruleBase, SessionConfiguration conf, Environment env) {
+		SingleSessionCommandService service = new SingleSessionCommandService(sessionId, ruleBase, conf, env);
+		service.addInterceptor(new ManualPersistInterceptor(service));
+		service.addInterceptor(new ManualPersistProcessInterceptor(service));
+		return service;
+	}
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/VariablePersistenceStrategyTest.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/VariablePersistenceStrategyTest.java
@@ -1,0 +1,689 @@
+package org.jbpm.persistence.session;
+
+import static org.jbpm.persistence.util.PersistenceUtil.JBPM_PERSISTENCE_UNIT_NAME;
+import static org.jbpm.persistence.util.PersistenceUtil.cleanUp;
+import static org.jbpm.persistence.util.PersistenceUtil.setupWithPoolingDataSource;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.naming.NamingException;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+
+import junit.framework.Assert;
+
+import org.drools.core.common.AbstractRuleBase;
+import org.drools.core.impl.InternalKnowledgeBase;
+import org.drools.core.io.impl.ClassPathResource;
+import org.drools.core.marshalling.impl.ClassObjectMarshallingStrategyAcceptor;
+import org.drools.core.marshalling.impl.SerializablePlaceholderResolverStrategy;
+import org.drools.core.process.core.Work;
+import org.drools.core.process.core.datatype.impl.type.ObjectDataType;
+import org.drools.core.process.core.impl.WorkImpl;
+import org.drools.persistence.infinispan.marshaller.InfinispanPlaceholderResolverStrategy;
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.jbpm.persistence.session.objects.MyEntity;
+import org.jbpm.persistence.session.objects.MyEntityMethods;
+import org.jbpm.persistence.session.objects.MyEntityOnlyFields;
+import org.jbpm.persistence.session.objects.MySubEntity;
+import org.jbpm.persistence.session.objects.MySubEntityMethods;
+import org.jbpm.persistence.session.objects.MyVariableExtendingSerializable;
+import org.jbpm.persistence.session.objects.MyVariableSerializable;
+import org.jbpm.persistence.session.objects.TestWorkItemHandler;
+import org.jbpm.persistence.util.PersistenceUtil;
+import org.jbpm.process.core.context.variable.Variable;
+import org.jbpm.process.instance.impl.Action;
+import org.jbpm.ruleflow.core.RuleFlowProcess;
+import org.jbpm.workflow.core.DroolsAction;
+import org.jbpm.workflow.core.Node;
+import org.jbpm.workflow.core.impl.ConnectionImpl;
+import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
+import org.jbpm.workflow.core.node.ActionNode;
+import org.jbpm.workflow.core.node.EndNode;
+import org.jbpm.workflow.core.node.StartNode;
+import org.jbpm.workflow.core.node.WorkItemNode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.io.ResourceType;
+import org.kie.api.marshalling.ObjectMarshallingStrategy;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.api.runtime.process.ProcessContext;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkflowProcessInstance;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderConfiguration;
+import org.kie.internal.builder.KnowledgeBuilderError;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class VariablePersistenceStrategyTest {
+
+    private static Logger logger = LoggerFactory.getLogger( VariablePersistenceStrategyTest.class );
+    
+    private HashMap<String, Object> context;
+    private DefaultCacheManager cm;
+
+    @Before
+    public void setUp() throws Exception {
+        context = setupWithPoolingDataSource(JBPM_PERSISTENCE_UNIT_NAME);
+        cm = (DefaultCacheManager) context.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        cleanUp(context);
+    }
+
+    @Test
+    public void testExtendingInterfaceVariablePersistence() throws Exception {
+        // Setup
+        Environment env = createEnvironment();
+        String processId = "extendingInterfaceVariablePersistence";
+        String variableText = "my extending serializable variable text";
+        KnowledgeBase kbase = getKnowledgeBaseForExtendingInterfaceVariablePersistence(processId,
+                                                                                       variableText);
+        StatefulKnowledgeSession ksession = createSession( kbase , env );
+        Map<String, Object> initialParams = new HashMap<String, Object>();
+        initialParams.put( "x", new MyVariableExtendingSerializable( variableText ) );
+        
+        // Start process and execute workItem
+        long processInstanceId = ksession.startProcess( processId, initialParams ).getId();
+        
+        ksession = reloadSession( ksession, kbase, env );
+        
+        long workItemId = TestWorkItemHandler.getInstance().getWorkItem().getId();
+        ksession.getWorkItemManager().completeWorkItem( workItemId, null );
+        
+        // Test
+        Assert.assertNull( ksession.getProcessInstance( processInstanceId ) );
+    }
+
+    private KnowledgeBase getKnowledgeBaseForExtendingInterfaceVariablePersistence(String processId, final String variableText) {
+        RuleFlowProcess process = new RuleFlowProcess();
+        process.setId( processId );
+        
+        List<Variable> variables = new ArrayList<Variable>();
+        Variable variable = new Variable();
+        variable.setName("x");
+        ObjectDataType extendingSerializableDataType = new ObjectDataType();
+        extendingSerializableDataType.setClassName(MyVariableExtendingSerializable.class.getName());
+        variable.setType(extendingSerializableDataType);
+        variables.add(variable);
+        process.getVariableScope().setVariables(variables);
+
+        StartNode startNode = new StartNode();
+        startNode.setName( "Start" );
+        startNode.setId(1);
+
+        WorkItemNode workItemNode = new WorkItemNode();
+        workItemNode.setName( "workItemNode" );
+        workItemNode.setId( 2 );
+        Work work = new WorkImpl();
+        work.setName( "MyWork" );
+        workItemNode.setWork( work );
+        
+        ActionNode actionNode = new ActionNode();
+        actionNode.setName( "Print" );
+        DroolsAction action = new DroolsConsequenceAction( "java" , null);
+        action.setMetaData( "Action" , new Action() {
+            public void execute(ProcessContext context) throws Exception {
+                Assert.assertEquals( variableText , ((MyVariableExtendingSerializable) context.getVariable( "x" )).getText()); ;
+            }
+        });
+        actionNode.setAction(action);
+        actionNode.setId( 3 );
+        
+        EndNode endNode = new EndNode();
+        endNode.setName("EndNode");
+        endNode.setId(4);
+        
+        connect( startNode, workItemNode );
+        connect( workItemNode, actionNode );
+        connect( actionNode, endNode );
+
+        process.addNode( startNode );
+        process.addNode( workItemNode );
+        process.addNode( actionNode );
+        process.addNode( endNode );
+        
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        ((AbstractRuleBase) ((InternalKnowledgeBase) kbase).getRuleBase()).addProcess(process);
+        return kbase;
+    }
+    
+    @Test
+    public void testPersistenceVariables() throws NamingException, NotSupportedException, SystemException, RollbackException, HeuristicMixedException, HeuristicRollbackException {
+        Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+        UserTransaction utx = (UserTransaction) cache.getAdvancedCache().getTransactionManager();
+        if( utx.getStatus() == Status.STATUS_NO_TRANSACTION ) { 
+            utx.begin();
+        }
+        
+        int origNumMyEntities = getEntitiesFromCache(cache, "myEntity", MyEntity.class).size();
+        int origNumMyEntityMethods = getEntitiesFromCache(cache, "myEntityMethods", MyEntityMethods.class).size();
+        int origNumMyEntityOnlyFields = getEntitiesFromCache(cache, "myEntityOnlyFields", MyEntityOnlyFields.class).size();
+        if( utx.getStatus() == Status.STATUS_ACTIVE ) { 
+            utx.commit();
+        }
+       
+        // Setup entities
+        MyEntity myEntity = new MyEntity("This is a test Entity with annotation in fields");
+        MyEntityMethods myEntityMethods = new MyEntityMethods("This is a test Entity with annotations in methods");
+        MyEntityOnlyFields myEntityOnlyFields = new MyEntityOnlyFields("This is a test Entity with annotations in fields and without accesors methods");
+        MyVariableSerializable myVariableSerializable = new MyVariableSerializable("This is a test SerializableObject");
+
+        // persist entities
+        utx = (UserTransaction) cache.getAdvancedCache().getTransactionManager();
+        utx.begin();
+        cache.put(generateId(cache, myEntity), myEntity);
+        cache.put(generateId(cache, myEntityMethods), myEntityMethods);
+        cache.put(generateId(cache, myEntityOnlyFields), myEntityOnlyFields);
+        utx.commit();
+        
+        // More setup
+        Environment env =  createEnvironment();
+        KnowledgeBase kbase = createKnowledgeBase( "VariablePersistenceStrategyProcess.rf" );
+        StatefulKnowledgeSession ksession = createSession( kbase, env );
+
+        logger.debug("### Starting process ###");
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("x", "SomeString");
+        parameters.put("y", myEntity);
+        parameters.put("m", myEntityMethods);
+        parameters.put("f", myEntityOnlyFields);
+        parameters.put("z", myVariableSerializable);
+        
+        // Start process
+        long processInstanceId = ksession.startProcess( "com.sample.ruleflow", parameters ).getId();
+
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+        // Test results
+        List<?> result = getEntitiesFromCache(cache, "myEntity", MyEntity.class);
+        assertEquals(origNumMyEntities + 1, result.size());
+        result = getEntitiesFromCache(cache, "myEntityMethods", MyEntityMethods.class);
+        assertEquals(origNumMyEntityMethods + 1, result.size());
+        result = getEntitiesFromCache(cache, "myEntityOnlyFields", MyEntityOnlyFields.class);
+        assertEquals(origNumMyEntityOnlyFields + 1, result.size());
+
+        logger.debug("### Retrieving process instance ###");
+        ksession = reloadSession( ksession, kbase, env );
+        WorkflowProcessInstance processInstance = (WorkflowProcessInstance)
+        	ksession.getProcessInstance( processInstanceId );
+        assertNotNull( processInstance );
+        assertEquals("SomeString", processInstance.getVariable("x"));
+        assertEquals("This is a test Entity with annotation in fields", ((MyEntity) processInstance.getVariable("y")).getTest());
+        assertEquals("This is a test Entity with annotations in methods", ((MyEntityMethods) processInstance.getVariable("m")).getTest());
+        assertEquals("This is a test Entity with annotations in fields and without accesors methods", ((MyEntityOnlyFields) processInstance.getVariable("f")).test);
+        assertEquals("This is a test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("z")).getText());
+        assertNull(processInstance.getVariable("a"));
+        assertNull(processInstance.getVariable("b"));
+        assertNull(processInstance.getVariable("c"));
+        logger.debug("### Completing first work item ###");
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(), null );
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+        
+        ksession.getWorkItemManager().completeWorkItem(workItem.getId(), null);
+        
+        logger.debug("### Retrieving process instance ###");
+        ksession = reloadSession( ksession, kbase, env);
+        processInstance = (WorkflowProcessInstance)
+        	ksession.getProcessInstance(processInstanceId);
+        assertNotNull(processInstance);
+        assertEquals("SomeString", processInstance.getVariable("x"));
+        assertEquals("This is a test Entity with annotation in fields", ((MyEntity) processInstance.getVariable("y")).getTest());
+        assertEquals("This is a test Entity with annotations in methods", ((MyEntityMethods) processInstance.getVariable("m")).getTest());
+        assertEquals("This is a test Entity with annotations in fields and without accesors methods", ((MyEntityOnlyFields) processInstance.getVariable("f")).test);
+        assertEquals("This is a test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("z")).getText());
+        assertEquals("Some changed String", processInstance.getVariable("a"));
+        assertEquals("This is a changed test Entity", ((MyEntity) processInstance.getVariable("b")).getTest());
+        assertEquals("This is a changed test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("c")).getText());
+        logger.debug("### Completing third work item ###");
+        ksession.getWorkItemManager().completeWorkItem(workItem.getId(), null);
+
+        workItem = handler.getWorkItem();
+        assertNotNull(workItem);
+        
+        logger.debug("### Retrieving process instance ###");
+        ksession = reloadSession( ksession, kbase, env);
+        processInstance = (WorkflowProcessInstance)
+        	ksession.getProcessInstance(processInstanceId);
+        assertNotNull(processInstance);
+        assertEquals("SomeString", processInstance.getVariable("x"));
+        assertEquals("This is a test Entity with annotation in fields", ((MyEntity) processInstance.getVariable("y")).getTest());
+        assertEquals("This is a test Entity with annotations in methods", ((MyEntityMethods) processInstance.getVariable("m")).getTest());
+        assertEquals("This is a test Entity with annotations in fields and without accesors methods", ((MyEntityOnlyFields) processInstance.getVariable("f")).test);
+        assertEquals("This is a test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("z")).getText());
+        assertEquals("Some changed String", processInstance.getVariable("a"));
+        assertEquals("This is a changed test Entity", ((MyEntity) processInstance.getVariable("b")).getTest());
+        assertEquals("This is a changed test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("c")).getText());
+        logger.debug("### Completing third work item ###");
+        ksession.getWorkItemManager().completeWorkItem(workItem.getId(), null);
+        
+        workItem = handler.getWorkItem();
+        assertNull(workItem);
+        
+        ksession = reloadSession( ksession, kbase, env );
+        processInstance = (WorkflowProcessInstance)
+			ksession.getProcessInstance(processInstanceId);
+        assertNull(processInstance);
+    }
+    
+    private List<?> getEntitiesFromCache(Cache<String, Object> cache, String keyPrefix, Class<?> clazz) {
+    	List<Object> retval = new ArrayList<Object>();
+    	for (Map.Entry<String, Object> entry : cache.entrySet()) {
+    		if (entry.getKey().startsWith(keyPrefix) && clazz.isInstance(entry.getValue())) {
+    			retval.add(cache.get(entry.getValue()));
+    		}
+    	}
+		return retval;
+	}
+
+	private static long MYENTITYMETHODS_KEY = 1;
+    private static long MYENTITYONLYFIELDS_KEY = 1;
+    private static long MYENTITY_KEY = 1;
+    private static final Object syncObject = new Object();
+    
+    private String generateId(Cache<String, Object> cache, MyEntityOnlyFields myEntityOnlyFields) {
+    	synchronized (syncObject) {
+    		while (cache.containsKey("myEntityOnlyFields" + MYENTITYONLYFIELDS_KEY)) {
+    			MYENTITYONLYFIELDS_KEY++;
+    		}
+    		myEntityOnlyFields.id = MYENTITYONLYFIELDS_KEY;
+		}
+		return "myEntityOnlyFields" + MYENTITYONLYFIELDS_KEY;
+    }
+    
+    private String generateId(Cache<String, Object> cache, MyEntityMethods myEntityMethods) {
+    	synchronized (syncObject) {
+    		while (cache.containsKey("myEntityMethods" + MYENTITYMETHODS_KEY)) {
+    			MYENTITYMETHODS_KEY++;
+    		}
+    		myEntityMethods.setId(MYENTITYMETHODS_KEY);
+		}
+		return "myEntityMethods" + MYENTITYMETHODS_KEY;
+	}
+
+	private String generateId(Cache<String, Object> cache, MyEntity myEntity) {
+    	synchronized (syncObject) {
+    		while (cache.containsKey("myEntity" + MYENTITY_KEY)) {
+    			MYENTITY_KEY++;
+    		}
+    		myEntity.setId(MYENTITY_KEY);
+		}
+		return "myEntity" + MYENTITY_KEY;
+	}
+
+	@Test
+    public void testPersistenceVariablesWithTypeChange() throws NamingException, NotSupportedException, SystemException, RollbackException, HeuristicMixedException, HeuristicRollbackException {
+
+        MyEntity myEntity = new MyEntity("This is a test Entity with annotation in fields");
+        MyEntityMethods myEntityMethods = new MyEntityMethods("This is a test Entity with annotations in methods");
+        MyEntityOnlyFields myEntityOnlyFields = new MyEntityOnlyFields("This is a test Entity with annotations in fields and without accesors methods");
+        MyVariableSerializable myVariableSerializable = new MyVariableSerializable("This is a test SerializableObject");
+
+        Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+        UserTransaction utx = (UserTransaction) cache.getAdvancedCache().getTransactionManager();
+        int s = utx.getStatus();
+        if( utx.getStatus() == Status.STATUS_NO_TRANSACTION ) { 
+            utx.begin();
+        }
+        cache.put(generateId(cache, myEntity), myEntity);
+        cache.put(generateId(cache, myEntityMethods), myEntityMethods);
+        cache.put(generateId(cache, myEntityOnlyFields), myEntityOnlyFields);
+        if( utx.getStatus() == Status.STATUS_ACTIVE ) { 
+            utx.commit();
+        }
+        Environment env = createEnvironment();
+        KnowledgeBase kbase = createKnowledgeBase( "VariablePersistenceStrategyProcessTypeChange.rf" );
+        StatefulKnowledgeSession ksession = createSession( kbase, env );
+        
+        
+        
+        
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("x", "SomeString");
+        parameters.put("y", myEntity);
+        parameters.put("m", myEntityMethods );
+        parameters.put("f", myEntityOnlyFields);
+        parameters.put("z", myVariableSerializable);
+        long processInstanceId = ksession.startProcess( "com.sample.ruleflow", parameters ).getId();
+
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession = reloadSession( ksession, kbase, env );
+        ProcessInstance processInstance = ksession.getProcessInstance( processInstanceId );
+        assertNotNull( processInstance );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(), null );
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession = reloadSession( ksession, kbase, env );
+        processInstance = ksession.getProcessInstance( processInstanceId );
+        assertNotNull( processInstance );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(), null );
+
+        workItem = handler.getWorkItem();
+        assertNull( workItem );
+
+        ksession = reloadSession( ksession, kbase, env );
+        processInstance = ksession.getProcessInstance( processInstanceId );
+        assertNull( processInstance );
+    }
+    
+    @Test
+    public void testPersistenceVariablesSubProcess() throws NamingException, NotSupportedException, SystemException, RollbackException, HeuristicMixedException, HeuristicRollbackException {
+        
+        MyEntity myEntity = new MyEntity("This is a test Entity with annotation in fields");
+        MyEntityMethods myEntityMethods = new MyEntityMethods("This is a test Entity with annotations in methods");
+        MyEntityOnlyFields myEntityOnlyFields = new MyEntityOnlyFields("This is a test Entity with annotations in fields and without accesors methods");
+        MyVariableSerializable myVariableSerializable = new MyVariableSerializable("This is a test SerializableObject");
+        Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+        UserTransaction utx = (UserTransaction) cache.getAdvancedCache().getTransactionManager();
+        utx.begin();
+        cache.put(generateId(cache, myEntity), myEntity);
+        cache.put(generateId(cache, myEntityMethods), myEntityMethods);
+        cache.put(generateId(cache, myEntityOnlyFields), myEntityOnlyFields);
+        utx.commit();
+        Environment env = createEnvironment();
+        KnowledgeBase kbase = createKnowledgeBase( "VariablePersistenceStrategySubProcess.rf" );
+        StatefulKnowledgeSession ksession = createSession( kbase, env );
+       
+        
+        
+        
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("x", "SomeString");
+        parameters.put("y", myEntity);
+        parameters.put("m", myEntityMethods);
+        parameters.put("f", myEntityOnlyFields);
+        parameters.put("z", myVariableSerializable);
+        long processInstanceId = ksession.startProcess( "com.sample.ruleflow", parameters ).getId();
+
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession = reloadSession( ksession, kbase, env );
+        ProcessInstance processInstance = ksession.getProcessInstance( processInstanceId );
+        assertNotNull( processInstance );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(), null );
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession = reloadSession( ksession, kbase, env );
+        processInstance = ksession.getProcessInstance( processInstanceId );
+        assertNotNull( processInstance );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(), null );
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        ksession = reloadSession( ksession, kbase, env );
+        processInstance = ksession.getProcessInstance( processInstanceId );
+        assertNotNull( processInstance );
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(), null );
+
+        workItem = handler.getWorkItem();
+        assertNull( workItem );
+
+        ksession = reloadSession( ksession, kbase, env );
+        processInstance = ksession.getProcessInstance( processInstanceId );
+        assertNull( processInstance );
+    }
+    
+    @Test
+    public void testWorkItemWithVariablePersistence() throws Exception{
+        MyEntity myEntity = new MyEntity("This is a test Entity");
+        MyVariableSerializable myVariableSerializable = new MyVariableSerializable("This is a test SerializableObject");
+        Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+        UserTransaction utx = (UserTransaction) cache.getAdvancedCache().getTransactionManager();
+        utx.begin();
+        
+        cache.put(generateId(cache, myEntity), myEntity);
+        utx.commit();
+        Environment env = createEnvironment();
+        KnowledgeBase kbase = createKnowledgeBase( "VPSProcessWithWorkItems.rf" );
+        StatefulKnowledgeSession ksession = createSession( kbase , env);
+        
+        
+       
+       
+        
+        logger.debug("### Starting process ###");
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("x", "SomeString");
+        parameters.put("y", myEntity);
+        parameters.put("z", myVariableSerializable);
+        long processInstanceId = ksession.startProcess( "com.sample.ruleflow", parameters ).getId();
+
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        logger.debug("### Retrieving process instance ###");
+        ksession = reloadSession( ksession, kbase , env);
+        WorkflowProcessInstance processInstance = (WorkflowProcessInstance)
+        	ksession.getProcessInstance( processInstanceId );
+        assertNotNull( processInstance );
+        assertEquals("SomeString", processInstance.getVariable("x"));
+        assertEquals("This is a test Entity", ((MyEntity) processInstance.getVariable("y")).getTest());
+        assertEquals("This is a test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("z")).getText());
+        assertNull(processInstance.getVariable("a"));
+        assertNull(processInstance.getVariable("b"));
+        assertNull(processInstance.getVariable("c"));
+
+        logger.debug("### Completing first work item ###");
+        Map<String, Object> results = new HashMap<String, Object>();
+        results.put("zeta", processInstance.getVariable("z"));
+        results.put("equis", processInstance.getVariable("x")+"->modifiedResult");
+
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(),  results );
+
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+
+        logger.debug("### Retrieving process instance ###");
+        ksession = reloadSession( ksession, kbase, env );
+		processInstance = (WorkflowProcessInstance)
+			ksession.getProcessInstance(processInstanceId);
+		assertNotNull(processInstance);
+        logger.debug("######## Getting the already Persisted Variables #########");
+        assertEquals("SomeString->modifiedResult", processInstance.getVariable("x"));
+        assertEquals("This is a test Entity", ((MyEntity) processInstance.getVariable("y")).getTest());
+        assertEquals("This is a test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("z")).getText());
+        assertEquals("Some new String", processInstance.getVariable("a"));
+        assertEquals("This is a new test Entity", ((MyEntity) processInstance.getVariable("b")).getTest());
+        assertEquals("This is a new test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("c")).getText());
+        logger.debug("### Completing second work item ###");
+        results = new HashMap<String, Object>();
+        results.put("zeta", processInstance.getVariable("z"));
+        results.put("equis", processInstance.getVariable("x"));
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(),  results );
+
+
+        workItem = handler.getWorkItem();
+        assertNotNull(workItem);
+
+        logger.debug("### Retrieving process instance ###");
+        ksession = reloadSession( ksession, kbase, env );
+        processInstance = (WorkflowProcessInstance)
+        	ksession.getProcessInstance(processInstanceId);
+        assertNotNull(processInstance);
+        assertEquals("SomeString->modifiedResult", processInstance.getVariable("x"));
+        assertEquals("This is a test Entity", ((MyEntity) processInstance.getVariable("y")).getTest());
+        assertEquals("This is a test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("z")).getText());
+        assertEquals("Some changed String", processInstance.getVariable("a"));
+        assertEquals("This is a changed test Entity", ((MyEntity) processInstance.getVariable("b")).getTest());
+        assertEquals("This is a changed test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("c")).getText());
+        logger.debug("### Completing third work item ###");
+        results = new HashMap<String, Object>();
+        results.put("zeta", processInstance.getVariable("z"));
+        results.put("equis", processInstance.getVariable("x"));
+        ksession.getWorkItemManager().completeWorkItem( workItem.getId(),  results );
+
+        workItem = handler.getWorkItem();
+        assertNull(workItem);
+
+
+        ksession = reloadSession( ksession, kbase, env );
+        processInstance = (WorkflowProcessInstance)
+			ksession.getProcessInstance(processInstanceId);
+        assertNull(processInstance);
+    }
+
+    @Test
+    public void testEntityWithSuperClassAnnotationField() throws Exception {
+    	MySubEntity subEntity = new MySubEntity();
+    	subEntity.setId(3L);
+    	assertEquals(3L, InfinispanPlaceholderResolverStrategy.getClassIdValue(subEntity));
+    }
+    
+    @Test
+    public void testEntityWithSuperClassAnnotationMethod() throws Exception {
+    	MySubEntityMethods subEntity = new MySubEntityMethods();
+    	subEntity.setId(3L);
+    	assertEquals(3L, InfinispanPlaceholderResolverStrategy.getClassIdValue(subEntity));
+    }
+    
+    @Test
+    public void testAbortWorkItemWithVariablePersistence() throws Exception{
+        MyEntity myEntity = new MyEntity("This is a test Entity");
+        MyVariableSerializable myVariableSerializable = new MyVariableSerializable("This is a test SerializableObject");
+        Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+        UserTransaction utx = (UserTransaction) cache.getAdvancedCache().getTransactionManager();
+        utx.begin();
+        
+        cache.put(generateId(cache, myEntity), myEntity);
+        utx.commit();
+        Environment env = createEnvironment();
+        KnowledgeBase kbase = createKnowledgeBase( "VPSProcessWithWorkItems.rf" );
+        StatefulKnowledgeSession ksession = createSession( kbase , env);
+        
+        logger.debug("### Starting process ###");
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("x", "SomeString");
+        parameters.put("y", myEntity);
+        parameters.put("z", myVariableSerializable);
+        long processInstanceId = ksession.startProcess( "com.sample.ruleflow", parameters ).getId();
+    
+        TestWorkItemHandler handler = TestWorkItemHandler.getInstance();
+        WorkItem workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+    
+        logger.debug("### Retrieving process instance ###");
+        ksession = reloadSession( ksession, kbase , env);
+        WorkflowProcessInstance processInstance = (WorkflowProcessInstance)
+               ksession.getProcessInstance( processInstanceId );
+        assertNotNull( processInstance );
+        assertEquals("SomeString", processInstance.getVariable("x"));
+        assertEquals("This is a test Entity", ((MyEntity) processInstance.getVariable("y")).getTest());
+        assertEquals("This is a test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("z")).getText());
+        assertNull(processInstance.getVariable("a"));
+        assertNull(processInstance.getVariable("b"));
+        assertNull(processInstance.getVariable("c"));
+    
+        logger.debug("### Completing first work item ###");
+        Map<String, Object> results = new HashMap<String, Object>();
+        results.put("zeta", processInstance.getVariable("z"));
+        results.put("equis", processInstance.getVariable("x")+"->modifiedResult");
+    
+        ksession.getWorkItemManager().completeWorkItem(workItem.getId(), results);
+        
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+        
+        // we simulate a failure here, aborting the work item
+        ksession.getWorkItemManager().abortWorkItem( workItem.getId() );
+    
+        workItem = handler.getWorkItem();
+        assertNotNull( workItem );
+    
+        logger.debug("### Retrieving process instance ###");
+        ksession = reloadSession( ksession, kbase, env );
+               processInstance = (WorkflowProcessInstance)
+                       ksession.getProcessInstance(processInstanceId);
+               assertNotNull(processInstance);
+        logger.debug("######## Getting the already Persisted Variables #########");
+        // we expect the variables to be unmodifed
+        assertEquals("SomeString->modifiedResult", processInstance.getVariable("x"));
+        assertEquals("This is a test Entity", ((MyEntity) processInstance.getVariable("y")).getTest());
+        assertEquals("This is a test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("z")).getText());
+        assertEquals("Some new String", processInstance.getVariable("a"));
+        assertEquals("This is a new test Entity", ((MyEntity) processInstance.getVariable("b")).getTest());
+        assertEquals("This is a new test SerializableObject", ((MyVariableSerializable) processInstance.getVariable("c")).getText());
+    }    
+    
+    private StatefulKnowledgeSession createSession(KnowledgeBase kbase, Environment env){
+        return InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
+    }
+    
+    private StatefulKnowledgeSession reloadSession(StatefulKnowledgeSession ksession, KnowledgeBase kbase, Environment env){
+        int sessionId = ksession.getId();
+        ksession.dispose();
+        return InfinispanKnowledgeService.loadStatefulKnowledgeSession( sessionId, kbase, null, env);
+    }
+
+    private KnowledgeBase createKnowledgeBase(String flowFile) {
+        KnowledgeBuilderConfiguration conf = KnowledgeBuilderFactory.newKnowledgeBuilderConfiguration();
+        conf.setProperty("drools.dialect.java.compiler", "JANINO");
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder(conf);
+        kbuilder.add( new ClassPathResource( flowFile ), ResourceType.DRF );
+        if(kbuilder.hasErrors()){
+            StringBuilder errorMessage = new StringBuilder();
+            for (KnowledgeBuilderError error: kbuilder.getErrors()) {
+                errorMessage.append( error.getMessage() );
+                errorMessage.append( System.getProperty( "line.separator" ) );
+            }
+            fail( errorMessage.toString());
+        }
+        
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+        return kbase;
+    }
+
+    private Environment createEnvironment() {
+        Environment env = PersistenceUtil.createEnvironment(context);
+        env.set(EnvironmentName.OBJECT_MARSHALLING_STRATEGIES, new ObjectMarshallingStrategy[]{
+                                    new InfinispanPlaceholderResolverStrategy(env),
+                                    new SerializablePlaceholderResolverStrategy( ClassObjectMarshallingStrategyAcceptor.DEFAULT  )
+                                     });
+        return env;
+    }
+    
+    private void connect(Node sourceNode,
+                         Node targetNode) {
+        new ConnectionImpl (sourceNode, Node.CONNECTION_DEFAULT_TYPE,
+                            targetNode, Node.CONNECTION_DEFAULT_TYPE);
+    }
+
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/WorkItemPersistenceTest.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/WorkItemPersistenceTest.java
@@ -1,0 +1,298 @@
+package org.jbpm.persistence.session;
+
+import static org.jbpm.persistence.util.PersistenceUtil.JBPM_PERSISTENCE_UNIT_NAME;
+import static org.jbpm.persistence.util.PersistenceUtil.cleanUp;
+import static org.jbpm.persistence.util.PersistenceUtil.createEnvironment;
+import static org.jbpm.persistence.util.PersistenceUtil.setupWithPoolingDataSource;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.kie.api.runtime.EnvironmentName.ENTITY_MANAGER_FACTORY;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.drools.core.WorkItemHandlerNotFoundException;
+import org.drools.core.common.AbstractRuleBase;
+import org.drools.core.impl.InternalKnowledgeBase;
+import org.drools.core.process.core.ParameterDefinition;
+import org.drools.core.process.core.Work;
+import org.drools.core.process.core.datatype.impl.type.IntegerDataType;
+import org.drools.core.process.core.datatype.impl.type.ObjectDataType;
+import org.drools.core.process.core.datatype.impl.type.StringDataType;
+import org.drools.core.process.core.impl.ParameterDefinitionImpl;
+import org.drools.core.process.core.impl.WorkImpl;
+import org.drools.core.runtime.process.ProcessRuntimeFactory;
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.jbpm.persistence.processinstance.ProcessEntityHolder;
+import org.jbpm.persistence.processinstance.ProcessInstanceInfo;
+import org.jbpm.persistence.session.objects.Person;
+import org.jbpm.process.core.context.variable.Variable;
+import org.jbpm.process.instance.ProcessRuntimeFactoryServiceImpl;
+import org.jbpm.process.instance.impl.demo.DoNothingWorkItemHandler;
+import org.jbpm.ruleflow.core.RuleFlowProcess;
+import org.jbpm.workflow.core.Node;
+import org.jbpm.workflow.core.impl.ConnectionImpl;
+import org.jbpm.workflow.core.node.EndNode;
+import org.jbpm.workflow.core.node.HumanTaskNode;
+import org.jbpm.workflow.core.node.StartNode;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WorkItemPersistenceTest {
+
+    private static Logger logger = LoggerFactory.getLogger(WorkItemPersistenceTest.class);
+    
+    private HashMap<String, Object> context;
+    private DefaultCacheManager cm;
+    
+    static {
+        ProcessRuntimeFactory.setProcessRuntimeFactoryService(new ProcessRuntimeFactoryServiceImpl());
+    }
+    
+    @Before
+    public void setUp() throws Exception {
+        context = setupWithPoolingDataSource(JBPM_PERSISTENCE_UNIT_NAME, false);
+        cm = (DefaultCacheManager) context.get(ENTITY_MANAGER_FACTORY);
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+       cleanUp(context); 
+    }
+   
+    protected StatefulKnowledgeSession createSession(KnowledgeBase kbase) {
+        return InfinispanKnowledgeService.newStatefulKnowledgeSession( kbase, null, createEnvironment(context) );
+    }
+
+    @Test
+    @Ignore
+    public void testCancelNonRegisteredWorkItemHandler() {
+        String processId = "org.drools.actions";
+        String workName = "Unnexistent Task";
+        RuleFlowProcess process = getWorkItemProcess( processId, workName );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        ((AbstractRuleBase) ((InternalKnowledgeBase) kbase).getRuleBase()).addProcess( process );
+        StatefulKnowledgeSession ksession = createSession(kbase);
+
+        ksession.getWorkItemManager().registerWorkItemHandler( workName, new DoNothingWorkItemHandler() );
+
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put( "UserName", "John Doe" );
+        parameters.put( "Person",
+                        new Person( "John Doe" ) );
+
+        ProcessInstance processInstance = ksession.startProcess( "org.drools.actions",
+                                                                  parameters );
+        long processInstanceId = processInstance.getId();
+        Assert.assertEquals( ProcessInstance.STATE_ACTIVE,
+                           processInstance.getState() );
+        ksession.getWorkItemManager().registerWorkItemHandler( workName,
+                                                               null );
+
+        try {
+            ksession.abortProcessInstance( processInstanceId );
+            Assert.fail( "should fail if WorkItemHandler for" + workName + "is not registered" );
+        } catch ( WorkItemHandlerNotFoundException wihnfe ) {
+
+        }
+
+        Assert.assertEquals( ProcessInstance.STATE_ABORTED, processInstance.getState() );
+    }
+
+    private RuleFlowProcess getWorkItemProcess(String processId, String workName) {
+        RuleFlowProcess process = new RuleFlowProcess();
+        process.setId( processId );
+
+        List<Variable> variables = new ArrayList<Variable>();
+        Variable variable = new Variable();
+        variable.setName( "UserName" );
+        variable.setType( new StringDataType() );
+        variables.add( variable );
+        
+        variable = new Variable();
+        variable.setName( "MyObject" );
+        variable.setType( new ObjectDataType() );
+        variables.add( variable );
+        variable = new Variable();
+        variable.setName( "Number" );
+        variable.setType( new IntegerDataType() );
+        variables.add( variable );
+        process.getVariableScope().setVariables( variables );
+
+        StartNode startNode = new StartNode();
+        startNode.setName( "Start" );
+        startNode.setId( 1 );
+
+        HumanTaskNode workItemNode = new HumanTaskNode();
+        workItemNode.setName( "workItemNode" );
+        workItemNode.setId( 2 );
+        workItemNode.addInMapping( "Attachment", "MyObject" );
+        workItemNode.addOutMapping( "Result", "MyObject" );
+        workItemNode.addOutMapping( "Result.length()", "Number" );
+        
+        Work work = new WorkImpl();
+        work.setName( workName );
+        
+        Set<ParameterDefinition> parameterDefinitions = new HashSet<ParameterDefinition>();
+        ParameterDefinition parameterDefinition = new ParameterDefinitionImpl( "ActorId", new StringDataType() );
+        parameterDefinitions.add( parameterDefinition );
+        parameterDefinition = new ParameterDefinitionImpl( "Content", new StringDataType() );
+        parameterDefinitions.add( parameterDefinition );
+        parameterDefinition = new ParameterDefinitionImpl( "Comment", new StringDataType() );
+        parameterDefinitions.add( parameterDefinition );
+        work.setParameterDefinitions( parameterDefinitions );
+        
+        work.setParameter( "ActorId", "#{UserName}" );
+        work.setParameter( "Content", "#{Person.name}" );
+        workItemNode.setWork( work );
+
+        EndNode endNode = new EndNode();
+        endNode.setName( "End" );
+        endNode.setId( 3 );
+
+        connect( startNode, workItemNode );
+        connect( workItemNode, endNode );
+
+        process.addNode( startNode );
+        process.addNode( workItemNode );
+        process.addNode( endNode );
+
+        return process;
+    }
+
+    private void connect(Node sourceNode,
+                         Node targetNode) {
+        new ConnectionImpl( sourceNode,
+                             Node.CONNECTION_DEFAULT_TYPE,
+                             targetNode,
+                             Node.CONNECTION_DEFAULT_TYPE );
+    }
+
+    @Test
+    public void testHumanTask() {
+        List<ProcessInstanceInfo> procInstInfoList = retrieveProcessInstanceInfo(cm);
+        int numProcInstInfos = procInstInfoList.size();
+        
+        Reader source = new StringReader(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<process xmlns=\"http://drools.org/drools-5.0/process\"\n" +
+            "         xmlns:xs=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+            "         xs:schemaLocation=\"http://drools.org/drools-5.0/process drools-processes-5.0.xsd\"\n" +
+            "         type=\"RuleFlow\" name=\"flow\" id=\"org.drools.humantask\" package-name=\"org.drools\" version=\"1\" >\n" +
+            "\n" +
+            "  <header>\n" +
+            "  </header>\n" +
+            "\n" +
+            "  <nodes>\n" +
+            "    <start id=\"1\" name=\"Start\" />\n" +
+            "    <humanTask id=\"2\" name=\"HumanTask\" >\n" +
+            "      <work name=\"Human Task\" >\n" +
+            "        <parameter name=\"ActorId\" >\n" +
+            "          <type name=\"org.drools.core.process.core.datatype.impl.type.StringDataType\" />\n" +
+            "          <value>John Doe</value>\n" +
+            "        </parameter>\n" +
+            "        <parameter name=\"TaskName\" >\n" +
+            "          <type name=\"org.drools.core.process.core.datatype.impl.type.StringDataType\" />\n" +
+            "          <value>Do something</value>\n" +
+            "        </parameter>\n" +
+            "        <parameter name=\"Priority\" >\n" +
+            "          <type name=\"org.drools.core.process.core.datatype.impl.type.StringDataType\" />\n" +
+            "        </parameter>\n" +
+            "        <parameter name=\"Comment\" >\n" +
+            "          <type name=\"org.drools.core.process.core.datatype.impl.type.StringDataType\" />\n" +
+            "        </parameter>\n" +
+            "      </work>\n" +
+            "    </humanTask>\n" +
+            "    <end id=\"3\" name=\"End\" />\n" +
+            "  </nodes>\n" +
+            "\n" +
+            "  <connections>\n" +
+            "    <connection from=\"1\" to=\"2\" />\n" +
+            "    <connection from=\"2\" to=\"3\" />\n" +
+            "  </connections>\n" +
+            "\n" +
+            "</process>");
+        
+        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+        kbuilder.add( ResourceFactory.newReaderResource(source), ResourceType.DRF );
+        KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );        
+        StatefulKnowledgeSession ksession = createSession(kbase);
+        
+        DoNothingWorkItemHandler handler = new DoNothingWorkItemHandler();
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
+        
+        ProcessInstance processInstance = ksession.startProcess("org.drools.humantask");
+        
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
+        
+        int state = processInstance.getState();
+        switch(state) { 
+        case ProcessInstance.STATE_ABORTED:
+            logger.debug("STATE_ABORTED");
+            break;
+        case ProcessInstance.STATE_ACTIVE:
+            logger.debug("STATE_ACTIVE");
+            break;
+        case ProcessInstance.STATE_COMPLETED:
+            logger.debug("STATE_COMPLETED");
+            break;
+        case ProcessInstance.STATE_PENDING:
+            logger.debug("STATE_PENDING");
+            break;
+        case ProcessInstance.STATE_SUSPENDED:
+            logger.debug("STATE_SUSPENDED");
+            break;
+        default: 
+            logger.debug("Unknown state: " + state );
+        }
+       
+        procInstInfoList = retrieveProcessInstanceInfo(cm);
+        assertTrue( (procInstInfoList.size() - numProcInstInfos) == 1);
+        
+        ProcessInstanceInfo processInstanceInfoMadeInThisTest = procInstInfoList.get(numProcInstInfos);
+        assertNotNull("ByteArray of ProcessInstanceInfo from this test is not filled and null!", 
+                processInstanceInfoMadeInThisTest.getProcessInstanceByteArray());
+        assertTrue("ByteArray of ProcessInstanceInfo from this test is not filled and empty!", 
+                processInstanceInfoMadeInThisTest.getProcessInstanceByteArray().length > 0);
+    }
+    
+    public static ArrayList<ProcessInstanceInfo> retrieveProcessInstanceInfo(DefaultCacheManager cm) { 
+        
+    	Cache<String, Object> cache = cm.getCache("jbpm-configured-cache");
+    	Set<String> keyset = cache.keySet();
+    	ArrayList<ProcessInstanceInfo> retval = new ArrayList<ProcessInstanceInfo>();
+    	for (String key : keyset) {
+    		if (key.startsWith("processInstanceInfo")) {
+    			ProcessEntityHolder holder = (ProcessEntityHolder) cache.get(key);
+    			ProcessInstanceInfo procInstInfo = holder.getProcessInstanceInfo();
+				retval.add(procInstInfo);
+    			logger.trace("> " + procInstInfo);
+    		}
+    	}
+    	return retval;
+    }
+    
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MyEntity.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MyEntity.java
@@ -1,0 +1,97 @@
+package org.jbpm.persistence.session.objects;
+
+import java.io.Serializable;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
+@Entity
+@Indexed
+public class MyEntity implements Serializable {
+
+
+	private static final long serialVersionUID = 510l;
+	
+	@Id @DocumentId @Field
+    private Long id;
+	@Field
+    private String test;
+	@Field
+	private String type = "myEntity";
+
+    public MyEntity(){}
+
+    public MyEntity(String string) {
+        this.test= string;
+    }
+
+    /**
+     * @return the id
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the test
+     */
+    public String getTest() {
+        return test;
+    }
+
+    /**
+     * @param test the test to set
+     */
+    public void setTest(String test) {
+        this.test = test;
+    }
+    public String toString(){
+        return "VARIABLE: " +this.getId() + " - " + this.getTest();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final MyEntity other = (MyEntity) obj;
+        if (this.id != other.id && (this.id == null || !this.id.equals(other.id))) {
+            return false;
+        }
+        if ((this.test == null) ? (other.test != null) : !this.test.equals(other.test)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 41 * hash + (this.id != null ? this.id.hashCode() : 0);
+        hash = 41 * hash + (this.test != null ? this.test.hashCode() : 0);
+        return hash;
+    }
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getType() {
+		return type;
+	}
+    
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MyEntityMethods.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MyEntityMethods.java
@@ -1,0 +1,98 @@
+package org.jbpm.persistence.session.objects;
+
+import java.io.Serializable;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
+@Entity
+@Indexed
+public class MyEntityMethods implements Serializable {
+	private static final long serialVersionUID = 510l;
+	
+	@Id @DocumentId @Field
+    private Long id;
+	@Field
+    private String test;
+	@Field
+	private String type = "myEntityMethods";
+
+    public MyEntityMethods(){}
+
+    public MyEntityMethods(String string) {
+        this.test= string;
+    }
+
+    /**
+     * @return the id
+     */
+    @Id @GeneratedValue(strategy=GenerationType.AUTO)
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the test
+     */
+    public String getTest() {
+        return test;
+    }
+
+    /**
+     * @param test the test to set
+     */
+    public void setTest(String test) {
+        this.test = test;
+    }
+    public String toString(){
+        return "VARIABLE: " +this.getId() + " - " + this.getTest();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final MyEntityMethods other = (MyEntityMethods) obj;
+        if (this.id != other.id && (this.id == null || !this.id.equals(other.id))) {
+            return false;
+        }
+        if ((this.test == null) ? (other.test != null) : !this.test.equals(other.test)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 41 * hash + (this.id != null ? this.id.hashCode() : 0);
+        hash = 41 * hash + (this.test != null ? this.test.hashCode() : 0);
+        return hash;
+    }
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getType() {
+		return type;
+	}
+    
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MyEntityOnlyFields.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MyEntityOnlyFields.java
@@ -1,0 +1,61 @@
+package org.jbpm.persistence.session.objects;
+
+import java.io.Serializable;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
+@Entity
+@Indexed
+public class MyEntityOnlyFields implements Serializable {
+
+	private static final long serialVersionUID = 510l;
+	
+	@Id @DocumentId @Field
+    public Long id;
+	@Field
+    public String test;
+	@Field
+	public String type = "myEntityOnlyFields";
+
+    public MyEntityOnlyFields(){}
+
+    public MyEntityOnlyFields(String string) {
+        this.test= string;
+    }
+    
+    public String toString(){
+        return "VARIABLE: " + id + " - " + test;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final MyEntityOnlyFields other = (MyEntityOnlyFields) obj;
+        if (this.id != other.id && (this.id == null || !this.id.equals(other.id))) {
+            return false;
+        }
+        if ((this.test == null) ? (other.test != null) : !this.test.equals(other.test)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 41 * hash + (this.id != null ? this.id.hashCode() : 0);
+        hash = 41 * hash + (this.test != null ? this.test.hashCode() : 0);
+        return hash;
+    }
+    
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MySubEntity.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MySubEntity.java
@@ -1,0 +1,10 @@
+package org.jbpm.persistence.session.objects;
+
+import javax.persistence.Entity;
+
+@Entity
+public class MySubEntity extends MyEntity {
+
+	private static final long serialVersionUID = 510l;
+	
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MySubEntityMethods.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MySubEntityMethods.java
@@ -1,0 +1,10 @@
+package org.jbpm.persistence.session.objects;
+
+import javax.persistence.Entity;
+
+@Entity
+public class MySubEntityMethods extends MyEntityMethods {
+	
+	private static final long serialVersionUID = 510l;
+
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MyVariableExtendingSerializable.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MyVariableExtendingSerializable.java
@@ -1,0 +1,16 @@
+package org.jbpm.persistence.session.objects;
+
+public class MyVariableExtendingSerializable extends MyVariableSerializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public MyVariableExtendingSerializable(String string) {
+        super( string );
+    }
+    
+    @Override
+    public String toString() {
+        return "Extended " + super.toString();
+    }
+
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MyVariableSerializable.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/MyVariableSerializable.java
@@ -1,0 +1,59 @@
+package org.jbpm.persistence.session.objects;
+
+import java.io.Serializable;
+
+/**
+ *
+ * @author salaboy
+ */
+public class MyVariableSerializable implements Serializable {
+
+	private static final long serialVersionUID = 510l;
+	
+	private String text = "";
+
+    public MyVariableSerializable(String string) {
+        this.text = string;
+    }
+
+    /**
+     * @return the text
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * @param text the text to set
+     */
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final MyVariableSerializable other = (MyVariableSerializable) obj;
+        if ((this.text == null) ? (other.text != null) : !this.text.equals(other.text)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 37 * hash + (this.text != null ? this.text.hashCode() : 0);
+        return hash;
+    }
+
+    public String toString(){
+        return "Serializable Variable: "+this.getText();
+    }
+
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/Person.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/Person.java
@@ -1,0 +1,44 @@
+package org.jbpm.persistence.session.objects;
+
+import java.io.Serializable;
+
+public class Person implements Serializable {
+    
+    private String name;
+    
+    public Person() {
+    }
+    
+    public Person(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) return true;
+        if ( obj == null ) return false;
+        if ( getClass() != obj.getClass() ) return false;
+        Person other = (Person) obj;
+        if ( name == null ) {
+            if ( other.name != null ) return false;
+        } else if ( !name.equals( other.name ) ) return false;
+        return true;
+    }
+    
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/VariableCheckerTestWorkItemHandler.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/session/objects/VariableCheckerTestWorkItemHandler.java
@@ -1,0 +1,33 @@
+package org.jbpm.persistence.session.objects;
+
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.api.runtime.process.WorkItemManager;
+
+public class VariableCheckerTestWorkItemHandler implements WorkItemHandler {
+
+	private static VariableCheckerTestWorkItemHandler INSTANCE = new VariableCheckerTestWorkItemHandler();
+	
+	private WorkItem workItem;
+	
+	private VariableCheckerTestWorkItemHandler() {
+	}
+	
+	public static VariableCheckerTestWorkItemHandler getInstance() {
+		return INSTANCE;
+	}
+	
+	public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
+		this.workItem = workItem;
+	}
+
+	public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {
+	}
+	
+	public WorkItem getWorkItem() {
+		WorkItem result = workItem;
+		workItem = null;
+		return result;
+	}
+
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/util/LoggingPrintStream.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/util/LoggingPrintStream.java
@@ -1,0 +1,170 @@
+package org.jbpm.persistence.util;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoggingPrintStream extends PrintStream {
+
+    private Logger logger;
+    private StringBuilder buffer = new StringBuilder();
+    
+    public LoggingPrintStream(OutputStream outputStream) { 
+        super(outputStream);
+        String className = Thread.currentThread().getStackTrace()[2].getClassName();
+        try {
+            logger = LoggerFactory.getLogger(Class.forName(className));
+        } catch (ClassNotFoundException e) {
+            logger = LoggerFactory.getLogger(this.getClass());
+        }
+    }
+    
+    protected void log(String s) { 
+        logger.debug(s);
+    }
+    
+    public void write(int b) {
+        log(String.valueOf(b));
+    }
+    
+    public void write(byte buf[], int off, int len) {
+        if (buf == null) {
+            throw new NullPointerException();
+        } else if ((off < 0) || (off > buf.length) || (len < 0) ||
+               ((off + len) > buf.length) || ((off + len) < 0)) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return;
+        }
+        for (int i = 0 ; i < len ; i++) {
+            write(buf[off + i]);
+        }
+        for (int i = 0 ; i < len ; i++) {
+            write(buf[off + i]);
+        }
+    }
+
+    private void write(byte b) {
+        buffer.append(Byte.toString(b));
+    }
+    
+    private void write(String s) { 
+        buffer.append(s);
+    }
+    
+    private void newLine() { 
+        synchronized(buffer) { 
+            log(buffer.toString());
+            buffer.delete(0, buffer.length());
+        }
+    }
+    
+    public void print(boolean b) {
+        write(b ? "true" : "false");
+    }
+    
+    public void print(char c) {
+        write(String.valueOf(c));
+    }
+    
+    public void print(int i) {
+        write(String.valueOf(i));
+    }
+    
+    public void print(long l) {
+        write(String.valueOf(l));
+    }
+    
+    public void print(float f) {
+        write(String.valueOf(f));
+    }
+    
+    public void print(double d) {
+        write(String.valueOf(d));
+    }
+    
+    public void print(char s[]) {
+        write(String.valueOf(s));
+    }
+    
+    public void print(String s) {
+        if (s == null) {
+            s = "null";
+        }
+        write(s);
+    }
+    
+    public void print(Object obj) {
+        write(String.valueOf(obj));
+    }
+    
+    public void println() {
+        newLine();
+    }
+    
+    public void println(boolean x) {
+        synchronized (this) {
+            print(x);
+            newLine();
+        }
+    }
+    
+    public void println(char x) {
+        synchronized (this) {
+            print(x);
+            newLine();
+        }
+    }
+    
+    public void println(int x) {
+        synchronized (this) {
+            print(x);
+            newLine();
+        }
+    }
+    
+    public void println(long x) {
+        synchronized (this) {
+            print(x);
+            newLine();
+        }
+    }
+    
+    public void println(float x) {
+        synchronized (this) {
+            print(x);
+            newLine();
+        }
+    }
+    
+    public void println(double x) {
+        synchronized (this) {
+            print(x);
+            newLine();
+        }
+    }
+    
+    public void println(char x[]) {
+        synchronized (this) {
+            print(x);
+            newLine();
+        }
+    }
+    
+    public void println(String x) {
+        synchronized (this) {
+            print(x);
+            newLine();
+        }
+    }
+    
+    public void println(Object x) {
+        synchronized (this) {
+            print(x);
+            newLine();
+        }
+    }
+}

--- a/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/util/PersistenceUtil.java
+++ b/jbpm-persistence-infinispan/src/test/java/org/jbpm/persistence/util/PersistenceUtil.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2011 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.persistence.util;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.kie.api.runtime.EnvironmentName.ENTITY_MANAGER_FACTORY;
+import static org.kie.api.runtime.EnvironmentName.GLOBALS;
+import static org.kie.api.runtime.EnvironmentName.TRANSACTION;
+import static org.kie.api.runtime.EnvironmentName.TRANSACTION_MANAGER;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Properties;
+
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+import org.drools.core.base.MapGlobalResolver;
+import org.drools.core.impl.EnvironmentFactory;
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.junit.Assert;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import bitronix.tm.BitronixTransactionManager;
+import bitronix.tm.TransactionManagerServices;
+
+public class PersistenceUtil {
+
+    private static Logger logger = LoggerFactory.getLogger( PersistenceUtil.class );
+
+    private static boolean TEST_MARSHALLING = true;
+    
+    // Persistence and data source constants
+    public static final String DROOLS_PERSISTENCE_UNIT_NAME = "org.drools.persistence.jpa";
+    public static final String DROOLS_LOCAL_PERSISTENCE_UNIT_NAME = "org.drools.persistence.jpa.local";
+    public static final String JBPM_PERSISTENCE_UNIT_NAME = "org.jbpm.persistence.jpa";
+    public static final String JBPM_LOCAL_PERSISTENCE_UNIT_NAME = "org.jbpm.persistence.jpa.local";
+        
+    protected static final String DATASOURCE_PROPERTIES = "/datasource.properties";
+    
+    private static Properties defaultProperties = null;
+   
+    // Setup and marshalling setup constants
+    public static String DATASOURCE = "org.droolsjbpm.persistence.datasource";
+
+    /**
+     * @see #setupWithPoolingDataSource(String, String, boolean)
+     * @param persistenceUnitName The name of the persistence unit to be used.
+     * @return test context
+     */
+    public static HashMap<String, Object> setupWithPoolingDataSource(String persistenceUnitName) {
+        return setupWithPoolingDataSource(persistenceUnitName, true);
+    }
+    
+    /**
+     * @see #setupWithPoolingDataSource(String, String, boolean)
+     * @param persistenceUnitName The name of the persistence unit to be used.
+     * @return test context
+     */
+    public static HashMap<String, Object> setupWithPoolingDataSource(String persistenceUnitName, boolean testMarshalling) {
+        return setupWithPoolingDataSource(persistenceUnitName, "jdbc/testDS1", testMarshalling);
+    }
+    
+    /**
+     * This method does all of the setup for the test and returns a HashMap
+     * containing the persistence objects that the test might need.
+     * 
+     * @param persistenceUnitName
+     *            The name of the persistence unit used by the test.
+     * @return HashMap<String Object> with persistence objects, such as the
+     *         EntityManagerFactory and DataSource
+     */
+    public static HashMap<String, Object> setupWithPoolingDataSource(final String persistenceUnitName, String dataSourceName, final boolean testMarshalling) {
+    	try {
+    		TransactionManagerServices.getTransactionManager().setTransactionTimeout(300);
+    	} catch (SystemException e) {
+    		//TODO
+    		e.printStackTrace();
+    	}
+    	HashMap<String, Object> context = new HashMap<String, Object>();
+
+        // set the right jdbc url
+        Properties dsProps = getDatasourceProperties();
+
+        determineTestMarshalling(dsProps, testMarshalling);
+        
+        // Setup persistence
+        DefaultCacheManager cm = null;
+        try {
+	        if (TEST_MARSHALLING) {
+	            cm = new DefaultCacheManager("infinispan.xml");
+	           
+	            UserTransaction ut = (UserTransaction) cm.getCache("jbpm-configured-cache").getAdvancedCache().getTransactionManager();
+	            context.put(TRANSACTION, ut);
+	        } else {
+	        	cm = new DefaultCacheManager("infinispan.xml");
+	        }
+        } catch (Exception e) {
+        	//TODO
+        	e.printStackTrace();
+        }
+        
+        context.put(ENTITY_MANAGER_FACTORY, cm);
+
+        return context;
+    }
+
+    private static void determineTestMarshalling(Properties dsProps, boolean useTestMarshallingInTestMethod ) { 
+        Object testMarshallingProperty = dsProps.get("testMarshalling"); 
+        if( "true".equals(testMarshallingProperty) ) { 
+            TEST_MARSHALLING = true;
+           if( !useTestMarshallingInTestMethod ) { 
+               TEST_MARSHALLING = false;
+           }
+        } 
+        else { 
+            TEST_MARSHALLING = false;
+        }
+    }
+    
+    /**
+     * This method should be called in the @After method of a test to clean up
+     * the persistence unit and datasource.
+     * 
+     * @param context
+     *            A HashMap generated by
+     *            {@link org.drools.persistence.util.PersistenceUtil setupWithPoolingDataSource(String)}
+     * 
+     */
+    public static void cleanUp(HashMap<String, Object> context) {
+        if (context != null) {
+            Object emfObject = context.remove(ENTITY_MANAGER_FACTORY);
+            if (emfObject != null) {
+                try {
+                    DefaultCacheManager cm = (DefaultCacheManager) emfObject;
+                    Cache<String,Object> cache = cm.getCache("jbpm-configured-cache");
+                    TransactionManager tm = cache.getAdvancedCache().getTransactionManager();
+                    boolean txOwner = false;
+                    if (tm.getStatus() == Status.STATUS_NO_TRANSACTION ) {
+                        tm.begin();
+                        txOwner = true;
+                    }
+                    if (tm.getStatus() != Status.STATUS_ACTIVE) {
+                    	tm.rollback();
+                    	tm.begin();
+                    	txOwner = true;
+                    }
+                    cache.clear();
+                    if (txOwner) {
+                    	tm.commit();
+                    }
+                    //cm.stop();
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+
+            BitronixTransactionManager txm = TransactionManagerServices.getTransactionManager();
+            if( txm != null ) { 
+                txm.shutdown();
+            }
+
+        }
+        
+    }
+    
+    /**
+     * Return the default database/datasource properties - These properties use
+     * an in-memory H2 database
+     * 
+     * This is used when the developer is somehow running the tests but
+     * bypassing the maven filtering that's been turned on in the pom.
+     * 
+     * @return Properties containing the default properties
+     */
+    private static Properties getDefaultProperties() {
+        if (defaultProperties == null) {
+            String[] keyArr = { "serverName", "portNumber", "databaseName", "url", "user", "password", "driverClassName",
+                    "className", "maxPoolSize", "allowLocalTransactions" };
+            String[] defaultPropArr = { "", "", "", "jdbc:h2:tcp://localhost/JPADroolsFlow", "sa", "", "org.h2.Driver",
+                    "bitronix.tm.resource.jdbc.lrc.LrcXADataSource", "16", "true" };
+            Assert.assertTrue("Unequal number of keys for default properties", keyArr.length == defaultPropArr.length);
+            defaultProperties = new Properties();
+            for (int i = 0; i < keyArr.length; ++i) {
+                defaultProperties.put(keyArr[i], defaultPropArr[i]);
+            }
+        }
+
+        return defaultProperties;
+    }
+
+    /**
+     * This reads in the (maven filtered) datasource properties from the test
+     * resource directory.
+     * 
+     * @return Properties containing the datasource properties.
+     */
+    public static Properties getDatasourceProperties() { 
+        String propertiesNotFoundMessage = "Unable to load datasource properties [" + DATASOURCE_PROPERTIES + "]";
+        boolean propertiesNotFound = false;
+
+        // Central place to set additional H2 properties
+        System.setProperty("h2.lobInDatabase", "true");
+        
+        InputStream propsInputStream = PersistenceUtil.class.getResourceAsStream(DATASOURCE_PROPERTIES);
+        assertNotNull(propertiesNotFoundMessage, propsInputStream);
+        Properties props = new Properties();
+        if (propsInputStream != null) {
+            try {
+                props.load(propsInputStream);
+            } catch (IOException ioe) {
+                propertiesNotFound = true;
+                logger.warn("Unable to find properties, using default H2 properties: " + ioe.getMessage());
+                ioe.printStackTrace();
+            }
+        } else {
+            propertiesNotFound = true;
+        }
+
+        String password = props.getProperty("password");
+        if ("${maven.jdbc.password}".equals(password) || propertiesNotFound) {
+            props = getDefaultProperties();
+        }
+
+        return props;
+    }
+
+    /**
+     * Reflection method when doing ugly hacks in tests.
+     * 
+     * @param fieldname
+     *            The name of the field to be retrieved.
+     * @param source
+     *            The object containing the field to be retrieved.
+     * @return The value (object instance) stored in the field requested from
+     *         the given source object.
+     */
+    public static Object getValueOfField(String fieldname, Object source) {
+        String sourceClassName = source.getClass().getSimpleName();
+    
+        Field field = null;
+        try {
+            field = source.getClass().getDeclaredField(fieldname);
+            field.setAccessible(true);
+        } catch (SecurityException e) {
+            fail("Unable to retrieve " + fieldname + " field from " + sourceClassName + ": " + e.getCause());
+        } catch (NoSuchFieldException e) {
+            fail("Unable to retrieve " + fieldname + " field from " + sourceClassName + ": " + e.getCause());
+        }
+    
+        assertNotNull("." + fieldname + " field is null!?!", field);
+        Object fieldValue = null;
+        try {
+            fieldValue = field.get(source);
+        } catch (IllegalArgumentException e) {
+            fail("Unable to retrieve value of " + fieldname + " from " + sourceClassName + ": " + e.getCause());
+        } catch (IllegalAccessException e) {
+            fail("Unable to retrieve value of " + fieldname + " from " + sourceClassName + ": " + e.getCause());
+        }
+        return fieldValue;
+    }
+
+    public static Environment createEnvironment(HashMap<String, Object> context) {
+        Environment env = EnvironmentFactory.newEnvironment();
+        
+        UserTransaction ut = (UserTransaction) context.get(TRANSACTION);
+        if( ut != null ) { 
+            env.set( TRANSACTION, ut);
+        }
+        
+        env.set( ENTITY_MANAGER_FACTORY, context.get(ENTITY_MANAGER_FACTORY) );
+        env.set( TRANSACTION_MANAGER, TransactionManagerServices.getTransactionManager() );
+        env.set( GLOBALS, new MapGlobalResolver() );
+        
+        return env;
+    }
+    
+   public static StatefulKnowledgeSession createKnowledgeSessionFromKBase(KnowledgeBase kbase, HashMap<String, Object> context) {
+       KieSessionConfiguration ksconf = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
+       StatefulKnowledgeSession knowledgeSession = InfinispanKnowledgeService.newStatefulKnowledgeSession(kbase, ksconf, createEnvironment(context));
+       return knowledgeSession;
+   }
+   
+   public static boolean testMarshalling() { 
+       return TEST_MARSHALLING;
+   }
+   
+}

--- a/jbpm-persistence-infinispan/src/test/resources/EventsProcess.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/EventsProcess.rf
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="TestProcess" id="org.drools.test.TestProcess" package-name="org.drools.test" >
+
+  <header>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" />
+    <workItem id="2" name="WorkItem1" >
+      <work name="MyWork" >
+      </work>
+    </workItem>
+    <eventNode id="3" name="Message" >
+      <eventFilters>
+        <eventFilter type="eventType" eventType="MyEvent1" />
+      </eventFilters>
+    </eventNode>
+    <actionNode id="4" name="Action1" >
+        <action type="expression" dialect="java" >System.out.println("Executed action1");</action>
+    </actionNode>
+    <eventNode id="5" name="Message" >
+      <eventFilters>
+        <eventFilter type="eventType" eventType="MyEvent2" />
+      </eventFilters>
+    </eventNode>
+    <actionNode id="6" name="Action2" >
+        <action type="expression" dialect="java" >System.out.println("Executed action2");</action>
+    </actionNode>
+    <join id="7" name="AND" type="1" />
+    <end id="8" name="End" />
+  </nodes>
+
+  <connections>
+    <connection from="1" to="2" />
+    <connection from="2" to="7" />
+    <connection from="3" to="4" />
+    <connection from="4" to="7" />
+    <connection from="5" to="6" />
+    <connection from="6" to="7" />
+    <connection from="7" to="8" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/META-INF/MyWorkItemHandlers.conf
+++ b/jbpm-persistence-infinispan/src/test/resources/META-INF/MyWorkItemHandlers.conf
@@ -1,0 +1,12 @@
+// We use MVEL to return a List of work definitions
+// The properties of the work definitions are specified as a Map<String, Object>
+// The allowed properties are name, parameters, displayName, icon and customEditor
+// The returned result should thus be of type List<Map<String, Object>>
+import org.jbpm.persistence.session.objects.TestWorkItemHandler;
+
+[
+
+  "MyWork" : TestWorkItemHandler.getInstance(),
+  "Human Task" : TestWorkItemHandler.getInstance()
+      
+]

--- a/jbpm-persistence-infinispan/src/test/resources/META-INF/drools.session.conf
+++ b/jbpm-persistence-infinispan/src/test/resources/META-INF/drools.session.conf
@@ -1,0 +1,3 @@
+drools.workItemHandlers = MyWorkItemHandlers.conf
+drools.processInstanceManagerFactory=org.jbpm.persistence.processinstance.InfinispanProcessInstanceManagerFactory
+drools.processSignalManagerFactory=org.jbpm.persistence.processinstance.InfinispanSignalManagerFactory

--- a/jbpm-persistence-infinispan/src/test/resources/RuleSetProcess.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/RuleSetProcess.rf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="ruleflow" id="org.drools.test.TestProcess" package-name="org.drools.test" >
+
+  <header>
+    <imports>
+      <import name="java.util.List" />
+    </imports>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" />
+    <ruleSet id="2" name="RuleSet" ruleFlowGroup="group1" />
+    <end id="3" name="End" />
+  </nodes>
+
+  <connections>
+    <connection from="1" to="2" />
+    <connection from="2" to="3" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/RuleSetRules.drl
+++ b/jbpm-persistence-infinispan/src/test/resources/RuleSetRules.drl
@@ -1,0 +1,10 @@
+package org.drools.test
+
+import java.util.List
+
+rule SimpleRule
+  when
+    l: List()
+  then
+    System.out.println("Found list " + l);
+end

--- a/jbpm-persistence-infinispan/src/test/resources/SimpleProcess.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/SimpleProcess.rf
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="ruleflow" id="org.jbpm.persistence.TestProcess" package-name="org.jbpm.persistence" >
+
+  <header>
+    <imports>
+      <import name="java.util.List" />
+    </imports>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" />
+    <state id="2" name="State" >
+      <constraints>
+        <constraint toNodeId="3" name="constraint" priority="1" >List()</constraint>
+      </constraints>
+    </state>
+    <end id="3" name="End" />
+  </nodes>
+
+  <connections>
+    <connection from="1" to="2" />
+    <connection from="2" to="3" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/StateProcess.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/StateProcess.rf
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="ruleflow" id="org.drools.test.TestProcess" package-name="org.drools.test" >
+
+  <header>
+    <imports>
+      <import name="java.util.List" />
+    </imports>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" />
+    <state id="2" name="State" >
+      <constraints>
+        <constraint toNodeId="3" name="constraint" priority="1" >List()</constraint>
+      </constraints>
+    </state>
+    <end id="3" name="End" />
+  </nodes>
+
+  <connections>
+    <connection from="1" to="2" />
+    <connection from="2" to="3" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/SubProcess.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/SubProcess.rf
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="SubProcess" id="com.sample.SubProcess" package-name="com.sample" >
+
+  <header>
+  </header>
+
+  <nodes>
+    <humanTask id="6" name="Task2" x="128" y="16" width="80" height="40" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+          <value>admin</value>
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+          <value>You need to do task 2 !</value>
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+          <value></value>
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+          <value>0</value>
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+          <value>false</value>
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+          <value>Task2</value>
+        </parameter>
+      </work>
+    </humanTask>
+    <start id="1" name="Start" x="16" y="16" width="80" height="40" />
+    <end id="3" name="End" x="240" y="16" width="80" height="40" />
+  </nodes>
+
+  <connections>
+    <connection from="1" to="6" />
+    <connection from="6" to="3" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/SuperProcess.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/SuperProcess.rf
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="SuperProcess" id="com.sample.SuperProcess" package-name="com.sample" >
+
+  <header>
+  </header>
+
+  <nodes>
+    <humanTask id="6" name="Task1" x="240" y="16" width="80" height="40" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+          <value>admin</value>
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+          <value>You need to do task 1 !</value>
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+          <value></value>
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+          <value>0</value>
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+          <value>false</value>
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+          <value>Task1</value>
+        </parameter>
+      </work>
+    </humanTask>
+    <start id="1" name="Start" x="16" y="52" width="80" height="40" />
+    <end id="3" name="End" x="576" y="52" width="80" height="40" />
+    <subProcess id="7" name="Flow" x="464" y="52" width="80" height="40" processId="com.sample.SubProcess" >
+    </subProcess>
+  </nodes>
+
+  <connections>
+    <connection from="1" to="6" />
+    <connection from="6" to="7" />
+    <connection from="7" to="3" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/TimerProcess.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/TimerProcess.rf
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="ruleflow" id="org.drools.test.TestProcess" package-name="org.drools.test" >
+
+  <header>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" />
+    <humanTask id="2" name="User Task" >
+      <work name="Human Task" >
+      </work>
+      <timers>
+        <timer id="1" delay="1000" >
+        <action type="expression" dialect="java" >System.out.println("Timer triggered");
+((org.jbpm.process.instance.ProcessInstance) kcontext.getProcessInstance()).setState(org.jbpm.runtime.process.ProcessInstance.STATE_ABORTED);</action>
+        </timer>
+      </timers>
+    </humanTask>
+    <end id="3" name="End" />
+  </nodes>
+
+  <connections>
+    <connection from="1" to="2" />
+    <connection from="2" to="3" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/VPSProcessWithWorkItems.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/VPSProcessWithWorkItems.rf
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="droolsflow" id="com.sample.ruleflow" package-name="com.sample" >
+
+  <header>
+    <imports>
+      <import name="org.jbpm.persistence.session.objects.MyEntity" />
+      <import name="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      <import name="org.infinispan.Cache" />
+      <import name="org.kie.api.runtime.EnvironmentName" />
+    </imports>
+    <variables>
+      <variable name="x" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+      </variable>
+      <variable name="y" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyEntity" />
+      </variable>
+      <variable name="z" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      </variable>
+      <variable name="a" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+      </variable>
+      <variable name="b" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyEntity" />
+      </variable>
+      <variable name="c" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      </variable>
+    </variables>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" x="16" y="16" width="48" height="48" />
+    <end id="3" name="End" x="957" y="16" width="48" height="48" />
+    <humanTask id="4" name="Human Task" x="208" y="16" width="93" height="48" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+      </work>
+      <mapping type="in" from="x" to="equis" />
+      <mapping type="in" from="z" to="zeta" />
+      <mapping type="out" from="equis" to="x" />
+      <mapping type="out" from="zeta" to="z" />
+    </humanTask>
+    <actionNode id="5" name="Action" x="96" y="20" width="80" height="40" >
+        <action type="expression" dialect="java" >System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);</action>
+    </actionNode>
+    <actionNode id="6" name="Action" x="333" y="20" width="80" height="40" >
+        <action type="expression" dialect="java" >System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);
+Cache cache = (Cache) kcontext.getKnowledgeRuntime().getEnvironment().get(EnvironmentName.APP_SCOPED_ENTITY_MANAGER);
+MyEntity myNewEntity = new MyEntity("This is a new test Entity");
+myNewEntity.setId(Long.valueOf(""+kcontext.getProcessInstance().getId()+"1"));
+cache.put("myEntity"+kcontext.getProcessInstance().getId()+"1", myNewEntity);
+kcontext.setVariable("a", "Some new String");
+kcontext.setVariable("b",myNewEntity );
+kcontext.setVariable("c", new MyVariableSerializable("This is a new test SerializableObject"));</action>
+    </actionNode>
+    <humanTask id="7" name="Human Task" x="445" y="20" width="124" height="40" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+      </work>
+      <mapping type="in" from="x" to="equis" />
+      <mapping type="in" from="z" to="zeta" />
+      <mapping type="out" from="equis" to="x" />
+      <mapping type="out" from="zeta" to="z" />
+    </humanTask>
+    <actionNode id="8" name="Action" x="601" y="20" width="80" height="40" >
+        <action type="expression" dialect="java" >System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);
+System.out.println("a = " + a);
+System.out.println("b = " + b);
+System.out.println("c = " + c);
+kcontext.setVariable("a", "Some changed String");
+Cache cache = (Cache) kcontext.getKnowledgeRuntime().getEnvironment().get(EnvironmentName.APP_SCOPED_ENTITY_MANAGER);
+MyEntity myNewEntity = new MyEntity("This is a changed test Entity");
+myNewEntity.setId(Long.valueOf(""+kcontext.getProcessInstance().getId()+"2"));
+cache.put("myEntity"+kcontext.getProcessInstance().getId()+"2", myNewEntity);
+kcontext.setVariable("b",myNewEntity );
+kcontext.setVariable("c", new MyVariableSerializable("This is a changed test SerializableObject"));</action>
+    </actionNode>
+    <humanTask id="9" name="Human Task" x="713" y="16" width="100" height="48" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+       
+      </work>
+       <mapping type="in" from="x" to="equis" />
+      <mapping type="in" from="z" to="zeta" />
+      <mapping type="out" from="equis" to="x" />
+      <mapping type="out" from="zeta" to="z" />
+    </humanTask>
+    <actionNode id="10" name="Action" x="845" y="16" width="80" height="48" >
+        <action type="expression" dialect="java" >System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);
+System.out.println("a = " + a);
+System.out.println("b = " + b);
+System.out.println("c = " + c);</action>
+    </actionNode>
+  </nodes>
+
+  <connections>
+    <connection from="10" to="3" />
+    <connection from="5" to="4" />
+    <connection from="1" to="5" />
+    <connection from="4" to="6" />
+    <connection from="6" to="7" />
+    <connection from="7" to="8" />
+    <connection from="8" to="9" />
+    <connection from="9" to="10" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/VariablePersistenceStrategyProcess.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/VariablePersistenceStrategyProcess.rf
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="ruleflow" id="com.sample.ruleflow" package-name="com.sample" >
+
+  <header>
+    <imports>
+      <import name="org.jbpm.persistence.session.objects.MyEntity" />
+      <import name="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      <import name="org.infinispan.Cache" />
+      <import name="org.kie.api.runtime.EnvironmentName" />
+    </imports>
+    <variables>
+      <variable name="x" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value></value>
+      </variable>
+      <variable name="y" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyEntity" />
+      </variable>
+      <variable name="z" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      </variable>
+      <variable name="a" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value></value>
+      </variable>
+      <variable name="b" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyEntity" />
+      </variable>
+      <variable name="c" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      </variable>
+    </variables>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" x="16" y="16" width="48" height="48" />
+    <end id="3" name="End" x="669" y="16" width="48" height="48" />
+    <humanTask id="4" name="Human Task" x="208" y="16" width="93" height="48" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+      </work>
+    </humanTask>
+    <actionNode id="5" name="Action" x="96" y="20" width="80" height="40" >
+        <action type="expression" dialect="java" >System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);</action>
+    </actionNode>
+    <actionNode id="6" name="Action" x="333" y="20" width="80" height="40" >
+        <action type="expression" dialect="java" >System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);
+kcontext.setVariable("a", "Some new String");
+Cache cache = (Cache) kcontext.getKnowledgeRuntime().getEnvironment().get(EnvironmentName.APP_SCOPED_ENTITY_MANAGER);
+MyEntity myNewEntity = new MyEntity("This is a new test Entity");
+myNewEntity.setId(Long.valueOf(""+kcontext.getProcessInstance().getId()+"1"));
+cache.put("myEntity"+ kcontext.getProcessInstance().getId() + "1", myNewEntity);
+kcontext.setVariable("b", myNewEntity);
+kcontext.setVariable("c", new MyVariableSerializable("This is a new test SerializableObject"));</action>
+    </actionNode>
+    <humanTask id="7" name="Human Task" x="445" y="20" width="80" height="40" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+      </work>
+    </humanTask>
+    <actionNode id="8" name="Action" x="557" y="20" width="80" height="40" >
+        <action type="expression" dialect="java" >System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);
+System.out.println("a = " + a);
+System.out.println("b = " + b);
+System.out.println("c = " + c);
+kcontext.setVariable("a", "Some changed String");
+Cache cache = (Cache)kcontext.getKnowledgeRuntime().getEnvironment().get(EnvironmentName.APP_SCOPED_ENTITY_MANAGER);
+MyEntity myNewEntity = new MyEntity("This is a changed test Entity");
+myNewEntity.setId(Long.valueOf(""+kcontext.getProcessInstance().getId()+"2"));
+cache.put("myEntity" + kcontext.getProcessInstance().getId() + "2", myNewEntity);
+kcontext.setVariable("b", myNewEntity);
+kcontext.setVariable("c", new MyVariableSerializable("This is a changed test SerializableObject"));</action>
+    </actionNode>
+    <humanTask id="9" name="Human Task" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+      </work>
+    </humanTask>
+    <actionNode id="10" name="Action" >
+        <action type="expression" dialect="java" >System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);
+System.out.println("a = " + a);
+System.out.println("b = " + b);
+System.out.println("c = " + c);</action>
+    </actionNode>
+  </nodes>
+
+  <connections>
+    <connection from="10" to="3" />
+    <connection from="5" to="4" />
+    <connection from="1" to="5" />
+    <connection from="4" to="6" />
+    <connection from="6" to="7" />
+    <connection from="7" to="8" />
+    <connection from="8" to="9" />
+    <connection from="9" to="10" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/VariablePersistenceStrategyProcessTypeChange.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/VariablePersistenceStrategyProcessTypeChange.rf
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="ruleflow" id="com.sample.ruleflow" package-name="com.sample" >
+
+  <header>
+    <imports>
+      <import name="org.jbpm.persistence.session.objects.MyEntity" />
+      <import name="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      <import name="org.infinispan.Cache" />
+      <import name="org.kie.api.runtime.EnvironmentName" />
+    </imports>
+    <variables>
+      <variable name="x" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value></value>
+      </variable>
+      <variable name="y" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyEntity" />
+      </variable>
+      <variable name="z" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      </variable>
+      <variable name="a" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value></value>
+      </variable>
+      <variable name="b" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyEntity" />
+      </variable>
+      <variable name="c" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      </variable>
+    </variables>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" x="16" y="16" width="48" height="48" />
+    <end id="3" name="End" x="669" y="16" width="48" height="48" />
+    <actionNode id="6" name="Action" x="333" y="20" width="80" height="40" >
+        <action type="expression" dialect="java" >System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);
+System.out.println("a = " + a);
+System.out.println("b = " + b);
+System.out.println("c = " + c);
+kcontext.setVariable("a", "Some new String");
+Cache cache = (Cache)kcontext.getKnowledgeRuntime().getEnvironment().get(EnvironmentName.APP_SCOPED_ENTITY_MANAGER);
+MyEntity myNewEntity = new MyEntity("This is a new test Entity");
+cache.put("myEntity"+kcontext.getProcessInstance().getId() +"_1", myNewEntity);
+kcontext.setVariable("b", myNewEntity);
+kcontext.setVariable("c", new MyVariableSerializable("This is a new test SerializableObject"));</action>
+    </actionNode>
+    <humanTask id="7" name="Human Task" x="445" y="20" width="80" height="40" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+      </work>
+    </humanTask>
+    <actionNode id="8" name="Action" x="557" y="20" width="80" height="40" >
+        <action type="expression" dialect="java" >System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);
+System.out.println("a = " + a);
+System.out.println("b = " + b);
+System.out.println("c = " + c);
+kcontext.setVariable("a", "Some changed String");
+Cache cache = (Cache)kcontext.getKnowledgeRuntime().getEnvironment().get(EnvironmentName.APP_SCOPED_ENTITY_MANAGER);
+MyEntity myNewEntity = new MyEntity("This is a changed test Entity");
+cache.put("myEntity"+kcontext.getProcessInstance().getId()+"_2", myNewEntity);
+kcontext.setVariable("b", myNewEntity);
+kcontext.setVariable("c", new MyVariableSerializable("This is a changed test SerializableObject"));</action>
+    </actionNode>
+    <humanTask id="9" name="Human Task" x="445" y="20" width="80" height="40" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+      </work>
+    </humanTask>
+    <actionNode id="10" name="Action" x="557" y="20" width="80" height="40" >
+        <action type="expression" dialect="java" >System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);
+System.out.println("a = " + a);
+System.out.println("b = " + b);
+System.out.println("c = " + c);
+        </action>
+    </actionNode>
+  </nodes>
+
+  <connections>
+    <connection from="8" to="9" />
+    <connection from="9" to="10" />
+    <connection from="10" to="3" />
+    <connection from="1" to="6" />
+    <connection from="6" to="7" />
+    <connection from="7" to="8" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/VariablePersistenceStrategySubProcess.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/VariablePersistenceStrategySubProcess.rf
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="ruleflow" id="com.sample.ruleflow" package-name="com.sample" >
+
+  <header>
+    <imports>
+      <import name="org.jbpm.persistence.session.objects.MyEntity" />
+      <import name="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      <import name="org.infinispan.Cache" />
+      <import name="org.kie.api.runtime.EnvironmentName" />
+    </imports>
+    <variables>
+      <variable name="x" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+      </variable>
+      <variable name="y" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyEntity" />
+      </variable>
+      <variable name="z" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      </variable>
+      <variable name="v" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value>Default</value>
+      </variable>
+    </variables>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" x="16" y="16" width="48" height="48" />
+    <end id="3" name="End" x="669" y="16" width="48" height="48" />
+    <composite id="4" name="CompositeNode" x="187" y="33" width="326" height="327" >
+    <variables>
+      <variable name="y" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyEntity" />
+      </variable>
+      <variable name="z" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      </variable>
+      <variable name="x" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value></value>
+      </variable>
+      <variable name="w" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value>New default</value>
+      </variable>
+    </variables>
+      <nodes>
+    <actionNode id="1" name="Action" x="31" y="62" >
+        <action type="expression" dialect="java" >
+        kcontext.setVariable("x", "new String");
+        Cache cache = (Cache)kcontext.getKnowledgeRuntime().getEnvironment().get(EnvironmentName.APP_SCOPED_ENTITY_MANAGER);
+        MyEntity newEntity = new MyEntity("This is a new test Entity");
+        cache.put("myEntity" + kcontext.getProcessInstance().getId(), newEntity);
+        kcontext.setVariable("y", newEntity);
+        MyVariableSerializable newSerializable = new MyVariableSerializable("This is a new test SerializableObject");
+        kcontext.setVariable("z", newSerializable);
+        
+        </action>
+    </actionNode>
+    <humanTask id="2" name="Human Task" x="122" y="61" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+      </work>
+    </humanTask>
+    <actionNode id="3" name="Action" x="211" y="61" >
+        <action type="expression" dialect="java" >System.out.println("v = " + v);
+System.out.println("w = " + w);
+System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);</action>
+    </actionNode>
+    <composite id="7" name="CompositeNode" x="26" y="136" width="273" height="173" >
+    <variables>
+      <variable name="a" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value>Newest Default 1</value>
+      </variable>
+      <variable name="z" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value>Newest Default 2</value>
+      </variable>
+    </variables>
+      <nodes>
+    <actionNode id="1" name="Action" x="18" y="55" >
+        <action type="expression" dialect="java" >System.out.println("a = " + a);
+System.out.println("v = " + v);
+System.out.println("w = " + w);
+System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);</action>
+    </actionNode>
+    <humanTask id="2" name="Human Task" x="140" y="40" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+      </work>
+    </humanTask>
+    <actionNode id="3" name="Action" x="163" y="112" >
+        <action type="expression" dialect="java" >System.out.println("a = " + a);
+System.out.println("v = " + v);
+System.out.println("w = " + w);
+System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);</action>
+    </actionNode>
+      </nodes>
+      <connections>
+    <connection from="1" to="2" />
+    <connection from="2" to="3" />
+      </connections>
+      <in-ports>
+        <in-port type="DROOLS_DEFAULT" nodeId="1" nodeInType="DROOLS_DEFAULT" />
+      </in-ports>
+      <out-ports>
+        <out-port type="DROOLS_DEFAULT" nodeId="3" nodeOutType="DROOLS_DEFAULT" />
+      </out-ports>
+    </composite>
+      </nodes>
+      <connections>
+    <connection from="1" to="2" />
+    <connection from="2" to="3" />
+    <connection from="3" to="7" />
+      </connections>
+      <in-ports>
+        <in-port type="DROOLS_DEFAULT" nodeId="1" nodeInType="DROOLS_DEFAULT" />
+      </in-ports>
+      <out-ports>
+        <out-port type="DROOLS_DEFAULT" nodeId="7" nodeOutType="DROOLS_DEFAULT" />
+      </out-ports>
+    </composite>
+    <actionNode id="5" name="Action" x="547" y="50" width="80" height="48" >
+        <action type="expression" dialect="mvel" >System.out.println("v = " + v);
+System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);</action>
+    </actionNode>
+    <humanTask id="6" name="Human Task" >
+      <work name="Human Task" >
+        <parameter name="ActorId" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Comment" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Content" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Priority" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="Skippable" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+        <parameter name="TaskName" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </parameter>
+      </work>
+    </humanTask>
+    <actionNode id="7" name="Action" >
+        <action type="expression" dialect="mvel" >System.out.println("v = " + v);
+System.out.println("x = " + x);
+System.out.println("y = " + y);
+System.out.println("z = " + z);</action>
+    </actionNode>
+  </nodes>
+
+  <connections>
+    <connection from="7" to="3" />
+    <connection from="1" to="4" />
+    <connection from="4" to="5" />
+    <connection from="5" to="6" />
+    <connection from="6" to="7" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/VariablesProcess.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/VariablesProcess.rf
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="TestProcess" id="org.drools.test.TestProcess" package-name="org.drools.test" >
+
+  <header>
+    <variables>
+      <variable name="name" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value>xxx</value>
+      </variable>
+    </variables>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" />
+    <actionNode id="2" name="Action" >
+        <action type="expression" dialect="java" >System.out.println("Executing for " + name);</action>
+    </actionNode>
+    <workItem id="3" name="WorkItem1" >
+      <work name="MyWork" >
+      </work>
+      <mapping type="in" from="name" to="name" />
+    </workItem>
+    <actionNode id="4" name="Action" >
+        <action type="expression" dialect="java" >System.out.println("Executing for " + name);</action>
+    </actionNode>
+    <composite id="5" name="CompositeNode" >
+      <variables>
+        <variable name="text" >
+          <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        </variable>
+      </variables>
+      <nodes>
+        <actionNode id="1" name="Action" >
+          <action type="expression" dialect="mvel" >kcontext.setVariable("text", name);</action>
+        </actionNode>
+        <workItem id="2" name="Log" x="130" y="46" width="80" height="40" >
+          <work name="MyWork" >
+            <parameter name="Message" >
+              <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+            </parameter>
+          </work>
+          <mapping type="in" from="text" to="text" />
+        </workItem>
+        <actionNode id="3" name="Action" x="129" y="109" >
+          <action type="expression" dialect="mvel" >System.out.println("Subprocess " + text);</action>
+        </actionNode>
+      </nodes>
+      <connections>
+        <connection from="1" to="2" />
+        <connection from="2" to="3" />
+      </connections>
+      <in-ports>
+        <in-port type="DROOLS_DEFAULT" nodeId="1" nodeInType="DROOLS_DEFAULT" />
+      </in-ports>
+      <out-ports>
+        <out-port type="DROOLS_DEFAULT" nodeId="3" nodeOutType="DROOLS_DEFAULT" />
+      </out-ports>
+    </composite>
+    <end id="6" name="End" />
+  </nodes>
+
+  <connections>
+    <connection from="1" to="2" />
+    <connection from="2" to="3" />
+    <connection from="3" to="4" />
+    <connection from="4" to="5" />
+    <connection from="5" to="6" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/WorkItemsProcess.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/WorkItemsProcess.rf
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="TestProcess" id="org.drools.test.TestProcess" package-name="org.drools.test" >
+
+  <header>
+  </header>
+
+  <nodes>
+    <actionNode id="2" name="Action" >
+        <action type="expression" dialect="java" >System.out.println("Executed action");</action>
+    </actionNode>
+    <workItem id="4" name="WorkItem2" >
+      <work name="MyWork" >
+      </work>
+    </workItem>
+    <end id="6" name="End" />
+    <start id="1" name="Start" />
+    <workItem id="3" name="WorkItem1" >
+      <work name="MyWork" >
+      </work>
+    </workItem>
+    <workItem id="5" name="WorkItem3" >
+      <work name="MyWork" >
+      </work>
+    </workItem>
+  </nodes>
+
+  <connections>
+    <connection from="1" to="2" />
+    <connection from="3" to="4" />
+    <connection from="5" to="6" />
+    <connection from="2" to="3" />
+    <connection from="4" to="5" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/jndi.properties
+++ b/jbpm-persistence-infinispan/src/test/resources/jndi.properties
@@ -1,0 +1,1 @@
+java.naming.factory.initial=bitronix.tm.jndi.BitronixInitialContextFactory

--- a/jbpm-persistence-infinispan/src/test/resources/log4j.xml
+++ b/jbpm-persistence-infinispan/src/test/resources/log4j.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<param name="Target" value="System.out"/>
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%d{dd/MM HH:mm:ss,SSS} %-5p %c{1}.%M - %m%n"/>
+		</layout>
+	</appender>
+
+    <logger name="org.jbpm.persistence">
+		<level value="INFO"/>
+	</logger>
+	
+    <!-- bitronix -->	
+    <logger name="bitronix.tm">
+        <level value="ERROR"/>
+	</logger>
+	
+    <logger name="org.hibernate.tool.hbm2ddl">
+        <level value="WARN"/>
+    </logger>
+    <logger name="org.hibernate.hql.internal">
+        <level value="WARN"/>
+    </logger>
+    <logger name="org.hibernate.engine.jdbc.internal">
+        <level value="WARN"/>
+    </logger>
+
+	<root>
+		<priority value="INFO"/>
+		<appender-ref ref="CONSOLE"/>
+	</root>
+</log4j:configuration>

--- a/jbpm-persistence-infinispan/src/test/resources/marshalling/.gitignore
+++ b/jbpm-persistence-infinispan/src/test/resources/marshalling/.gitignore
@@ -1,0 +1,2 @@
+/testData.*
+/baseData\.*.db

--- a/jbpm-persistence-infinispan/src/test/resources/processinstance/HelloWorld.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/processinstance/HelloWorld.rf
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="Hello World process" id="org.jbpm.processinstance.helloworld" package-name="org.jbpm.processinstance" >
+
+  <header>
+    <variables>
+      <variable name="name" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value></value>
+      </variable>
+      <variable name="var" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+      </variable>
+    </variables>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" x="16" y="16" width="48" height="48" />
+    <end id="2" name="End" x="208" y="16" width="48" height="48" />
+    <actionNode id="3" name="Script" x="96" y="16" width="80" height="48" >
+        <action type="expression" dialect="java" >System.out.println("Hello world from " + name + "!");</action>
+    </actionNode>
+  </nodes>
+
+  <connections>
+    <connection from="3" to="2" />
+    <connection from="1" to="3" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/processinstance/Subprocess.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/processinstance/Subprocess.rf
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="Subprocess test" id="org.jbpm.processinstance.subprocess" package-name="org.jbpm.processinstance" >
+
+  <header>
+    <variables>
+      <variable name="var" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value></value>
+      </variable>
+      <variable name="type" >
+        <type name="org.drools.core.process.core.datatype.impl.type.StringDataType" />
+        <value></value>
+      </variable>
+    </variables>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" x="12" y="108" width="48" height="48" />
+    <split id="2" name="Gateway" x="108" y="108" width="49" height="49" type="2" >
+      <constraints>
+        <constraint toNodeId="5" toType="DROOLS_DEFAULT" name="default" priority="10" type="rule" dialect="mvel" >eval(true)</constraint>
+        <constraint toNodeId="4" toType="DROOLS_DEFAULT" name="script" priority="1" type="code" dialect="java" >return "script".equals(type);</constraint>
+        <constraint toNodeId="3" toType="DROOLS_DEFAULT" name="event" priority="1" type="code" dialect="java" >return "event".equals(type);</constraint>
+      </constraints>
+    </split>
+    <join id="3" name="event" x="252" y="12" width="49" height="49" type="1" />
+    <actionNode id="4" name="Change variable" x="204" y="204" width="145" height="49" >
+        <action type="expression" dialect="java" >kcontext.setVariable("var", "Somebody");</action>
+    </actionNode>
+    <join id="5" name="Gateway" x="396" y="108" width="49" height="49" type="2" />
+    <subProcess id="6" name="Sub-Process" x="492" y="108" width="110" height="48" processId="org.jbpm.processinstance.helloworld" >
+      <mapping type="in" from="var" to="name" />
+    </subProcess>
+    <end id="7" name="End" x="648" y="108" width="48" height="48" />
+    <eventNode id="8" name="Signal" x="108" y="12" width="48" height="48" variableName="var" scope="external" >
+      <eventFilters>
+        <eventFilter type="eventType" eventType="pass" />
+      </eventFilters>
+    </eventNode>
+  </nodes>
+
+  <connections>
+    <connection from="1" to="2" />
+    <connection from="2" to="3" />
+    <connection from="8" to="3" />
+    <connection from="2" to="4" />
+    <connection from="2" to="5" />
+    <connection from="3" to="5" />
+    <connection from="4" to="5" />
+    <connection from="5" to="6" />
+    <connection from="6" to="7" />
+  </connections>
+
+</process>

--- a/jbpm-persistence-infinispan/src/test/resources/testVariables.rf
+++ b/jbpm-persistence-infinispan/src/test/resources/testVariables.rf
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<process xmlns="http://drools.org/drools-5.0/process"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+         xs:schemaLocation="http://drools.org/drools-5.0/process drools-processes-5.0.xsd"
+         type="RuleFlow" name="flow" id="testVariables" package-name="org.drools.examples" >
+
+  <header>
+    <variables>
+      <variable name="var1" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyEntity" />
+      </variable>
+      <variable name="var2" >
+        <type name="org.drools.core.process.core.datatype.impl.type.ObjectDataType" className="org.jbpm.persistence.session.objects.MyVariableSerializable" />
+      </variable>
+    </variables>
+  </header>
+
+  <nodes>
+    <start id="1" name="Start" x="147" y="32" width="80" height="40" />
+ 
+    <workItem id="2" name="Log1" x="147" y="191" width="80" height="40" >
+      <work name="Log" >
+       
+      </work>
+      <mapping type="in" from="var1" to="var1" />
+      <mapping type="in" from="var2" to="var2" />
+      <mapping type="out" from="var1" to="var1" />
+      <mapping type="out" from="var2" to="var2" />
+    </workItem>
+    <actionNode id="3" name="Action1" x="146" y="117" width="80" height="40" >
+        <action type="expression" dialect="mvel" >
+            System.out.println("Variable Value: "+kcontext.getVariable("var1"));
+            System.out.println("Variable Value: "+kcontext.getVariable("var2"));
+        </action>
+    </actionNode>
+    <actionNode id="4" name="Action2" x="147" y="268" width="80" height="40" >
+        <action type="expression" dialect="mvel" >
+            System.out.println("Variable Value: "+kcontext.getVariable("var1"));
+            System.out.println("Variable Value: "+kcontext.getVariable("var2"));
+        </action>
+    </actionNode>
+    <workItem id="5" name="Log2" x="146" y="345" width="80" height="40" >
+      <work name="Log" >
+      
+      </work>
+     <mapping type="in" from="var1" to="var1" />
+      <mapping type="in" from="var2" to="var2" />
+      <mapping type="out" from="var1" to="var1" />
+      <mapping type="out" from="var2" to="var2" />
+    </workItem>
+    <actionNode id="6" name="Action3" x="144" y="422" width="80" height="40" >
+        <action type="expression" dialect="mvel" >
+            System.out.println("Variable Value: "+kcontext.getVariable("var1"));
+            System.out.println("Variable Value: "+kcontext.getVariable("var2"));
+        </action>
+    </actionNode>
+    <workItem id="7" name="Log3" x="146" y="345" width="80" height="40" >
+      <work name="Log" >
+        
+      </work>
+      <mapping type="in" from="var1" to="var1" />
+      <mapping type="in" from="var2" to="var2" />
+      <mapping type="out" from="var1" to="var1" />
+      <mapping type="out" from="var2" to="var2" />
+    </workItem>
+    <end id="8" name="End" x="145" y="494" width="80" height="40" />
+  </nodes>
+
+  <connections>
+    <connection from="3" to="2" />
+    <connection from="1" to="3" />
+    <connection from="2" to="4" />
+    <connection from="4" to="5" />
+    <connection from="5" to="6" />
+    <connection from="6" to="7" />
+    <connection from="7" to="8" />
+  </connections>
+
+</process>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <module>jbpm-flow</module>
     <module>jbpm-flow-builder</module>
     <module>jbpm-persistence-jpa</module>
+    <module>jbpm-persistence-infinispan</module>
     <module>jbpm-audit</module>
     <module>jbpm-bpmn2</module>
     <module>jbpm-bpmn2-emfextmodel</module>


### PR DESCRIPTION
I’ve worked on an infinispan based persistence scheme for drools objects.
The whole idea is to give both a possibility for Infinispan users to have a way to persist these contents in something different than JPA, as well as to give an example of how to build your own persistence scheme for drools and jbpm objects.
