### PR TITLE
JBPM-5610: Not able to exclude multiple owners for HumanTask - Tests

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/TaskQueryServiceBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/TaskQueryServiceBaseTest.java
@@ -156,6 +156,36 @@ public abstract class TaskQueryServiceBaseTest extends HumanTaskServicesBaseTest
         tasks = taskService.getTasksAssignedAsPotentialOwner("Luke Cage", "en-UK");
         assertEquals(0, tasks.size());
     }
+
+    @Test
+    public void testGetTasksAssignedAsPotentialOwnerWithUserGroupsSingleUserExcluded() {
+        String str = "(with (new Task()) { priority = 55, taskData = (with( new TaskData()) { } ), ";
+        str += " peopleAssignments = (with ( new PeopleAssignments() ) { potentialOwners = [new Group('Crusaders'), ], excludedOwners = [new User('Luke Cage')],businessAdministrators = [ new User('Administrator') ], }),";
+        str += "name =  'This is my task name' })";
+
+        Task task = TaskFactory.evalTask(new StringReader(str));
+        taskService.addTask(task, new HashMap<String, Object>());
+        List<TaskSummary> tasks = taskService.getTasksAssignedAsPotentialOwner("Luke Cage", "en-UK");
+        assertEquals(0, tasks.size());
+
+        tasks = taskService.getTasksAssignedAsPotentialOwner("Bobba Fet", "en-UK");
+        assertEquals(1, tasks.size());
+    }
+
+    @Test
+    public void testGetTasksAssignedAsPotentialOwnerWithUserGroupsMultipleUsersExcluded() {
+        String str = "(with (new Task()) { priority = 55, taskData = (with( new TaskData()) { } ), ";
+        str += " peopleAssignments = (with ( new PeopleAssignments() ) { potentialOwners = [new Group('Crusaders'), ], excludedOwners = [new User('Luke Cage'), new User('Bobba Fet')],businessAdministrators = [ new User('Administrator') ], }),";
+        str += "name =  'This is my task name' })";
+
+        Task task = TaskFactory.evalTask(new StringReader(str));
+        taskService.addTask(task, new HashMap<String, Object>());
+        List<TaskSummary> tasks = taskService.getTasksAssignedAsPotentialOwner("Luke Cage", "en-UK");
+        assertEquals(0, tasks.size());
+
+        tasks = taskService.getTasksAssignedAsPotentialOwner("Bobba Fet", "en-UK");
+        assertEquals(0, tasks.size());
+    }
     
     // getTasksAssignedAsPotentialOwner(String userId, String language)
     


### PR DESCRIPTION
**Add tests with groups and excluded owners**

Adds 2 tests methods that test behavior of excluding user/users
from group which is set as potential owner of the task.