### PR TITLE
JBPM-4443 Adding quartz timer tests

### DIFF
--- a/jbpm-test/src/test/resources/BPMN2-IntermediateCatchEventTimerCycle4.bpmn2
+++ b/jbpm-test/src/test/resources/BPMN2-IntermediateCatchEventTimerCycle4.bpmn2
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<definitions id="Definition"
+             targetNamespace="http://www.example.org/MinimalExample"
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <itemDefinition id="_xItem" structureRef="String" />
+
+  <process processType="Private" isExecutable="true" id="IntermediateCatchEvent" name="IntermediateCatchEvent Process" >
+
+    <!-- process variables -->
+    <property id="x" itemSubjectRef="_xItem"/>
+
+    <!-- nodes -->
+    <startEvent id="_1" name="StartProcess" />
+    <intermediateCatchEvent id="_3" name="timer" >
+      <timerEventDefinition>
+        <timeCycle>R2/PT5S</timeCycle>
+      </timerEventDefinition>
+    </intermediateCatchEvent>
+    <scriptTask id="_4" name="Event" >
+      <script>System.out.println("Timer triggered");</script>
+    </scriptTask>
+    <endEvent id="_5" name="EndProcess" />
+
+    <!-- connections -->
+    <sequenceFlow id="_1-_3" sourceRef="_1" targetRef="_3" />
+    <sequenceFlow id="_3-_4" sourceRef="_3" targetRef="_4" />
+    <sequenceFlow id="_4-_5" sourceRef="_4" targetRef="_5" />
+
+  </process>
+
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="IntermediateCatchEvent" >
+      <bpmndi:BPMNShape bpmnElement="_1" >
+        <dc:Bounds x="16" y="16" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_3" >
+        <dc:Bounds x="96" y="16" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_4" >
+        <dc:Bounds x="176" y="16" width="80" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_5" >
+        <dc:Bounds x="288" y="16" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_1-_3" >
+        <di:waypoint x="40" y="40" />
+        <di:waypoint x="120" y="40" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_3-_4" >
+        <di:waypoint x="120" y="40" />
+        <di:waypoint x="216" y="40" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_4-_5" >
+        <di:waypoint x="216" y="40" />
+        <di:waypoint x="312" y="40" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+
+</definitions>


### PR DESCRIPTION
This testContinueTimer() is trying to test a quartz timer surviving server restart. As commented in testContinueGlobalTestService(), it's not a real db but an in-memory db. But doesn't this test make sense? Please let me know if this test is not appropriate.

testContinueTimer() passes asserts (= Timer is correctly fired) but you will see tons of Exceptions in timer threads. I guess we need let timer service wait until a RuntimeEngine is initialized.
# 

java.lang.NullPointerException
    at org.jbpm.persistence.timer.GlobalJpaTimerJobInstance.call(GlobalJpaTimerJobInstance.java:67)
    at org.jbpm.persistence.timer.GlobalJpaTimerJobInstance.call(GlobalJpaTimerJobInstance.java:46)
    at org.jbpm.process.core.timer.impl.QuartzSchedulerService$QuartzJob.execute(QuartzSchedulerService.java:279)
    at org.quartz.core.JobRunShell.run(JobRunShell.java:216)
...
# 

java.lang.RuntimeException: No runtime engine found, could not be initialized yet
    at org.jbpm.process.core.timer.impl.GlobalTimerService.getCommandService(GlobalTimerService.java:210)
    at org.jbpm.process.core.timer.impl.GlobalTimerService.getCommandService(GlobalTimerService.java:192)
    at org.jbpm.persistence.timer.GlobalJpaTimerJobInstance.call(GlobalJpaTimerJobInstance.java:67)
    at org.jbpm.persistence.timer.GlobalJpaTimerJobInstance.call(GlobalJpaTimerJobInstance.java:46)
    at org.jbpm.process.core.timer.impl.QuartzSchedulerService$QuartzJob.execute(QuartzSchedulerService.java:279)
    at org.quartz.core.JobRunShell.run(JobRunShell.java:216)
...
