### PR TITLE
Changing eagarDisabled field initial value to reflect the expected defau...

### DIFF
--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/persistence/TaskTransactionInterceptor.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/persistence/TaskTransactionInterceptor.java
@@ -34,7 +34,7 @@ public class TaskTransactionInterceptor extends AbstractInterceptor {
 	private CommandService             commandService;
     private TransactionManager         txm;
     private TaskPersistenceContextManager  tpm;
-    private boolean eagerDisabled = true;
+    private boolean eagerDisabled = false;
     
     public TaskTransactionInterceptor(Environment environment) {
     	this.eagerDisabled = Boolean.getBoolean("jbpm.ht.eager.disabled");


### PR DESCRIPTION
Changing eagarDisabled field initial value to reflect the expected defaut value.

As Maciej described in https://bugzilla.redhat.com/show_bug.cgi?id=1155855#c12 , System property "jbpm.ht.eager.disabled" is 'false' by default so TaskTransactionInterceptor.eagerDisabled is intentionally 'false' by default.

This PR doesn't change the behavior at all but just change the eagarDisabled field initial value to reflect the expected defaut value ('false') for readability.
