### PR TITLE
[6.5.x] Fix Byteman test for IBM Java

### DIFF
--- a/jbpm-runtime-manager/pom.xml
+++ b/jbpm-runtime-manager/pom.xml
@@ -204,7 +204,40 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkMode>always</forkMode>
+          <!-- Properties for Byteman which allows it to run on IBM Java as well -->
+          <argLine>
+            -javaagent:${project.build.directory}/agents/byteman.jar=port:9091,boot:${project.build.directory}/agents/byteman.jar
+          </argLine>
+          <systemPropertyVariables>
+            <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>
+            <org.jboss.byteman.allow.config.update>true</org.jboss.byteman.allow.config.update>
+          </systemPropertyVariables>
         </configuration>
+      </plugin>
+
+      <!-- Byteman jar is copied to target/agents directory so Java is able to bootstrap it -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-agent</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.jboss.byteman</groupId>
+                  <artifactId>byteman</artifactId>
+                  <outputDirectory>${project.build.directory}/agents</outputDirectory>
+                  <destFileName>byteman.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/TimerInitFailureRuntimeManagerTest.java
+++ b/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/TimerInitFailureRuntimeManagerTest.java
@@ -86,7 +86,7 @@ public class TimerInitFailureRuntimeManagerTest extends AbstractBaseTest {
     }
  
     
-    @Test(timeout=10000)
+    @Test(timeout=15000)
     @BMScript(value = "byteman-scripts/failOnRuntimeManagerInitRules.btm")
     public void testPerProcessInstanceRuntimeManager() throws Exception {
         final CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("Intermediate Catch Event 1", 1);


### PR DESCRIPTION
Hi, @mswiderski,

I noticed that this new Byteman test hasn't been passing with IBM Java, but I have found a way to boot Byteman even with this version of Java. What do you think? Should I create the same workaround for other modules where Byteman is used?

Thanks,

Marian
