### PR TITLE
JBPM-5886: Replace joda-time with Java 8 time implementation

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
@@ -15,6 +15,7 @@ limitations under the License.*/
 
 package org.jbpm.bpmn2;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -49,7 +50,6 @@ import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.jbpm.process.instance.timer.TimerInstance;
 import org.jbpm.process.instance.timer.TimerManager;
 import org.jbpm.test.util.CountDownProcessEventListener;
-import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1110,9 +1110,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ksession.addEventListener(countDownListener);
         ksession.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
         HashMap<String, Object> params = new HashMap<String, Object>();
-        DateTime now = new DateTime(System.currentTimeMillis());
-        now.plus(2000);
-        params.put("date", now.toString());
+        OffsetDateTime plusTwoSeconds = OffsetDateTime.now().plusSeconds(2);
+        params.put("date", plusTwoSeconds.toString());
         ProcessInstance processInstance = ksession.startProcess("TimerBoundaryEvent", params);
         assertProcessInstanceActive(processInstance);
         countDownListener.waitTillCompleted();
@@ -1332,9 +1331,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ksession.addEventListener(countDownListener);
 
         HashMap<String, Object> params = new HashMap<String, Object>();
-        DateTime now = new DateTime(System.currentTimeMillis());
-        now.plus(2000);
-        params.put("date", now.toString());
+        OffsetDateTime plusTwoSeconds = OffsetDateTime.now().plusSeconds(2);
+        params.put("date", plusTwoSeconds.toString());
         ProcessInstance processInstance = ksession.startProcess("IntermediateCatchEvent", params);
         assertProcessInstanceActive(processInstance);
         // now wait for 1 second for timer to trigger

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StartEventTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StartEventTest.java
@@ -16,6 +16,7 @@ limitations under the License.*/
 package org.jbpm.bpmn2;
 
 import java.io.StringReader;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,7 +31,6 @@ import org.jbpm.bpmn2.objects.NotAvailableGoodsReport;
 import org.jbpm.bpmn2.objects.Person;
 import org.jbpm.bpmn2.objects.TestWorkItemHandler;
 import org.jbpm.test.util.CountDownProcessEventListener;
-import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -148,10 +148,9 @@ public class StartEventTest extends JbpmBpmn2TestCase {
         byte[] content = IoUtils.readBytesFromInputStream(this.getClass().getResourceAsStream("/BPMN2-TimerStartDate.bpmn2"));
         String processContent = new String(content, "UTF-8");
 
-        DateTime now = new DateTime(System.currentTimeMillis());
-        now = now.plus(2000);
+        OffsetDateTime plusTwoSeconds = OffsetDateTime.now().plusSeconds(2);
 
-        processContent = processContent.replaceFirst("#\\{date\\}", now.toString());
+        processContent = processContent.replaceFirst("#\\{date\\}", plusTwoSeconds.toString());
         Resource resource = ResourceFactory.newReaderResource(new StringReader(processContent));
         resource.setSourcePath("/BPMN2-TimerStartDate.bpmn2");
         resource.setTargetPath("/BPMN2-TimerStartDate.bpmn2");

--- a/jbpm-flow/pom.xml
+++ b/jbpm-flow/pom.xml
@@ -141,10 +141,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/jbpm-flow/src/test/java/org/jbpm/process/core/timer/BusinessCalendarImplTest.java
+++ b/jbpm-flow/src/test/java/org/jbpm/process/core/timer/BusinessCalendarImplTest.java
@@ -310,6 +310,19 @@ public class BusinessCalendarImplTest extends AbstractBaseTest {
 		Date result = businessCalendarImpl.calculateBusinessTimeAsDate("4d");
 		assertEquals(expectedDate, formatDate("yyyy-MM-dd HH:mm", result));
     }
+
+    @Test
+    public void testCalculateMillisecondsAsDefault() {
+        Properties config = new Properties();
+        String expectedDate = "2012-05-04 16:45:10.000";
+        SessionPseudoClock clock = new StaticPseudoClock(parseToDateWithTimeAndMillis("2012-05-04 16:45:00.000").getTime());
+
+        BusinessCalendarImpl businessCal = new BusinessCalendarImpl(config, clock);
+
+        Date result = businessCal.calculateBusinessTimeAsDate("10000");
+
+        assertEquals(expectedDate, formatDate("yyyy-MM-dd HH:mm:ss.SSS", result));
+    }
     
     private Date parseToDate(String dateString) {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");

--- a/jbpm-flow/src/test/java/org/jbpm/process/core/timer/DateTimeUtilsTest.java
+++ b/jbpm-flow/src/test/java/org/jbpm/process/core/timer/DateTimeUtilsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.jbpm.process.core.timer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import org.jbpm.test.util.AbstractBaseTest;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+public class DateTimeUtilsTest extends AbstractBaseTest {
+
+    private static final long MINUTE_IN_MILLISECONDS = 60 * 1000L;
+    private static final long FIFTY_NINE_SECONDS_IN_MILLISECONDS = 59 * 1000L;
+    private static final long HOUR_IN_MILLISECONDS = 60 * 60 * 1000L;
+
+    public void addLogger() {
+        logger = LoggerFactory.getLogger(this.getClass());
+    }
+
+    @Test
+    public void testParseDateTime() {
+        OffsetDateTime hourAfterEpoch = OffsetDateTime.of(1970, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC);
+
+        long parsedMilliseconds = DateTimeUtils.parseDateTime(hourAfterEpoch.format(DateTimeFormatter.ISO_DATE_TIME));
+
+        assertEquals(HOUR_IN_MILLISECONDS, parsedMilliseconds);
+    }
+
+    @Test
+    public void testParseDuration() {
+        long parsedMilliseconds = DateTimeUtils.parseDuration("1h");
+
+        assertEquals(HOUR_IN_MILLISECONDS, parsedMilliseconds);
+    }
+
+    @Test
+    public void testParseDurationPeriodFormat() {
+        long parsedMilliseconds = DateTimeUtils.parseDuration("PT1H");
+
+        assertEquals(HOUR_IN_MILLISECONDS, parsedMilliseconds);
+    }
+
+    @Test
+    public void testParseDurationDefaultMilliseconds() {
+        long parsedMilliseconds = DateTimeUtils.parseDuration(Long.toString(HOUR_IN_MILLISECONDS));
+
+        assertEquals(HOUR_IN_MILLISECONDS, parsedMilliseconds);
+    }
+
+    @Test
+    public void testParseDateAsDuration() {
+        OffsetDateTime oneMinuteFromNow = OffsetDateTime.now().plusMinutes(1);
+
+        long parsedMilliseconds = DateTimeUtils.parseDateAsDuration(oneMinuteFromNow.format(DateTimeFormatter.ISO_DATE_TIME));
+
+        assertTrue("Parsed date as duration is bigger than " + MINUTE_IN_MILLISECONDS, parsedMilliseconds <= MINUTE_IN_MILLISECONDS);
+        assertTrue("Parsed date as duration is too low! Expected value is between " + MINUTE_IN_MILLISECONDS + " and " + FIFTY_NINE_SECONDS_IN_MILLISECONDS + " but is " + parsedMilliseconds, parsedMilliseconds > FIFTY_NINE_SECONDS_IN_MILLISECONDS);
+    }
+
+    @Test
+    public void testParseRepeatableStartEndDateTime() {
+        OffsetDateTime oneMinuteFromNow = OffsetDateTime.now().plusMinutes(1);
+        OffsetDateTime twoMinutesFromNow = oneMinuteFromNow.plusMinutes(1);
+        String oneMinuteFromNowFormatted = oneMinuteFromNow.format(DateTimeFormatter.ISO_DATE_TIME);
+        String twoMinutesFromNowFormatted = twoMinutesFromNow.format(DateTimeFormatter.ISO_DATE_TIME);
+        String isoString = "R5/" + oneMinuteFromNowFormatted  + "/" + twoMinutesFromNowFormatted;
+
+        long[] parsedRepeatable = DateTimeUtils.parseRepeatableDateTime(isoString);
+
+        assertEquals(5L, parsedRepeatable[0]);
+        assertTrue("Parsed delay is bigger than " + MINUTE_IN_MILLISECONDS, parsedRepeatable[1] <= MINUTE_IN_MILLISECONDS);
+        assertTrue("Parsed delay is too low! Expected value is between " + MINUTE_IN_MILLISECONDS + " and " + FIFTY_NINE_SECONDS_IN_MILLISECONDS + " but is " + parsedRepeatable[1], parsedRepeatable[1] > FIFTY_NINE_SECONDS_IN_MILLISECONDS);
+        assertEquals("Parsed period should be one minute in milliseconds but is " + parsedRepeatable[2], MINUTE_IN_MILLISECONDS, parsedRepeatable[2]);
+    }
+
+    @Test
+    public void testParseRepeatableStartDateTimeAndPeriod() {
+        OffsetDateTime oneMinuteFromNow = OffsetDateTime.now().plusMinutes(1);
+        String oneMinuteFromNowFormatted = oneMinuteFromNow.format(DateTimeFormatter.ISO_DATE_TIME);
+        String isoString = "R5/" + oneMinuteFromNowFormatted  + "/PT1M";
+
+        long[] parsedRepeatable = DateTimeUtils.parseRepeatableDateTime(isoString);
+
+        assertEquals(5L, parsedRepeatable[0]);
+        assertTrue("Parsed delay is bigger than " + MINUTE_IN_MILLISECONDS, parsedRepeatable[1] <= MINUTE_IN_MILLISECONDS);
+        assertTrue("Parsed delay is too low! Expected value is between " + MINUTE_IN_MILLISECONDS + " and " + FIFTY_NINE_SECONDS_IN_MILLISECONDS + " but is " + parsedRepeatable[1], parsedRepeatable[1] > FIFTY_NINE_SECONDS_IN_MILLISECONDS);
+        assertEquals("Parsed period should be one minute in milliseconds but is " + parsedRepeatable[2], MINUTE_IN_MILLISECONDS, parsedRepeatable[2]);
+    }
+
+    @Test
+    public void testParseRepeatablePeriodAndEndDateTime() {
+        OffsetDateTime twoMinutesFromNow = OffsetDateTime.now().plusMinutes(2);
+        String twoMinutesFromNowFormatted = twoMinutesFromNow.format(DateTimeFormatter.ISO_DATE_TIME);
+        String isoString = "R5/PT1M/" + twoMinutesFromNowFormatted;
+
+        long[] parsedRepeatable = DateTimeUtils.parseRepeatableDateTime(isoString);
+
+        assertEquals(5L, parsedRepeatable[0]);
+        assertTrue("Parsed delay is bigger than " + MINUTE_IN_MILLISECONDS, parsedRepeatable[1] <= MINUTE_IN_MILLISECONDS);
+        assertTrue("Parsed delay is too low! Expected value is between " + MINUTE_IN_MILLISECONDS + " and " + FIFTY_NINE_SECONDS_IN_MILLISECONDS + " but is " + parsedRepeatable[1], parsedRepeatable[1] > FIFTY_NINE_SECONDS_IN_MILLISECONDS);
+        assertEquals("Parsed period should be one minute in milliseconds but is " + parsedRepeatable[2], MINUTE_IN_MILLISECONDS, parsedRepeatable[2]);
+    }
+
+    @Test
+    public void testParseRepeatablePeriodOnly() {
+        String isoString = "R/PT1M";
+
+        long[] parsedRepeatable = DateTimeUtils.parseRepeatableDateTime(isoString);
+
+        assertEquals(-1L, parsedRepeatable[0]);
+        // Default delay time is 1000ms
+        assertEquals(1000L, parsedRepeatable[1]);
+        assertEquals("Parsed period should be one minute in milliseconds but is " + parsedRepeatable[2], MINUTE_IN_MILLISECONDS, parsedRepeatable[2]);
+    }
+}

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/event/BoundaryEventOnTaskWithCalendarTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/event/BoundaryEventOnTaskWithCalendarTest.java
@@ -15,6 +15,7 @@
 
 package org.jbpm.test.functional.event;
 
+import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.HashMap;
 
@@ -22,7 +23,6 @@ import org.drools.core.time.TimeUtils;
 import org.jbpm.process.core.timer.BusinessCalendarImpl;
 import org.jbpm.test.JbpmTestCase;
 import org.jbpm.test.listener.CountDownProcessEventListener;
-import org.joda.time.DateTime;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
@@ -47,9 +47,8 @@ public class BoundaryEventOnTaskWithCalendarTest extends JbpmTestCase {
         ksession.getEnvironment().set("jbpm.business.calendar", new BusinessCalendarImpl());
         
         HashMap<String, Object> params = new HashMap<String, Object>();
-        DateTime now = new DateTime(System.currentTimeMillis());
-        now.plus(2000);
-        params.put("date", now.toString());
+        OffsetDateTime plusTwoSeconds = OffsetDateTime.now().plusSeconds(2);
+        params.put("date", plusTwoSeconds.toString());
 
 
         ProcessInstance processInstance = ksession.startProcess("boundaryTimer", params);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/ConcurrentGlobalTimerServiceTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/ConcurrentGlobalTimerServiceTest.java
@@ -22,7 +22,6 @@ import org.jbpm.process.core.timer.GlobalSchedulerService;
 import org.jbpm.process.core.timer.impl.ThreadPoolSchedulerService;
 import org.jbpm.services.task.exception.PermissionDeniedException;
 import org.jbpm.services.task.identity.JBossUserGroupCallbackImpl;
-import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -179,10 +178,8 @@ public class ConcurrentGlobalTimerServiceTest extends TimerBaseTest {
                 ut.begin();
                 logger.debug("Starting process on ksession {}", runtime.getKieSession().getIdentifier());
                 Map<String, Object> params = new HashMap<String, Object>();
-                DateTime now = new DateTime();
-                now.plus(1000);
 
-                params.put("x", "R2/" + wait + "/PT1S");
+                params.put("x", "R2/PT1S");
                 ProcessInstance processInstance = runtime.getKieSession().startProcess("IntermediateCatchEvent", params);
                 logger.debug("Started process instance {} on ksession {}", processInstance.getId(), runtime.getKieSession().getIdentifier());
                 ut.commit();


### PR DESCRIPTION
Add support for ISO_8601 repeating intervals.

Cherrypick of https://github.com/kiegroup/jbpm/pull/809 and https://github.com/kiegroup/jbpm/pull/819