### PR TITLE
Fix tests in CI by using local maven repo in target/

### DIFF
--- a/jbpm-runtime-manager/pom.xml
+++ b/jbpm-runtime-manager/pom.xml
@@ -137,13 +137,28 @@
     </dependency>
   </dependencies>
   <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>false</filtering>
+      </testResource>
+      <testResource>
+        <directory>src/test/filtered-resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
     <plugins>
       <plugin>
         <!-- we need to fork always as we have mixture of both arquillian tests and regular
-      and to avoid clashing between them as both need to setup data source and bound it to JNDI -->
+             and to avoid clashing between them as both need to setup data source and bound it to JNDI -->
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkMode>always</forkMode>
+          <systemProperties>
+            <kie.maven.settings.custom>
+              ${project.build.testOutputDirectory}/jbpm-runtime-manager-tests-custom-settings.xml
+            </kie.maven.settings.custom>
+          </systemProperties>
         </configuration>
       </plugin>
 

--- a/jbpm-runtime-manager/src/test/filtered-resources/jbpm-runtime-manager-tests-custom-settings.xml
+++ b/jbpm-runtime-manager/src/test/filtered-resources/jbpm-runtime-manager-tests-custom-settings.xml
@@ -1,0 +1,21 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>${project.build.directory}/testing-maven-repo</localRepository>
+  <profiles>
+    <profile>
+      <!-- Repository with SNAPSHOTs-->
+      <id>additional-maven-repos</id>
+      <repositories>
+        <repository>
+          <id>jboss-public-repo</id>
+          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>additional-maven-repos</activeProfile>
+  </activeProfiles>
+</settings>

--- a/jbpm-services/jbpm-kie-services/pom.xml
+++ b/jbpm-services/jbpm-kie-services/pom.xml
@@ -173,7 +173,17 @@
   </dependencies>
 
   <build>
-    <plugins> 
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>false</filtering>
+      </testResource>
+      <testResource>
+        <directory>src/test/filtered-resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+    <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -191,11 +201,16 @@
         </configuration>
       </plugin>   
       <plugin>
-      <!-- we need to fork always as we have mixture of both arquillian tests and regular 
-    and to avoid clashing between them as both need to setup data source and bound it to JNDI -->
+        <!-- we need to fork always as we have mixture of both arquillian tests and regular
+             and to avoid clashing between them as both need to setup data source and bound it to JNDI -->
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkMode>always</forkMode>
+          <systemProperties>
+            <kie.maven.settings.custom>
+              ${project.build.testOutputDirectory}/jbpm-kie-services-tests-custom-settings.xml
+            </kie.maven.settings.custom>
+          </systemProperties>
         </configuration>
       </plugin>
       <plugin>

--- a/jbpm-services/jbpm-kie-services/src/test/filtered-resources/jbpm-kie-services-tests-custom-settings.xml
+++ b/jbpm-services/jbpm-kie-services/src/test/filtered-resources/jbpm-kie-services-tests-custom-settings.xml
@@ -1,0 +1,21 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>${project.build.directory}/testing-maven-repo</localRepository>
+  <profiles>
+    <profile>
+      <!-- Repository with SNAPSHOTs-->
+      <id>additional-maven-repos</id>
+      <repositories>
+        <repository>
+          <id>jboss-public-repo</id>
+          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>additional-maven-repos</activeProfile>
+  </activeProfiles>
+</settings>

--- a/jbpm-services/jbpm-services-cdi/pom.xml
+++ b/jbpm-services/jbpm-services-cdi/pom.xml
@@ -175,13 +175,28 @@
   </dependencies>
   
   <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>false</filtering>
+      </testResource>
+      <testResource>
+        <directory>src/test/filtered-resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
     <plugins>  
       <plugin>
-      <!-- we need to fork always as we have mixture of both arquillian tests and regular 
-    and to avoid clashing between them as both need to setup data source and bound it to JNDI -->
+        <!-- we need to fork always as we have mixture of both arquillian tests and regular
+             and to avoid clashing between them as both need to setup data source and bound it to JNDI -->
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkMode>always</forkMode>
+          <systemProperties>
+            <kie.maven.settings.custom>
+              ${project.build.testOutputDirectory}/jbpm-services-cdi-tests-custom-settings.xml
+            </kie.maven.settings.custom>
+          </systemProperties>
         </configuration>
       </plugin>
       <plugin>

--- a/jbpm-services/jbpm-services-cdi/src/test/filtered-resources/jbpm-services-cdi-tests-custom-settings.xml
+++ b/jbpm-services/jbpm-services-cdi/src/test/filtered-resources/jbpm-services-cdi-tests-custom-settings.xml
@@ -1,0 +1,21 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>${project.build.directory}/testing-maven-repo</localRepository>
+  <profiles>
+    <profile>
+      <!-- Repository with SNAPSHOTs-->
+      <id>additional-maven-repos</id>
+      <repositories>
+        <repository>
+          <id>jboss-public-repo</id>
+          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>additional-maven-repos</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
- about 150 tests in currently failing in CI due to failure when acquiring some file from ~/.m2.
- using clean repo for every build (instead of the
  shared one in ~/.m2) fixes the failing tests in CI
- having the local repo in target/ also greatly
  improves the isolation of the tests. They are
  less dependent on the current state of ~/.m2 on
  the particular machine
- with these changes, there is only remaining failure that does not seem to be related to this: https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbpm-psiroky-testing/ (I cloned the job and ran with the changes in this PR)
- this solution is not 100 % ideal as the same xml file/code is in three places. However, I could not think of any easier/better way. I will try to find an easy way to specify this config in one place so it can be shared by other modules and create another PR if I find such solution.
