### PR TITLE
(JBPM-5878) DocumentImpl toString() generates NPE when no modification date is available

### DIFF
--- a/jbpm-document/src/main/java/org/jbpm/document/service/impl/DocumentImpl.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/service/impl/DocumentImpl.java
@@ -150,6 +150,6 @@ public class DocumentImpl implements Document {
     @Override
     public String toString() {
         SimpleDateFormat sdf = new SimpleDateFormat( DOCUMENT_DATE_PATTERN );
-        return  name + PROPERTIES_SEPARATOR + size + PROPERTIES_SEPARATOR + sdf.format( lastModified ) + PROPERTIES_SEPARATOR + link ;
+        return  name + PROPERTIES_SEPARATOR + size + PROPERTIES_SEPARATOR + ((lastModified!=null)? sdf.format( lastModified ) : "" ) + PROPERTIES_SEPARATOR + link ;
     }
 }

--- a/jbpm-document/src/test/java/org/jbpm/document/service/impl/DocumentImplTest.java
+++ b/jbpm-document/src/test/java/org/jbpm/document/service/impl/DocumentImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jbpm.document.service.impl;
 
 import org.jbpm.document.Document;
@@ -6,14 +21,13 @@ import org.junit.Test;
 
 public class DocumentImplTest {
 
-	@Test
-	public void testToStringRepresentation(){
-		
-		Document document = new DocumentImpl();
-		try{
-			Assert.assertNotNull( document.toString() );
-		}catch( Throwable th ){
-			Assert.fail( "toString method must not fire any exception:" + th.getMessage() );
-		}
-	}
+    @Test
+    public void testToStringRepresentation(){		
+        Document document = new DocumentImpl();
+        try {
+            Assert.assertNotNull(document.toString());
+	} catch(Throwable th) {
+            Assert.fail("toString method must not fire any exception: " + th.getMessage());
+        }
+    }
 }

--- a/jbpm-document/src/test/java/org/jbpm/document/service/impl/DocumentImplTest.java
+++ b/jbpm-document/src/test/java/org/jbpm/document/service/impl/DocumentImplTest.java
@@ -1,0 +1,19 @@
+package org.jbpm.document.service.impl;
+
+import org.jbpm.document.Document;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DocumentImplTest {
+
+	@Test
+	public void testToStringRepresentation(){
+		
+		Document document = new DocumentImpl();
+		try{
+			Assert.assertNotNull( document.toString() );
+		}catch( Throwable th ){
+			Assert.fail( "toString method must not fire any exception:" + th.getMessage() );
+		}
+	}
+}


### PR DESCRIPTION
Avoid NPE while calling toString on DocumentImpl without lastModifiedDate.

Simple unit test included