### PR TITLE
JBPM-4069 XmlBPMNProcessDumper.dump() misses conditionExpression in sequ...

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/XMLBPMNProcessDumperTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/XMLBPMNProcessDumperTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2010 JBoss Inc
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.bpmn2;
+
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.Difference;
+import org.custommonkey.xmlunit.DifferenceListener;
+import org.jbpm.bpmn2.xml.XmlBPMNProcessDumper;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.definition.process.WorkflowProcess;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Node;
+
+public class XMLBPMNProcessDumperTest extends JbpmBpmn2TestCase {
+    
+    private static final Logger logger = LoggerFactory.getLogger(XMLBPMNProcessDumperTest.class);
+    
+    public XMLBPMNProcessDumperTest() {
+        super(false);
+    }
+
+    /**
+     * TESTS
+     */
+
+    @Test
+    public void testConditionExpression() throws Exception {
+        // JBPM-4069 : XmlBPMNProcessDumper.dump() misses conditionExpression in sequenceFlow
+        String filename = "JBPM-4069_Gateway.bpmn2";
+        String original = BPMN2XMLTest.slurp(XMLBPMNProcessDumperTest.class.getResourceAsStream("/" + filename));
+        
+        KieBase kbase = createKnowledgeBase(filename);
+        WorkflowProcess process = (WorkflowProcess)kbase.getProcess("GatewayTest");
+        String result = XmlBPMNProcessDumper.INSTANCE.dump(process, XmlBPMNProcessDumper.META_DATA_USING_DI);
+        
+        // Compare original with result using XMLUnit
+        Diff diff = new Diff(original, result);
+        
+        diff.overrideDifferenceListener(new DifferenceListener() {
+            
+            public int differenceFound(Difference diff) {
+                String nodeName = diff.getTestNodeDetail().getNode().getNodeName();
+                
+                if (nodeName.equals("conditionExpression") || nodeName.equals("language")) {
+                    logger.info(diff.toString());
+                    return RETURN_ACCEPT_DIFFERENCE;
+                }
+                
+                return RETURN_IGNORE_DIFFERENCE_NODES_IDENTICAL;
+            }
+
+            @Override
+            public void skippedComparison(Node one, Node two) { 
+                logger.info("{} : {}", one.getLocalName(), two.getLocalName()) ;
+            }
+            
+        });
+        
+        assertTrue("Original and generated output is not the same.", diff.identical());
+   }
+
+}

--- a/jbpm-bpmn2/src/test/resources/JBPM-4069_Gateway.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/JBPM-4069_Gateway.bpmn2
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<definitions id="Definition"
+             targetNamespace="http://www.jboss.org/drools"
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:g="http://www.jboss.org/drools/flow/gpd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <process processType="Private" isExecutable="true" id="GatewayTest" name="GatewayTest" >
+
+    <!-- nodes -->
+    <startEvent id="_1" name="StartProcess" />
+    <endEvent id="_3" name="EndProcess" >
+        <terminateEventDefinition />
+    </endEvent>
+    <exclusiveGateway id="_4" name="Gateway" gatewayDirection="Diverging" />
+    <scriptTask id="_5" name="Script1" scriptFormat="http://www.java.com/java" >
+      <script>System.out.println("Script1 executed");</script>
+    </scriptTask>
+    <scriptTask id="_6" name="Script2" scriptFormat="http://www.java.com/java" >
+      <script>System.out.println("Script2 executed");</script>
+    </scriptTask>
+    <exclusiveGateway id="_7" name="Gateway" gatewayDirection="Converging" />
+    <exclusiveGateway id="_8" name="Gateway" gatewayDirection="Diverging" />
+    <scriptTask id="_9" name="Script3" scriptFormat="http://www.java.com/java" >
+      <script>System.out.println("Script3 executed");</script>
+    </scriptTask>
+    <scriptTask id="_10" name="Script4" scriptFormat="http://www.java.com/java" >
+      <script>System.out.println("Script4 executed");</script>
+    </scriptTask>
+    <exclusiveGateway id="_11" name="Gateway" gatewayDirection="Converging" />
+
+    <!-- connections -->
+    <sequenceFlow id="_11-_3" sourceRef="_11" targetRef="_3" />
+    <sequenceFlow id="_1-_4" sourceRef="_1" targetRef="_4" />
+    <sequenceFlow id="_4-_5" sourceRef="_4" targetRef="_5" name="code myVar==1" tns:priority="1" >
+      <conditionExpression xsi:type="tFormalExpression" language="http://www.java.com/java" >return 1==(Integer)kcontext.getVariable("myVar");</conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="_4-_6" sourceRef="_4" targetRef="_6" name="code myVar==2" tns:priority="1" >
+      <conditionExpression xsi:type="tFormalExpression" language="http://www.java.com/java" >return 2==(Integer)kcontext.getVariable("myVar");</conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="_5-_7" sourceRef="_5" targetRef="_7" />
+    <sequenceFlow id="_6-_7" sourceRef="_6" targetRef="_7" />
+    <sequenceFlow id="_7-_8" sourceRef="_7" targetRef="_8" />
+    <sequenceFlow id="_8-_9" sourceRef="_8" targetRef="_9" name="rule exists" tns:priority="1" >
+      <conditionExpression xsi:type="tFormalExpression" language="http://www.jboss.org/drools/rule" >exists Integer()</conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="_8-_10" sourceRef="_8" targetRef="_10" name="rule not" tns:priority="1" >
+      <conditionExpression xsi:type="tFormalExpression" language="http://www.jboss.org/drools/rule" >not Integer()</conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="_9-_11" sourceRef="_9" targetRef="_11" />
+    <sequenceFlow id="_10-_11" sourceRef="_10" targetRef="_11" />
+
+  </process>
+
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="GatewayTest" >
+      <bpmndi:BPMNShape bpmnElement="_1" >
+        <dc:Bounds x="19" y="182" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_3" >
+        <dc:Bounds x="782" y="164" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_4" >
+        <dc:Bounds x="112" y="182" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_5" >
+        <dc:Bounds x="219" y="79" width="80" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_6" >
+        <dc:Bounds x="228" y="246" width="80" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_7" >
+        <dc:Bounds x="358" y="179" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_8" >
+        <dc:Bounds x="450" y="179" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_9" >
+        <dc:Bounds x="552" y="73" width="80" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_10" >
+        <dc:Bounds x="556" y="238" width="80" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_11" >
+        <dc:Bounds x="674" y="166" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_11-_3" >
+        <di:waypoint x="698" y="190" />
+        <di:waypoint x="806" y="188" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_1-_4" >
+        <di:waypoint x="43" y="206" />
+        <di:waypoint x="136" y="206" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_4-_5" >
+        <di:waypoint x="136" y="206" />
+        <di:waypoint x="259" y="103" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_4-_6" >
+        <di:waypoint x="136" y="206" />
+        <di:waypoint x="268" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_5-_7" >
+        <di:waypoint x="259" y="103" />
+        <di:waypoint x="382" y="203" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_6-_7" >
+        <di:waypoint x="268" y="270" />
+        <di:waypoint x="382" y="203" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_7-_8" >
+        <di:waypoint x="382" y="203" />
+        <di:waypoint x="474" y="203" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_8-_9" >
+        <di:waypoint x="474" y="203" />
+        <di:waypoint x="592" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_8-_10" >
+        <di:waypoint x="474" y="203" />
+        <di:waypoint x="596" y="262" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_9-_11" >
+        <di:waypoint x="592" y="97" />
+        <di:waypoint x="698" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_10-_11" >
+        <di:waypoint x="596" y="262" />
+        <di:waypoint x="698" y="190" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+
+</definitions>

--- a/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/SplitNodeBuilder.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/SplitNodeBuilder.java
@@ -55,6 +55,8 @@ public class SplitNodeBuilder implements ProcessNodeBuilder {
                 ruleConstraint.setName( constraint.getName() );
                 ruleConstraint.setPriority( constraint.getPriority() );
                 ruleConstraint.setDefault( constraint.isDefault() );
+                ruleConstraint.setType(constraint.getType());
+                ruleConstraint.setConstraint(constraint.getConstraint());
                 splitNode.setConstraint( outgoingConnection, ruleConstraint );
             } else if (constraint != null && "code".equals( constraint.getType() ) ) {
                 ReturnValueConstraintEvaluator returnValueConstraint = new ReturnValueConstraintEvaluator();
@@ -62,6 +64,8 @@ public class SplitNodeBuilder implements ProcessNodeBuilder {
                 returnValueConstraint.setName( constraint.getName() );
                 returnValueConstraint.setPriority( constraint.getPriority() );
                 returnValueConstraint.setDefault( constraint.isDefault() );
+                returnValueConstraint.setType(constraint.getType());
+                returnValueConstraint.setConstraint(constraint.getConstraint());
                 splitNode.setConstraint( outgoingConnection, returnValueConstraint );            
                 
                 ReturnValueDescr returnValueDescr = new ReturnValueDescr();


### PR DESCRIPTION
Test case and fix.

SplitNodeBuilder swaps the Constraint without complete field mapping during ProcessBuilderImpl.buildProcess() and it results in this problem. XmlProcessReader.read() doesn't cause this. So I added new XMLBPMNProcessDumperTest class instead of adding a test method to BPMN2XMLTest.
