### PR TITLE
JBPM-5880 - 'async' as a default option for all tasks

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
@@ -46,6 +46,7 @@ import org.jbpm.workflow.core.node.AsyncEventNode;
 import org.jbpm.workflow.core.node.EventNode;
 import org.jbpm.workflow.core.node.EventNodeInterface;
 import org.jbpm.workflow.core.node.EventSubProcessNode;
+import org.jbpm.workflow.core.node.StartNode;
 import org.jbpm.workflow.instance.NodeInstance;
 import org.jbpm.workflow.instance.WorkflowProcessInstance;
 import org.jbpm.workflow.instance.node.CompositeNodeInstance;
@@ -229,13 +230,13 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl
 		}
 		return result;
 	}
-
+	
 	public NodeInstance getNodeInstance(final Node node) {
 	    Node actualNode = node;
 	    // async continuation handling
 	    if (node instanceof AsyncEventNode) {
             actualNode = ((AsyncEventNode) node).getActualNode();
-        } else if (Boolean.parseBoolean((String)node.getMetaData().get("customAsync"))) {
+        } else if (useAsync(node)) {
             actualNode = new AsyncEventNode(node);
         }
 
@@ -748,5 +749,17 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl
         }
 
         return true;
+    }    
+
+    protected boolean useAsync(final Node node) {
+        if (node instanceof StartNode) {
+            return false;
+        }
+        boolean asyncMode = Boolean.parseBoolean((String)node.getMetaData().get("customAsync"));
+        if (asyncMode) {
+            return asyncMode;
+        }
+        
+        return Boolean.parseBoolean((String)getKnowledgeRuntime().getEnvironment().get("AsyncMode"));
     }
 }

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/CompositeNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/CompositeNodeInstance.java
@@ -259,7 +259,7 @@ public class CompositeNodeInstance extends StateBasedNodeInstance implements Nod
         // async continuation handling
         if (node instanceof AsyncEventNode) {
             actualNode = ((AsyncEventNode) node).getActualNode();
-        } else if (Boolean.parseBoolean((String)node.getMetaData().get("customAsync"))) {
+        } else if (useAsync(node)) {
             actualNode = new AsyncEventNode(node);
         }
 
@@ -425,6 +425,16 @@ public class CompositeNodeInstance extends StateBasedNodeInstance implements Nod
         return iterationLevels;
     }
 
-
+    protected boolean useAsync(final Node node) {
+        if (node instanceof StartNode) {
+            return false;
+        }
+        boolean asyncMode = Boolean.parseBoolean((String)node.getMetaData().get("customAsync"));
+        if (asyncMode) {
+            return asyncMode;
+        }
+        
+        return Boolean.parseBoolean((String)getProcessInstance().getKnowledgeRuntime().getEnvironment().get("AsyncMode"));
+    }
 
 }

--- a/jbpm-services/jbpm-executor/src/test/java/org/jbpm/executor/impl/wih/AsyncContinuationSupportTest.java
+++ b/jbpm-services/jbpm-executor/src/test/java/org/jbpm/executor/impl/wih/AsyncContinuationSupportTest.java
@@ -25,7 +25,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
@@ -758,6 +760,65 @@ public class AsyncContinuationSupportTest extends AbstractExecutorBaseTest {
         List<? extends NodeInstanceLog> logs = runtime.getAuditService().findNodeInstances(processInstanceId);
         assertNotNull(logs);
         assertEquals(8, logs.size());
+    } 
+    
+    @Test(timeout=10000)
+    public void testAsyncModeWithScriptTask() throws Exception {
+        final CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("EndProcess", 1);
+        RuntimeEnvironment environment = RuntimeEnvironmentBuilder.Factory.get().newDefaultBuilder()
+                .userGroupCallback(userGroupCallback)
+                .addAsset(ResourceFactory.newClassPathResource("BPMN2-ScriptTask.bpmn2"), ResourceType.BPMN2)
+                .addEnvironmentEntry("ExecutorService", executorService)
+                .addEnvironmentEntry("AsyncMode", "true")
+                .registerableItemsFactory(new DefaultRegisterableItemsFactory() {
+
+                    @Override
+                    public Map<String, WorkItemHandler> getWorkItemHandlers(RuntimeEngine runtime) {
+
+                        Map<String, WorkItemHandler> handlers = super.getWorkItemHandlers(runtime);
+                        handlers.put("async", new SystemOutWorkItemHandler());
+                        return handlers;
+                    }
+                    @Override
+                    public List<ProcessEventListener> getProcessEventListeners( RuntimeEngine runtime) {
+                        List<ProcessEventListener> listeners = super.getProcessEventListeners(runtime);
+                        listeners.add(countDownListener);
+                        return listeners;
+                    }
+                })
+                .get();
+        
+        manager = RuntimeManagerFactory.Factory.get().newSingletonRuntimeManager(environment); 
+        assertNotNull(manager);
+        
+        RuntimeEngine runtime = manager.getRuntimeEngine(EmptyContext.get());
+        KieSession ksession = runtime.getKieSession();
+        assertNotNull(ksession);       
+        
+        ProcessInstance processInstance = ksession.startProcess("ScriptTask");
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
+        long processInstanceId = processInstance.getId();
+        
+        // make sure that waiting for event process is not finished yet as it must be through executor/async
+        processInstance = runtime.getKieSession().getProcessInstance(processInstanceId);
+        assertNotNull(processInstance);
+        
+        countDownListener.waitTillCompleted();
+        
+        processInstance = runtime.getKieSession().getProcessInstance(processInstanceId);
+        assertNull(processInstance);
+        
+        List<? extends NodeInstanceLog> logs = runtime.getAuditService().findNodeInstances(processInstanceId);
+        assertNotNull(logs);
+        assertEquals(8, logs.size());
+        
+        List<RequestInfo> completed = executorService.getCompletedRequests(new QueryContext());
+        // there should 3 completed commands (for script, for task and end node)
+        assertEquals(3, completed.size());
+        
+        Set<String> commands = completed.stream().map(RequestInfo::getCommandName).collect(Collectors.toSet());
+        assertEquals(1, commands.size());
+        assertEquals(AsyncSignalEventCommand.class.getName(), commands.iterator().next());
     } 
       
     


### PR DESCRIPTION
@krisv here is the option to turn all nodes into async mode via deployment descriptor. This means we can have it globally by using server level deployment descriptor or per kjar deployed.

in deployment descriptor it needs to be given as environment entry named "AsyncMode" and the value is "true" or "false"