### PR TITLE
Add .gitignore file to jbpm-persistence module

### DIFF
--- a/jbpm-persistence/.gitignore
+++ b/jbpm-persistence/.gitignore
@@ -1,0 +1,12 @@
+/target
+/local
+/bin
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml
+


### PR DESCRIPTION
During the refactoring of the _jbpm-persistence_ module, the **.gitignore** file has been removed from this module's root directory and Git sees all files and directories created by IDEs now. This pull-request addresses this problem.