### PR TITLE
[6.5.x] RHBPMS-4659 - persisting org.slf4j.Logger fails - temp fix for test

### DIFF
--- a/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/processinstance/ProcessInstanceResolverStrategyTest.java
+++ b/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/processinstance/ProcessInstanceResolverStrategyTest.java
@@ -125,8 +125,7 @@ public class ProcessInstanceResolverStrategyTest extends AbstractBaseTest {
         NonSerializableClass processVar = new NonSerializableClass();
         processVar.setString("1234567890");
         params.put(VAR_NAME, processVar);
-        params.put("logger", logger);
-
+        
         // Persist variable
         UserTransaction ut = (UserTransaction) new InitialContext().lookup("java:comp/UserTransaction");
         ut.begin();


### PR DESCRIPTION
change in https://github.com/kiegroup/droolsjbpm-build-bootstrap/commit/c1df75a4d209ae8c705a2848f9679658f8051c7d#diff-600376dffeb79835ede4a0b285078036R77
weirdly affected this test where a slf4j logger was intersted into ksession and was persisted. 

Temp fix for this test while someone can figure out why this change in bootstrap affected it.