### PR TITLE
Provide the loggers in jbpm test case and check they are not null while ...

### DIFF
--- a/jbpm-test/src/main/java/org/jbpm/test/JbpmJUnitBaseTestCase.java
+++ b/jbpm-test/src/main/java/org/jbpm/test/JbpmJUnitBaseTestCase.java
@@ -627,15 +627,23 @@ public abstract class JbpmJUnitBaseTestCase extends Assert {
     }
     
     protected void clearHistory() {
-        if (sessionPersistence) {
+        if (sessionPersistence && logService != null) {
             logService.clear();
-        } else {
+        } else if (inMemoryLogger != null) {
             inMemoryLogger.clear();
         }
     }
     
     protected TestWorkItemHandler getTestWorkItemHandler() {
         return workItemHandler;
+    }
+    
+    protected AuditLogService getLogService() {
+        return logService;
+    }
+    
+    protected WorkingMemoryInMemoryLogger getInMemoryLogger() {
+        return inMemoryLogger;
     }
 
     protected static class TestWorkItemHandler implements WorkItemHandler {


### PR DESCRIPTION
...clearing the history

The loggers can be null for example when the build of assets fail. There is risen an exception but it prevents only the running of test. Nevertheless, the tearDown() method is called and the logger is null then.
