### PR TITLE
6.4.x Solves (JBPM-5878) DocumentImpl toString() generates NPE when no modification date is available

### DIFF
--- a/jbpm-document/src/main/java/org/jbpm/document/service/impl/DocumentImpl.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/service/impl/DocumentImpl.java
@@ -142,6 +142,6 @@ public class DocumentImpl implements Document {
     @Override
     public String toString() {
         SimpleDateFormat sdf = new SimpleDateFormat( DOCUMENT_DATE_PATTERN );
-        return  name + PROPERTIES_SEPARATOR + size + PROPERTIES_SEPARATOR + sdf.format( lastModified ) + PROPERTIES_SEPARATOR + link ;
+        return  name + PROPERTIES_SEPARATOR + size + PROPERTIES_SEPARATOR + ((lastModified!= null)? sdf.format( lastModified ) : "" )+ PROPERTIES_SEPARATOR + link ;
     }
 }

--- a/jbpm-document/src/test/java/org/jbpm/document/service/impl/DocumentImplTest.java
+++ b/jbpm-document/src/test/java/org/jbpm/document/service/impl/DocumentImplTest.java
@@ -1,0 +1,19 @@
+package org.jbpm.document.service.impl;
+
+import org.jbpm.document.Document;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DocumentImplTest {
+
+	@Test
+	public void testToStringRepresentation(){
+		
+		Document document = new DocumentImpl();
+		try{
+			Assert.assertNotNull( document.toString() );
+		}catch( Throwable th ){
+			Assert.fail( "toString method must not fire any exception:" + th.getMessage() );
+		}
+	}
+}


### PR DESCRIPTION
[JBoss JIRA] (JBPM-5878) DocumentImpl toString() generates NPE when no modification date is available

Including a poor man test to avoid reiteration.