### PR TITLE
[7.0.x] JBPM-5897 - Fails to start a process with CorrelationKey which is unique but includes correlation properties of an existing correlation key

### DIFF
--- a/jbpm-persistence/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/JpaProcessPersistenceContext.java
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/JpaProcessPersistenceContext.java
@@ -138,12 +138,8 @@ public class JpaProcessPersistenceContext extends JpaPersistenceContext
      */
     public Long getProcessInstanceByCorrelationKey(CorrelationKey correlationKey) {
         Query processInstancesForEvent = getEntityManager().createNamedQuery( "GetProcessInstanceIdByCorrelation" );
-        processInstancesForEvent.setParameter( "elem_count", new Long(correlationKey.getProperties().size()) );
-        List<Object> properties = new ArrayList<Object>();
-        for (CorrelationProperty<?> property : correlationKey.getProperties()) {
-            properties.add(property.getValue());
-        }
-        processInstancesForEvent.setParameter( "properties", properties );
+        processInstancesForEvent.setParameter( "ckey", correlationKey.toExternalForm());
+        
         try {
             return (Long) processInstancesForEvent.getSingleResult();
         } catch (NonUniqueResultException e) {

--- a/jbpm-persistence/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/correlation/JPACorrelationKeyFactory.java
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/correlation/JPACorrelationKeyFactory.java
@@ -29,7 +29,7 @@ public class JPACorrelationKeyFactory implements CorrelationKeyFactory {
 
         CorrelationKeyInfo correlationKey = new CorrelationKeyInfo();
         correlationKey.addProperty(new CorrelationPropertyInfo(null, businessKey));
-
+        correlationKey.setName(correlationKey.toExternalForm());
         return correlationKey;
     }
 
@@ -42,7 +42,7 @@ public class JPACorrelationKeyFactory implements CorrelationKeyFactory {
         for (String businessKey : properties) {
             correlationKey.addProperty(new CorrelationPropertyInfo(null, businessKey));
         }
-
+        correlationKey.setName(correlationKey.toExternalForm());
         return correlationKey;
     }
 }

--- a/jbpm-persistence/jbpm-persistence-jpa/src/main/resources/META-INF/JBPMorm.xml
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/main/resources/META-INF/JBPMorm.xml
@@ -21,13 +21,8 @@ where
     key.processInstanceId 
 from 
     CorrelationKeyInfo key 
-    left join key.properties props 
 where 
-    cast(:elem_count as integer) = 
-	(select count(id) from CorrelationPropertyInfo cpi where cpi.correlationKey.id = key.id) and 
-    props.value in :properties 
-    group by key.id,key.processInstanceId 
-having count(key.id) = :elem_count
+    key.name = :ckey
     </query>
   </named-query>
   <named-query name="GetCorrelationKeysByProcessInstanceId">

--- a/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/correlation/CorrelationPersistenceTest.java
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/correlation/CorrelationPersistenceTest.java
@@ -101,8 +101,7 @@ public class CorrelationPersistenceTest extends AbstractBaseTest {
         EntityManager em = emf.createEntityManager();
 
         Query query = em.createNamedQuery("GetProcessInstanceIdByCorrelation");
-        query.setParameter("properties", Arrays.asList(new String[] {"test123"}));
-        query.setParameter("elem_count", new Long(1));
+        query.setParameter("ckey", "test123");        
         
         List<Long> processInstances = query.getResultList();
         em.close();
@@ -116,8 +115,7 @@ public class CorrelationPersistenceTest extends AbstractBaseTest {
         EntityManager em = emf.createEntityManager();
         
         Query query = em.createNamedQuery("GetProcessInstanceIdByCorrelation");
-        query.setParameter("properties", Arrays.asList(new String[] {"test123"}));
-        query.setParameter("elem_count", new Long(2));
+        query.setParameter("ckey", "test1234"); 
         
         List<Long> processInstances = query.getResultList();
         em.close();
@@ -131,8 +129,7 @@ public class CorrelationPersistenceTest extends AbstractBaseTest {
         EntityManager em = emf.createEntityManager();
         
         Query query = em.createNamedQuery("GetProcessInstanceIdByCorrelation");
-        query.setParameter("properties", Arrays.asList(new String[] {"test123", "123test"}));
-        query.setParameter("elem_count", new Long(2));
+        query.setParameter("ckey", "test123:123test");
         
         List<Long> processInstances = query.getResultList();
         em.close();

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/mapper/JPAMapper.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/mapper/JPAMapper.java
@@ -127,12 +127,7 @@ public class JPAMapper extends InternalMapper {
     public Context getProcessInstanceByCorrelationKey(CorrelationKey correlationKey, EntityManager em) {
         Query processInstancesForEvent = em.createNamedQuery( "GetProcessInstanceIdByCorrelation" );
         
-        processInstancesForEvent.setParameter( "elem_count", new Long(correlationKey.getProperties().size()) );
-        List<Object> properties = new ArrayList<Object>();
-        for (CorrelationProperty<?> property : correlationKey.getProperties()) {
-            properties.add(property.getValue());
-        }
-        processInstancesForEvent.setParameter( "properties", properties );
+        processInstancesForEvent.setParameter( "ckey", correlationKey.toExternalForm());
         try {
             return ProcessInstanceIdContext.get((Long) processInstancesForEvent.getSingleResult());
         } catch (NonUniqueResultException e) {

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/CorrelationKeyTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/CorrelationKeyTest.java
@@ -151,4 +151,15 @@ public class CorrelationKeyTest extends JbpmTestCase {
         Assertions.assertThat(variables.get(0).getValue()).isEqualTo(VARIABLE_VALUE);
     }
 
+    @Test
+    public void testMultiValuedKeyUniqueButInclusive() {
+        // JBPM-5897
+        CorrelationKey key1 = keyFactory.newCorrelationKey(Arrays.asList("ABC", "DEF", "DEF"));
+        ProcessInstance processInstance = ksession.startProcess(PROCESS, key1, null);
+        assertProcessInstanceActive(processInstance.getId());
+
+        CorrelationKey key2 = keyFactory.newCorrelationKey(Arrays.asList("ABC", "DEF", "GHI"));
+        ProcessInstance processInstance2 = ksession.startProcess(PROCESS, key2, null);
+        assertProcessInstanceActive(processInstance2.getId());
+    }
 }


### PR DESCRIPTION
@tsurdilo here is a back port from master to 7.0.x