### PR TITLE
Upgrade freemarker from 2.3.8 to 2.3.19 + sync up with droolsjbpm-parent

### DIFF
--- a/jbpm-services/jbpm-kie-services/pom.xml
+++ b/jbpm-services/jbpm-kie-services/pom.xml
@@ -133,10 +133,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>freemarker</groupId>
+      <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>2.3.8</version>
-      <type>jar</type>
     </dependency>
     
     <dependency>


### PR DESCRIPTION
The parent pom already had a freemarker dependency.
Problem is this file used the bad freemarker groupId. The correct one is "org.freemarker".
Furthermore, only the parent pom must declare versions.
This change fixes the issues above.

Note: not tested if it compiles/runs (but freemarker is backwards compatible so it should)
