### PR TITLE
Avoid NPE while using document.toString();

### DIFF
--- a/jbpm-document/src/main/java/org/jbpm/document/service/impl/DocumentImpl.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/service/impl/DocumentImpl.java
@@ -142,6 +142,6 @@ public class DocumentImpl implements Document {
     @Override
     public String toString() {
         SimpleDateFormat sdf = new SimpleDateFormat( DOCUMENT_DATE_PATTERN );
-        return  name + PROPERTIES_SEPARATOR + size + PROPERTIES_SEPARATOR + sdf.format( lastModified ) + PROPERTIES_SEPARATOR + link ;
+        return  name + PROPERTIES_SEPARATOR + size + PROPERTIES_SEPARATOR + ((lastModified!= null)? sdf.format( lastModified ) : "" )+ PROPERTIES_SEPARATOR + link ;
     }
 }


### PR DESCRIPTION
[JBoss JIRA] (JBPM-5878) DocumentImpl toString() generates NPE when no modification date is available