### PR TITLE
[JBPM-4216] resolve by GAV instead of identifier

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/KModuleDeploymentService.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/KModuleDeploymentService.java
@@ -58,12 +58,13 @@ public class KModuleDeploymentService extends AbstractDeploymentService {
             throw new IllegalArgumentException("Invalid deployment unit provided - " + unit.getClass().getName());
         }
         KModuleDeploymentUnit kmoduleUnit = (KModuleDeploymentUnit) unit;
-        DeployedUnitImpl deployedUnit = new DeployedUnitImpl(unit);
         KieServices ks = KieServices.Factory.get();
-        MavenRepository repository = getMavenRepository();
-        repository.resolveArtifact(kmoduleUnit.getIdentifier());
-
+        DeployedUnitImpl deployedUnit = new DeployedUnitImpl(unit);
         ReleaseId releaseId = ks.newReleaseId(kmoduleUnit.getGroupId(), kmoduleUnit.getArtifactId(), kmoduleUnit.getVersion());
+
+        MavenRepository repository = getMavenRepository();
+        repository.resolveArtifact(releaseId.toExternalForm());
+
         KieContainer kieContainer = ks.newKieContainer(releaseId);
 
         String kbaseName = kmoduleUnit.getKbaseName();


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/JBPM-4216

as discussed in https://community.jboss.org/thread/235789

This fix stops KModuleDeploymentService from accidentally allowing only a single deploy of a repository artefact.  KIE allows many KModules to be created from a deployment, but KModuleDeploymentService would not permit it.
