### PR TITLE
avoid NPE when dynamic task parameters are not given

### DIFF
--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/dynamic/HumanTaskSpecification.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/dynamic/HumanTaskSpecification.java
@@ -58,9 +58,10 @@ public class HumanTaskSpecification implements TaskSpecification {
         if (taskName == null) {
             throw new IllegalArgumentException("Missing manadatory parameter - taskName");
         }
-        Map<String, Object> workParams = new HashMap<String, Object>();       
-        workParams.putAll(parameters);
-    
+        Map<String, Object> workParams = new HashMap<String, Object>();
+        if (parameters != null) {
+            workParams.putAll(parameters);
+        }
         workParams.put("NodeName", taskName);
         workParams.put("TaskName", taskName);
         workParams.put("ActorId", actorIds);


### PR DESCRIPTION
@cristianonicolai here is a tiny change to make the dynamic task work from the case mgmt showcase app, otherwise it fails with NPE