### PR TITLE
[JBPM-4235] fix CDI producer for JAAS-backed UserGroupCallback

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/cdi/producer/JAASUserGroupInfoProducer.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/cdi/producer/JAASUserGroupInfoProducer.java
@@ -20,12 +20,14 @@ public class JAASUserGroupInfoProducer implements UserGroupInfoProducer {
 	
 	@Override
 	@Produces
+	@Selectable
 	public UserGroupCallback produceCallback() {
 		return callback;
 	}
 
 	@Override
 	@Produces
+	@Selectable
 	public UserInfo produceUserInfo() {
 		return userInfo;
 	}


### PR DESCRIPTION
This may not be a good patch, or at least it may not be a complete one.  Please review the comments in the JIRA.
