### PR TITLE
JBPM-5974: Extend tests triggering case ad-hoc tasks

### DIFF
--- a/jbpm-case-mgmt/jbpm-case-mgmt-api/src/main/java/org/jbpm/casemgmt/api/CaseService.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-api/src/main/java/org/jbpm/casemgmt/api/CaseService.java
@@ -27,10 +27,10 @@ import org.jbpm.casemgmt.api.model.instance.CaseRoleInstance;
 import org.jbpm.casemgmt.api.model.instance.CommentInstance;
 import org.jbpm.casemgmt.api.model.instance.CommentSortBy;
 import org.jbpm.services.api.ProcessInstanceNotFoundException;
+import org.kie.api.runtime.query.QueryContext;
 import org.kie.api.task.model.Group;
 import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.User;
-import org.kie.api.runtime.query.QueryContext;
 
 /**
  * Provides case management operations.
@@ -43,27 +43,27 @@ public interface CaseService {
      * Case id is generated based on case id prefix (defined on case definition) and generated value.<br>
      * <code>CASE-XXXXXXXXX</code> where <code>XXXXXXX</code> is generated value for the prefix<br/>
      * Examples:
-     * <ul> 
-     *  <li>CASE-0000000123</li>
-     *  <li>HR-0000000321</li>
-     *  <li>LOAN-0000000099</li>
+     * <ul>
+     * <li>CASE-0000000123</li>
+     * <li>HR-0000000321</li>
+     * <li>LOAN-0000000099</li>
      * </ul>
      * @param deploymentId deployment id of project that case definition belongs to
      * @param caseDefinitionId id of case definition
      * @return returns unique case id in the format PREFIX-GENERATED_ID as described above
      */
     String startCase(String deploymentId, String caseDefinitionId);
-    
+
     /**
      * Starts a new case for given definition with given case file.
      * <br/>
      * Case id is generated based on case id prefix (defined on case definition) and generated value.<br>
      * <code>CASE-XXXXXXXXX</code> where <code>XXXXXXX</code> is generated value for the prefix<br/>
      * Examples:
-     * <ul> 
-     *  <li>CASE-0000000123</li>
-     *  <li>HR-0000000321</li>
-     *  <li>LOAN-0000000099</li>
+     * <ul>
+     * <li>CASE-0000000123</li>
+     * <li>HR-0000000321</li>
+     * <li>LOAN-0000000099</li>
      * </ul>
      * @param deploymentId deployment id of project that case definition belongs to
      * @param caseDefinitionId id of case definition
@@ -71,15 +71,15 @@ public interface CaseService {
      * @return returns unique case id in the format PREFIX-GENERATED_ID as described above
      */
     String startCase(String deploymentId, String caseDefinitionId, CaseFileInstance caseFile);
-    
+
     /**
      * Returns Case file for give case id
-     * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method 
+     * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
      * @return returns current snapshot of CaseFileInstance
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     CaseFileInstance getCaseFileInstance(String caseId) throws CaseNotFoundException;
-    
+
     /**
      * Returns case instance (only if it's active) identified by given case id - does not load case file, roles, milestones nor stages.
      * Use {@link #getCaseInstance(String, boolean, boolean, boolean, boolean)} for more advanced fetch options.
@@ -88,7 +88,7 @@ public interface CaseService {
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     CaseInstance getCaseInstance(String caseId) throws CaseNotFoundException;
-    
+
     /**
      * Returns case instance (only if it's active) identified by given case id with options on what should be fetched
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
@@ -100,23 +100,23 @@ public interface CaseService {
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     CaseInstance getCaseInstance(String caseId, boolean withData, boolean withRoles, boolean withMilestones, boolean withStages) throws CaseNotFoundException;
-    
+
     /**
-     * Cancels case with given case id (including all attached process instances if any). 
-     * Does not affect case file so in case it can still be used to reopen the case by starting new instances. 
+     * Cancels case with given case id (including all attached process instances if any).
+     * Does not affect case file so in case it can still be used to reopen the case by starting new instances.
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     void cancelCase(String caseId) throws CaseNotFoundException;
-    
+
     /**
-     * Permanently destroys case identified by given case id. It performs the same operation as abortCase 
+     * Permanently destroys case identified by given case id. It performs the same operation as abortCase
      * and destroys the case file and other attached information.
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     void destroyCase(String caseId) throws CaseNotFoundException;
-    
+
     /**
      * Reopens case given by case id by starting another instance of case definition. It will inherit all data
      * from case file that was available in before case was closed/canceled.
@@ -127,7 +127,7 @@ public interface CaseService {
      * @throws CaseActiveException thrown when case is still active
      */
     void reopenCase(String caseId, String deploymentId, String caseDefinitionId) throws CaseNotFoundException;
-    
+
     /**
      * Reopens case given by case id by starting another instance of case definition. It will inherit all data
      * from case file that was available in before case was closed/canceled.
@@ -143,28 +143,28 @@ public interface CaseService {
     /*
      * dynamic case operations section
      */
-    
+
     /**
-     * Adds new user task to specified case. Should be used when user task should be added to the main process instance of the case. 
-     * If there are more process instances for given case and user task should be added to specific process instance 
+     * Adds new user task to specified case. Should be used when user task should be added to the main process instance of the case.
+     * If there are more process instances for given case and user task should be added to specific process instance
      * {@link #addDynamicTask(Long, TaskSpecification)} should be used
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
      * @param taskSpecification complete specification that defines the type of a task to be added
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     void addDynamicTask(String caseId, TaskSpecification taskSpecification) throws CaseNotFoundException;
-    
+
     /**
-     * Adds new user task to specified process instance. 
+     * Adds new user task to specified process instance.
      * @param processInstanceId unique process instance id
      * @param taskSpecification complete specification that defines the type of a task to be added
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     void addDynamicTask(Long processInstanceId, TaskSpecification taskSpecification) throws ProcessInstanceNotFoundException;
-    
+
     /**
-     * Adds new user task to specified case and stage. Should be used when user task should be added to the main process instance of the case. 
-     * If there are more process instances for given case and user task should be added to specific process instance 
+     * Adds new user task to specified case and stage. Should be used when user task should be added to the main process instance of the case.
+     * If there are more process instances for given case and user task should be added to specific process instance
      * {@link #addDynamicTaskToStage(Long, String, TaskSpecification)} should be used
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
      * @param stageId id of the stage there the task should be added
@@ -173,9 +173,9 @@ public interface CaseService {
      * @throws StageNotFoundException thrown in case stage does not exist
      */
     void addDynamicTaskToStage(String caseId, String stageId, TaskSpecification taskSpecification) throws CaseNotFoundException, StageNotFoundException;
-    
+
     /**
-     * Adds new user task to specified case and stage on given process instance. 
+     * Adds new user task to specified case and stage on given process instance.
      * @param processInstanceId unique process instance id
      * @param stageId id of the stage there the task should be added
      * @param taskSpecification complete specification that defines the type of a task to be added
@@ -183,10 +183,10 @@ public interface CaseService {
      * @throws StageNotFoundException thrown in case stage does not exist
      */
     void addDynamicTaskToStage(Long processInstanceId, String stageId, TaskSpecification taskSpecification) throws CaseNotFoundException, StageNotFoundException;
-    
+
     /**
-     * Adds new subprocess (identified by process id) to given process instance. Should be used when subprocess should be added to the main process instance of the case. 
-     * If there are more process instances for given case and subprocess should be added to specific process instance 
+     * Adds new subprocess (identified by process id) to given process instance. Should be used when subprocess should be added to the main process instance of the case.
+     * If there are more process instances for given case and subprocess should be added to specific process instance
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
      * @param processId identifier of the process to be added
      * @param parameters optional parameters for the subprocess
@@ -194,7 +194,7 @@ public interface CaseService {
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     Long addDynamicSubprocess(String caseId, String processId, Map<String, Object> parameters) throws CaseNotFoundException;
-    
+
     /**
      * Adds new subprocess (identified by process id) to case.
      * @param processInstanceId unique process instance id
@@ -204,10 +204,10 @@ public interface CaseService {
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     Long addDynamicSubprocess(Long processInstanceId, String processId, Map<String, Object> parameters) throws CaseNotFoundException;
-    
+
     /**
-     * Adds new subprocess (identified by process id) to given process instance. Should be used when subprocess should be added to the 
-     * main process instance of the case. If there are more process instances for given case and subprocess should be added to specific process instance 
+     * Adds new subprocess (identified by process id) to given process instance. Should be used when subprocess should be added to the
+     * main process instance of the case. If there are more process instances for given case and subprocess should be added to specific process instance
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method {@link #addDynamicSubprocess(Long, String, Map)}
      * method should be used instead.
      * @param stageId id of the stage there the task should be added
@@ -217,7 +217,7 @@ public interface CaseService {
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     Long addDynamicSubprocessToStage(String caseId, String stageId, String processId, Map<String, Object> parameters) throws CaseNotFoundException;
-    
+
     /**
      * Adds new subprocess (identified by process id) to case.
      * @param processInstanceId unique process instance id
@@ -228,20 +228,20 @@ public interface CaseService {
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     Long addDynamicSubprocessToStage(Long processInstanceId, String stageId, String processId, Map<String, Object> parameters) throws CaseNotFoundException;
-    
+
     /**
-     * Triggers given by fragmentName adhoc element (such as task, milestone) within given case.  Should be used when fragment should be triggered 
+     * Triggers given by fragmentName adhoc element (such as task, milestone) within given case.  Should be used when fragment should be triggered
      * on the main process instance of the case. If there are more process instances for given case and fragment should be triggered on specific process
-     *  instance {@link #triggerAdHocFragment(Long, String, Object)} method should be used instead 
+     * instance {@link #triggerAdHocFragment(Long, String, Object)} method should be used instead
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
      * @param fragmentName name of the element that can be triggered
      * @param data optional data to be given when triggering the node
      */
     void triggerAdHocFragment(String caseId, String fragmentName, Object data) throws CaseNotFoundException;
-    
+
     /**
      * Triggers given by fragmentName adhoc element (such as task, milestone) within given process instance
-     * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
+     * @param processInstanceId unique process instance id
      * @param fragmentName name of the element that can be triggered
      * @param data optional data to be given when triggering the node
      * @throws CaseNotFoundException thrown in case case was not found with given id
@@ -251,7 +251,7 @@ public interface CaseService {
     /*
      * Case file section
      */
-    
+
     /**
      * Adds given named value into case file of given case.
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
@@ -260,15 +260,15 @@ public interface CaseService {
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     void addDataToCaseFile(String caseId, String name, Object value) throws CaseNotFoundException;
-    
+
     /**
      * Adds complete map to case file of given case. Replaces any existing value that is registered under same name.
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
      * @param data key value representing data to be added to case file
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
-    void addDataToCaseFile(String caseId, Map<String,Object> data) throws CaseNotFoundException;
-    
+    void addDataToCaseFile(String caseId, Map<String, Object> data) throws CaseNotFoundException;
+
     /**
      * Removes given variable (stored under name) from case file of given case.
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
@@ -276,7 +276,7 @@ public interface CaseService {
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     void removeDataFromCaseFile(String caseId, String name) throws CaseNotFoundException;
-    
+
     /**
      * Removes given variables (stored under variableNames) from case file of given case.
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
@@ -288,17 +288,17 @@ public interface CaseService {
     /*
      * Case role section
      */
-    
+
     /**
      * Assigns given entity (user or group) to case role for a given case. Case roles can be used for user task assignments.
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
      * @param role name of the role entity should be assigned to
      * @param entity user or group to be assigned to given role
      * @throws CaseNotFoundException thrown in case case was not found with given id
-     * @throws IllegalArgumentException thrown in case there no role found with given name or cardinality was exceeded 
+     * @throws IllegalArgumentException thrown in case there no role found with given name or cardinality was exceeded
      */
     void assignToCaseRole(String caseId, String role, OrganizationalEntity entity) throws CaseNotFoundException;
-    
+
     /**
      * Removes given entity (user or group) from the case role for a given case.
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
@@ -307,10 +307,10 @@ public interface CaseService {
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     void removeFromCaseRole(String caseId, String role, OrganizationalEntity entity) throws CaseNotFoundException;
-    
+
     /**
      * Returns role assignments for given case
-     * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method 
+     * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
      * @return returns collection of all currently defined role assignments of the given case
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
@@ -319,15 +319,15 @@ public interface CaseService {
     /*
      * Case comments section
      */
-    
+
     /**
      * Returns all case comments sorted by date
-     * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method 
+     * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
      * @return returns all comments added to given case
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     Collection<CommentInstance> getCaseComments(String caseId, QueryContext queryContext) throws CaseNotFoundException;
-    
+
     /**
      * Returns all case comments sorted with given sortBy
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
@@ -336,7 +336,7 @@ public interface CaseService {
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     Collection<CommentInstance> getCaseComments(String caseId, CommentSortBy sortBy, QueryContext queryContext) throws CaseNotFoundException;
-    
+
     /**
      * Adds new comment to the case
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
@@ -345,7 +345,7 @@ public interface CaseService {
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     void addCaseComment(String caseId, String author, String comment) throws CaseNotFoundException;
-    
+
     /**
      * Updated given comment with entire text provided
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
@@ -355,7 +355,7 @@ public interface CaseService {
      * @throws CaseNotFoundException thrown in case case was not found with given id
      */
     void updateCaseComment(String caseId, String commentId, String author, String text) throws CaseNotFoundException;
-    
+
     /**
      * Removes given comment from the case comments list
      * @param caseId unique case id in the format PREFIX-GENERATED_ID as described on startCase method
@@ -367,7 +367,7 @@ public interface CaseService {
     /*
      * Case model instance creation section
      */
-    
+
     /**
      * Builds and returns new CaseFileInstance with given data. Not yet associated with any case
      * @param deploymentId deployment that case belongs to
@@ -376,7 +376,7 @@ public interface CaseService {
      * @return returns new instance (not associated with case) of CaseFileInstance populated with given data
      */
     CaseFileInstance newCaseFileInstance(String deploymentId, String caseDefinition, Map<String, Object> data);
-    
+
     /**
      * Builds and returns new CaseFileInstance with given data and roles assignments. Not yet associated with any case
      * @param deploymentId deployment that case belongs to
@@ -386,19 +386,19 @@ public interface CaseService {
      * @return returns new instance (not associated with case) of CaseFileInstance populated with given data
      */
     CaseFileInstance newCaseFileInstance(String deploymentId, String caseDefinition, Map<String, Object> data, Map<String, OrganizationalEntity> rolesAssignment);
-    
+
     /**
      * Returns new TaskSpecification describing user task so it can be created as dynamic task. All string
      * based attributes support variable expressions (#{variable-name})
      * @param taskName - mandatory name of the task
      * @param description - optional description of the task
      * @param actorIds - optional list (comma separated) of actors to be assigned
-     * @param groupIds - optional list (comma separated) of groups to be assigned 
+     * @param groupIds - optional list (comma separated) of groups to be assigned
      * @param parameters - optional parameters (task inputs)
      * @return
      */
     TaskSpecification newHumanTaskSpec(String taskName, String description, String actorIds, String groupIds, Map<String, Object> parameters);
-    
+
     /**
      * Returns new TaskSpecification describing generic (work item based) task so it can be added as dynamic task.
      * @param nodeType - type of a node (same as used for registering work item handler)
@@ -407,14 +407,14 @@ public interface CaseService {
      * @return
      */
     TaskSpecification newTaskSpec(String nodeType, String nodeName, Map<String, Object> parameters);
-    
+
     /**
      * Creates new user with given id;
      * @param userId user id to be used when creating User instance
      * @return new instance for userId
      */
     User newUser(String userId);
-    
+
     /**
      * Creates new group with given id;
      * @param groupId group id to be used when creating Group instance


### PR DESCRIPTION
I have extended case management tests which cover triggering ad-hoc tasks. This is needed in order to properly test [BPMSPL-317](https://issues.jboss.org/browse/BPMSPL-317).

I have also fixed `processInstanceId` parameter in the JavaDoc of `triggerAdHocFragment` from `CaseService`.

It seems that the files were not properly formatted so there are many whitespace changes. You can look at this commit without whitespace changes [here](https://github.com/kiegroup/jbpm/commit/8327a326fc14395c0bac232146213e7b940c1a12?w=1).