### PR TITLE
RHBPMS-4729 QuartzSchedulerService increments NEXT_FIRE_TIME by timeC…

### DIFF
--- a/jbpm-test-coverage/src/test/resources/quartz-db-short-misfire.properties
+++ b/jbpm-test-coverage/src/test/resources/quartz-db-short-misfire.properties
@@ -1,0 +1,66 @@
+#org.quartz.jobStore.class = org.quartz.simpl.RAMJobStore
+
+
+#============================================================================
+# Configure Main Scheduler Properties  
+#============================================================================
+
+org.quartz.scheduler.instanceName = TestScheduler
+org.quartz.scheduler.instanceId = instance_one
+org.quartz.scheduler.skipUpdateCheck=true
+org.quartz.scheduler.idleWaitTime=1000
+#============================================================================
+# Configure ThreadPool  
+#============================================================================
+
+org.quartz.threadPool.class = org.quartz.simpl.SimpleThreadPool
+org.quartz.threadPool.threadCount = 15
+org.quartz.threadPool.threadPriority = 5
+
+
+#============================================================================
+# Configure JobStore  
+#============================================================================
+
+org.quartz.jobStore.misfireThreshold = 3000
+
+org.quartz.jobStore.class=org.quartz.impl.jdbcjobstore.JobStoreCMT
+org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.StdJDBCDelegate
+org.quartz.jobStore.useProperties=false
+org.quartz.jobStore.dataSource=myDS
+org.quartz.jobStore.nonManagedTXDataSource=notManagedDS
+org.quartz.jobStore.tablePrefix=QRTZ_
+org.quartz.jobStore.isClustered=false
+
+#============================================================================
+# Other Example Delegates
+#============================================================================
+#org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.CloudscapeDelegate
+#org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.DB2v6Delegate
+#org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.DB2v7Delegate
+#org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.DriverDelegate
+#org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.HSQLDBDelegate
+#org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.MSSQLDelegate
+#org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.PointbaseDelegate
+#org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+#org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.StdJDBCDelegate
+#org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.WebLogicDelegate
+#org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.oracle.OracleDelegate
+#org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.oracle.WebLogicOracleDelegate
+
+#============================================================================
+# Configure Datasources  
+#============================================================================
+org.quartz.dataSource.myDS.jndiURL=jdbc/jbpm-ds
+#this notManagedDS should be same as one defined in TimerBaseTest class
+#org.quartz.dataSource.notManagedDS.driver=org.h2.Driver
+#org.quartz.dataSource.notManagedDS.URL=jdbc:h2:mem:test;MVCC=true
+#org.quartz.dataSource.notManagedDS.user=sa
+#org.quartz.dataSource.notManagedDS.password=
+#org.quartz.dataSource.notManagedDS.maxConnections=5
+org.quartz.dataSource.notManagedDS.connectionProvider.class=org.jbpm.test.functional.timer.addon.NonTransactionalConnectionProvider
+org.quartz.dataSource.notManagedDS.driverClassName=org.h2.Driver
+org.quartz.dataSource.notManagedDS.user=sa
+org.quartz.dataSource.notManagedDS.password=sasa
+org.quartz.dataSource.notManagedDS.url=jdbc:h2:mem:test;MVCC=true
+


### PR DESCRIPTION
…ycle regardless of current time when calling rescheduleJob()

Please review, thanks!

Some points:

- It calls trigger.setNextFireTime() to update org.drools.core.time.impl.IntervalTrigger/CronTrigger not only SimpleTrigger. If it updates SimpleTrigger only, IntervalTrigger/CronTrigger would stay old so this logic would be executed every time.

- I'm not sure what value is good for "org.jbpm.timer.reschedule.delay" default. I set "500ms" because there was 70ms gap in a known issue case (RHBPMS-4717).