### PR TITLE
JBPM-6013: Extend case stage completion condition tests

### DIFF
--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/CarInsuranceClaimCaseTest.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/CarInsuranceClaimCaseTest.java
@@ -16,14 +16,6 @@
 
 package org.jbpm.casemgmt.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.kie.scanner.MavenRepository.getMavenRepository;
-
-import java.io.File;
-import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.jbpm.casemgmt.api.model.instance.CaseFileInstance;
 import org.jbpm.casemgmt.api.model.instance.CaseInstance;
 import org.jbpm.casemgmt.api.model.instance.CaseStageInstance;
@@ -44,17 +35,12 @@ import org.jbpm.casemgmt.impl.util.AbstractCaseServicesBaseTest;
 import org.jbpm.casemgmt.impl.util.CountDownListenerFactory;
 import org.jbpm.document.Document;
 import org.jbpm.document.service.impl.DocumentImpl;
-import org.jbpm.kie.services.impl.KModuleDeploymentUnit;
-import org.jbpm.services.api.model.DeploymentUnit;
 import org.jbpm.services.api.model.ProcessInstanceDesc;
 import org.jbpm.services.task.impl.model.UserImpl;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
-import org.kie.api.KieServices;
-import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.query.QueryContext;
 import org.kie.api.task.model.OrganizationalEntity;
@@ -62,100 +48,66 @@ import org.kie.api.task.model.Status;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.query.QueryFilter;
 import org.kie.internal.runtime.conf.ObjectModel;
-import org.kie.scanner.MavenRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.Assert.*;
+
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class CarInsuranceClaimCaseTest extends AbstractCaseServicesBaseTest {
-    
+
     private static final Logger logger = LoggerFactory.getLogger(CarInsuranceClaimCaseTest.class);
-    private static final String TEST_DOC_STORAGE = "target/docs";
-    
-    private List<DeploymentUnit> units = new ArrayList<DeploymentUnit>();
-    
+
     private static final String CAR_INSURANCE_CLAIM_PROC_ID = "insurance-claims.CarInsuranceClaimCase";
-    
+
     protected static final String CAR_INS_CASE_ID = "CAR_INS-0000000001";
-    
-    @Before
-    public void prepare() {
-        System.setProperty("org.jbpm.document.storage", TEST_DOC_STORAGE);
-        deleteFolder(TEST_DOC_STORAGE);
-        configureServices();
-        KieServices ks = KieServices.Factory.get();
-        ReleaseId releaseId = ks.newReleaseId(GROUP_ID, ARTIFACT_ID, VERSION);
+
+    @Override
+    protected List<String> getProcessDefinitionFiles() {
         List<String> processes = new ArrayList<String>();
         processes.add("org/jbpm/casemgmt/demo/insurance/CarInsuranceClaimCase.bpmn2");
         processes.add("org/jbpm/casemgmt/demo/insurance/insurance-rules.drl");
-        
-        
-        InternalKieModule kJar1 = createKieJar(ks, releaseId, processes);
-        File pom = new File("target/kmodule", "pom.xml");
-        pom.getParentFile().mkdir();
-        try {
-            FileOutputStream fs = new FileOutputStream(pom);
-            fs.write(getPom(releaseId).getBytes());
-            fs.close();
-        } catch (Exception e) {
-            
-        }
-        MavenRepository repository = getMavenRepository();
-        repository.deployArtifact(releaseId, kJar1, pom);
-        // use user name who is part of the case roles assignment
-        // so (s)he will be authorized to access case instance
-        identityProvider.setName("john");
+        return processes;
     }
-    
+
     @After
-    public void cleanup() {
-        identityProvider.reset();
-        System.clearProperty("org.jbpm.document.storage");
-        cleanupSingletonSessionId();
-        if (units != null && !units.isEmpty()) {
-            for (DeploymentUnit unit : units) {
-                deploymentService.undeploy(unit);
-            }
-            units.clear();
-        }
-        close();
+    public void tearDown() {
+        super.tearDown();
         CountDownListenerFactory.clear();
     }
-    
+
     @Test
     public void testCarInsuranceClaimCase() {
-        String deploymentId = deployAndAssert();
         // let's assign users to roles so they can be participants in the case
-        String caseId = startAndAssertCaseInstance(deploymentId, "john", "mary");
+        String caseId = startAndAssertCaseInstance(deploymentUnit.getIdentifier(), "john", "mary");
         try {
             // let's verify case is created
-            assertCaseInstance(deploymentId, CAR_INS_CASE_ID);
+            assertCaseInstance(deploymentUnit.getIdentifier(), CAR_INS_CASE_ID);
             // let's look at what stages are active
-            assertBuildClaimReportStage();            
+            assertBuildClaimReportStage();
             // since the first task assigned to insured is with auto start it should be already active            
             // the same task can be claimed by insuranceRepresentative in case claim is reported over phone
-            long taskId = assertBuildClaimReportAvailableForBothRoles();            
+            long taskId = assertBuildClaimReportAvailableForBothRoles();
             // let's provide claim report with initial data            
             // claim report should be stored in case file data
-            provideAndAssertClaimReport(taskId);            
+            provideAndAssertClaimReport(taskId);
             // now we have another task for insured to provide property damage report
-            taskId = assertPropertyDamageReportAvailableForBothRoles();            
+            taskId = assertPropertyDamageReportAvailableForBothRoles();
             // let's provide the property damage report
-            provideAndAssertPropertyDamageReport(taskId);  
+            provideAndAssertPropertyDamageReport(taskId);
             // let's complete the stage by explicitly stating that claimReport is done
             caseService.addDataToCaseFile(CAR_INS_CASE_ID, "claimReportDone", true);
             // we should be in another stage - Claim assessment
             assertClaimAssesmentStage();
             // let's trigger claim offer calculation
-            caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Calculate claim", null);            
+            caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Calculate claim", null);
             // now we have another task for insured as claim was calculated            
             // let's accept the calculated claim 
-            assertAndAcceptClaimOffer();            
+            assertAndAcceptClaimOffer();
             // there should be no process instances for the case
-            Collection<ProcessInstanceDesc> caseProcesInstances = caseRuntimeDataService.getProcessInstancesForCase(CAR_INS_CASE_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE),  new QueryContext());
-            assertEquals(0, caseProcesInstances.size());   
+            Collection<ProcessInstanceDesc> caseProcesInstances = caseRuntimeDataService.getProcessInstancesForCase(CAR_INS_CASE_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), new QueryContext());
+            assertEquals(0, caseProcesInstances.size());
             caseId = null;
-            
         } catch (Exception e) {
             logger.error("Unexpected error {}", e.getMessage(), e);
             fail("Unexpected exception " + e.getMessage());
@@ -165,43 +117,41 @@ public class CarInsuranceClaimCaseTest extends AbstractCaseServicesBaseTest {
             }
         }
     }
-    
+
     @Test
     public void testCarInsuranceClaimCaseWithPoliceReport() {
-        String deploymentId = deployAndAssert();
         // let's assign users to roles so they can be participants in the case and start it
-        String caseId = startAndAssertCaseInstance(deploymentId, "john", "mary");
+        String caseId = startAndAssertCaseInstance(deploymentUnit.getIdentifier(), "john", "mary");
         try {
             // let's verify case is created
-            assertCaseInstance(deploymentId, CAR_INS_CASE_ID);
+            assertCaseInstance(deploymentUnit.getIdentifier(), CAR_INS_CASE_ID);
             // let's look at what stages are active
-            assertBuildClaimReportStage();            
+            assertBuildClaimReportStage();
             // since the first task assigned to insured is with auto start it should be already active            
             // the same task can be claimed by insuranceRepresentative in case claim is reported over phone
-            long taskId = assertBuildClaimReportAvailableForBothRoles();            
+            long taskId = assertBuildClaimReportAvailableForBothRoles();
             // let's provide claim report with initial data            
             // claim report should be stored in case file data
-            provideAndAssertClaimReport(taskId);            
+            provideAndAssertClaimReport(taskId);
             // now we have another task for insured to provide property damage report
-            taskId = assertPropertyDamageReportAvailableForBothRoles();    
+            taskId = assertPropertyDamageReportAvailableForBothRoles();
             // let's attach police report as document
-            attachAndAssertPoliceReport();            
+            attachAndAssertPoliceReport();
             // let's provide the property damage report
-            provideAndAssertPropertyDamageReport(taskId);            
+            provideAndAssertPropertyDamageReport(taskId);
             // let's complete the stage by explicitly stating that claimReport is done
-            caseService.addDataToCaseFile(CAR_INS_CASE_ID, "claimReportDone", true);            
+            caseService.addDataToCaseFile(CAR_INS_CASE_ID, "claimReportDone", true);
             // we should be in another stage - Claim assessment
             assertClaimAssesmentStage();
             // let's trigger claim offer calculation
-            caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Calculate claim", null);            
+            caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Calculate claim", null);
             // now we have another task for insured as claim was calculated            
             // let's accept the calculated claim 
-            assertAndAcceptClaimOffer();            
+            assertAndAcceptClaimOffer();
             // there should be no process instances for the case
-            Collection<ProcessInstanceDesc> caseProcesInstances = caseRuntimeDataService.getProcessInstancesForCase(CAR_INS_CASE_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE),  new QueryContext());
-            assertEquals(0, caseProcesInstances.size());   
+            Collection<ProcessInstanceDesc> caseProcesInstances = caseRuntimeDataService.getProcessInstancesForCase(CAR_INS_CASE_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), new QueryContext());
+            assertEquals(0, caseProcesInstances.size());
             caseId = null;
-            
         } catch (Exception e) {
             logger.error("Unexpected error {}", e.getMessage(), e);
             fail("Unexpected exception " + e.getMessage());
@@ -211,52 +161,50 @@ public class CarInsuranceClaimCaseTest extends AbstractCaseServicesBaseTest {
             }
         }
     }
-    
-    @Test(timeout=10000)
+
+    @Test(timeout = 10000)
     public void testCarInsuranceClaimCaseWithContactByInsured() {
-        String deploymentId = deployAndAssert();
         // let's assign users to roles so they can be participants in the case
-        String caseId = startAndAssertCaseInstance(deploymentId, "john", "mary");
+        String caseId = startAndAssertCaseInstance(deploymentUnit.getIdentifier(), "john", "mary");
         try {
             // let's verify case is created
-            assertCaseInstance(deploymentId, CAR_INS_CASE_ID);
+            assertCaseInstance(deploymentUnit.getIdentifier(), CAR_INS_CASE_ID);
             // let's look at what stages are active
-            assertBuildClaimReportStage();            
+            assertBuildClaimReportStage();
             // since the first task assigned to insured is with auto start it should be already active            
             // the same task can be claimed by insuranceRepresentative in case claim is reported over phone
-            long taskId = assertBuildClaimReportAvailableForBothRoles();            
+            long taskId = assertBuildClaimReportAvailableForBothRoles();
             // let's provide claim report with initial data            
             // claim report should be stored in case file data
-            provideAndAssertClaimReport(taskId);            
+            provideAndAssertClaimReport(taskId);
             // now we have another task for insured to provide property damage report
-            taskId = assertPropertyDamageReportAvailableForBothRoles();            
+            taskId = assertPropertyDamageReportAvailableForBothRoles();
             // let's provide the property damage report
-            provideAndAssertPropertyDamageReport(taskId); 
-            
+            provideAndAssertPropertyDamageReport(taskId);
+
             // before completing claim report, let's call insurance company with some questions
             // when call is answered insurance representative gets a task
-            caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Contacted by insured", null); 
+            caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Contacted by insured", null);
             attachAndAssertPoliceReport(false, null);
-            
+
             // still not satisfied, let's call insurance company with these questions again and ask for callback in 2 sec
             // when call is answered insurance representative gets a task
-            caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Contacted by insured", null); 
+            caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Contacted by insured", null);
             attachAndAssertPoliceReport(true, "2s");
-            
+
             // let's complete the stage by explicitly stating that claimReport is done
             caseService.addDataToCaseFile(CAR_INS_CASE_ID, "claimReportDone", true);
             // we should be in another stage - Claim assessment
             assertClaimAssesmentStage();
             // let's trigger claim offer calculation
-            caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Calculate claim", null);            
+            caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Calculate claim", null);
             // now we have another task for insured as claim was calculated            
             // let's accept the calculated claim 
-            assertAndAcceptClaimOffer();            
+            assertAndAcceptClaimOffer();
             // there should be no process instances for the case
-            Collection<ProcessInstanceDesc> caseProcesInstances = caseRuntimeDataService.getProcessInstancesForCase(CAR_INS_CASE_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE),  new QueryContext());
-            assertEquals(0, caseProcesInstances.size());   
+            Collection<ProcessInstanceDesc> caseProcesInstances = caseRuntimeDataService.getProcessInstancesForCase(CAR_INS_CASE_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), new QueryContext());
+            assertEquals(0, caseProcesInstances.size());
             caseId = null;
-            
         } catch (Exception e) {
             logger.error("Unexpected error {}", e.getMessage(), e);
             fail("Unexpected exception " + e.getMessage());
@@ -266,41 +214,39 @@ public class CarInsuranceClaimCaseTest extends AbstractCaseServicesBaseTest {
             }
         }
     }
-    
+
     @Test
     public void testCarInsuranceClaimCaseWithNegotiations() {
-        String deploymentId = deployAndAssert();
         // let's assign users to roles so they can be participants in the case
-        String caseId = startAndAssertCaseInstance(deploymentId, "john", "mary");
+        String caseId = startAndAssertCaseInstance(deploymentUnit.getIdentifier(), "john", "mary");
         try {
             // let's verify case is created
-            assertCaseInstance(deploymentId, CAR_INS_CASE_ID);
+            assertCaseInstance(deploymentUnit.getIdentifier(), CAR_INS_CASE_ID);
             // let's look at what stages are active
-            assertBuildClaimReportStage();            
+            assertBuildClaimReportStage();
             // since the first task assigned to insured is with auto start it should be already active            
             // the same task can be claimed by insuranceRepresentative in case claim is reported over phone
-            long taskId = assertBuildClaimReportAvailableForBothRoles();            
+            long taskId = assertBuildClaimReportAvailableForBothRoles();
             // let's provide claim report with initial data            
             // claim report should be stored in case file data
-            provideAndAssertClaimReport(taskId);            
+            provideAndAssertClaimReport(taskId);
             // now we have another task for insured to provide property damage report
-            taskId = assertPropertyDamageReportAvailableForBothRoles();            
+            taskId = assertPropertyDamageReportAvailableForBothRoles();
             // let's provide the property damage report
-            provideAndAssertPropertyDamageReport(taskId);  
+            provideAndAssertPropertyDamageReport(taskId);
             // let's complete the stage by explicitly stating that claimReport is done
             caseService.addDataToCaseFile(CAR_INS_CASE_ID, "claimReportDone", true);
             // we should be in another stage - Claim assessment
             assertClaimAssesmentStage();
             // let's trigger claim offer calculation
-            caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Calculate claim", null);            
+            caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Calculate claim", null);
             // now we have another task for insured as claim was calculated            
             // let's negotiate few times the calculated claim offer 
-            assertAndNegotiateClaimOffer(3);            
+            assertAndNegotiateClaimOffer(3);
             // there should be no process instances for the case
-            Collection<ProcessInstanceDesc> caseProcesInstances = caseRuntimeDataService.getProcessInstancesForCase(CAR_INS_CASE_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE),  new QueryContext());
-            assertEquals(0, caseProcesInstances.size());   
+            Collection<ProcessInstanceDesc> caseProcesInstances = caseRuntimeDataService.getProcessInstancesForCase(CAR_INS_CASE_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), new QueryContext());
+            assertEquals(0, caseProcesInstances.size());
             caseId = null;
-            
         } catch (Exception e) {
             logger.error("Unexpected error {}", e.getMessage(), e);
             fail("Unexpected exception " + e.getMessage());
@@ -310,43 +256,41 @@ public class CarInsuranceClaimCaseTest extends AbstractCaseServicesBaseTest {
             }
         }
     }
-    
+
     @Test
     public void testCarInsuranceClaimCaseWithAssessorInvolved() {
-        String deploymentId = deployAndAssert();
         // let's assign users to roles so they can be participants in the case
-        String caseId = startAndAssertCaseInstance(deploymentId, "john", "mary");
+        String caseId = startAndAssertCaseInstance(deploymentUnit.getIdentifier(), "john", "mary");
         try {
             // let's verify case is created
-            assertCaseInstance(deploymentId, CAR_INS_CASE_ID);
+            assertCaseInstance(deploymentUnit.getIdentifier(), CAR_INS_CASE_ID);
             // let's look at what stages are active
-            assertBuildClaimReportStage();            
+            assertBuildClaimReportStage();
             // let's now add assessor to the case as we will need his/her opinion
-            caseService.assignToCaseRole(CAR_INS_CASE_ID, "assessor", new UserImpl("krisv"));              
+            caseService.assignToCaseRole(CAR_INS_CASE_ID, "assessor", new UserImpl("krisv"));
             // since the first task assigned to insured is with auto start it should be already active            
             // the same task can be claimed by insuranceRepresentative in case claim is reported over phone
-            long taskId = assertBuildClaimReportAvailableForBothRoles();            
+            long taskId = assertBuildClaimReportAvailableForBothRoles();
             // let's provide claim report with initial data            
             // claim report should be stored in case file data
-            provideAndAssertClaimReport(taskId);            
+            provideAndAssertClaimReport(taskId);
             // now we have another task for insured to provide property damage report
-            taskId = assertPropertyDamageReportAvailableForBothRoles();            
+            taskId = assertPropertyDamageReportAvailableForBothRoles();
             // let's provide the property damage report
-            provideAndAssertPropertyDamageReport(taskId);                        
+            provideAndAssertPropertyDamageReport(taskId);
             // let's complete the stage by explicitly stating that claimReport is done
             caseService.addDataToCaseFile(CAR_INS_CASE_ID, "claimReportDone", true);
             // we should be in another stage - Claim assessment
-            assertClaimAssesmentStage();                       
+            assertClaimAssesmentStage();
             // now krisv should have a task assigned as assessor
-            assertAndRunClaimAssessment();            
+            assertAndRunClaimAssessment();
             // now we have another task for insured as claim was calculated            
             // let's accept the calculated claim 
-            assertAndAcceptClaimOffer();            
+            assertAndAcceptClaimOffer();
             // there should be no process instances for the case
-            Collection<ProcessInstanceDesc> caseProcesInstances = caseRuntimeDataService.getProcessInstancesForCase(CAR_INS_CASE_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE),  new QueryContext());
-            assertEquals(0, caseProcesInstances.size());   
+            Collection<ProcessInstanceDesc> caseProcesInstances = caseRuntimeDataService.getProcessInstancesForCase(CAR_INS_CASE_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), new QueryContext());
+            assertEquals(0, caseProcesInstances.size());
             caseId = null;
-            
         } catch (Exception e) {
             logger.error("Unexpected error {}", e.getMessage(), e);
             fail("Unexpected exception " + e.getMessage());
@@ -355,20 +299,6 @@ public class CarInsuranceClaimCaseTest extends AbstractCaseServicesBaseTest {
                 caseService.cancelCase(caseId);
             }
         }
-    }
-
-
-    /*
-     * Helper methods
-     */
-    protected String deployAndAssert() {
-        assertNotNull(deploymentService);        
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
-        
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
-        
-        return deploymentUnit.getIdentifier();
     }
 
     protected void assertComment(CommentInstance comment, String author, String content) {
@@ -376,124 +306,124 @@ public class CarInsuranceClaimCaseTest extends AbstractCaseServicesBaseTest {
         assertEquals(author, comment.getAuthor());
         assertEquals(content, comment.getComment());
     }
-    
+
     protected void assertTask(TaskSummary task, String actor, String name, Status status) {
-        assertNotNull(task);            
+        assertNotNull(task);
         assertEquals(name, task.getName());
         assertEquals(actor, task.getActualOwnerId());
         assertEquals(status, task.getStatus());
     }
-    
+
     protected String startAndAssertCaseInstance(String deploymentId, String insured, String insuranceRepresentative) {
         Map<String, OrganizationalEntity> roleAssignments = new HashMap<>();
         roleAssignments.put("insured", new UserImpl(insured));
         roleAssignments.put("insuranceRepresentative", new UserImpl(insuranceRepresentative));
-        
+
         // start new instance of a case with data and role assignment
         Map<String, Object> data = new HashMap<>();
-        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentId, CAR_INSURANCE_CLAIM_PROC_ID, data, roleAssignments);        
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentId, CAR_INSURANCE_CLAIM_PROC_ID, data, roleAssignments);
         String caseId = caseService.startCase(deploymentId, CAR_INSURANCE_CLAIM_PROC_ID, caseFile);
         assertNotNull(caseId);
         assertEquals(CAR_INS_CASE_ID, caseId);
-        
+
         return caseId;
     }
-    
+
     protected void assertCaseInstance(String deploymentId, String caseId) {
         CaseInstance cInstance = caseService.getCaseInstance(caseId);
         assertNotNull(cInstance);
         assertEquals(caseId, cInstance.getCaseId());
         assertEquals(deploymentId, cInstance.getDeploymentId());
     }
-    
+
     protected void assertBuildClaimReportStage() {
         Collection<CaseStageInstance> activeStages = caseRuntimeDataService.getCaseInstanceStages(CAR_INS_CASE_ID, true, new QueryContext());
         assertEquals(1, activeStages.size());
         CaseStageInstance stage = activeStages.iterator().next();
         assertEquals("Build claim report", stage.getName());
     }
-    
+
     protected void assertClaimAssesmentStage() {
         Collection<CaseStageInstance> activeStages = caseRuntimeDataService.getCaseInstanceStages(CAR_INS_CASE_ID, true, new QueryContext());
         assertEquals(1, activeStages.size());
         CaseStageInstance stage = activeStages.iterator().next();
         assertEquals("Claim assesment", stage.getName());
     }
-    
-    protected long assertBuildClaimReportAvailableForBothRoles() {        
+
+    protected long assertBuildClaimReportAvailableForBothRoles() {
         return assertTasksForBothRoles("Provide accident information", "john", "mary", Status.Ready);
     }
-    
-    protected long assertPropertyDamageReportAvailableForBothRoles() {           
-        return assertTasksForBothRoles("File property damage claim", "john", "mary", Status.Ready);        
+
+    protected long assertPropertyDamageReportAvailableForBothRoles() {
+        return assertTasksForBothRoles("File property damage claim", "john", "mary", Status.Ready);
     }
-    
+
     protected long assertTasksForBothRoles(String taskName, String actor1, String actor2, Status status) {
         List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(actor1, new QueryFilter());
         assertNotNull(tasks);
-        assertEquals(1, tasks.size());            
+        assertEquals(1, tasks.size());
         assertTask(tasks.get(0), null, taskName, status);
         // the same task can be claimed by insuranceRepresentative in case claim is reported over phone
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(actor2, new QueryFilter());
         assertNotNull(tasks);
-        assertEquals(1, tasks.size());            
+        assertEquals(1, tasks.size());
         assertTask(tasks.get(0), null, taskName, status);
-        
+
         return tasks.get(0).getId();
     }
-    
+
     protected void provideAndAssertClaimReport(Long taskId) {
         ClaimReport claimReport = new ClaimReport();
         claimReport.setName("John Doe");
         claimReport.setAddress("Main street, NY");
         claimReport.setAccidentDescription("It happened so sudden...");
         claimReport.setAccidentDate(new Date());
-        
+
         Map<String, Object> params = new HashMap<>();
         params.put("claimReport_", claimReport);
         userTaskService.completeAutoProgress(taskId, "john", params);
-        
+
         // claim report should be stored in case file data
         CaseFileInstance caseFile = caseService.getCaseFileInstance(CAR_INS_CASE_ID);
         assertNotNull(caseFile);
         ClaimReport caseClaimReport = (ClaimReport) caseFile.getData("claimReport");
         assertNotNull(caseClaimReport);
     }
-    
+
     protected void provideAndAssertPropertyDamageReport(Long taskId) {
         PropertyDamageReport damageReport = new PropertyDamageReport("Car is completely destroyed", 1000.0);
         Map<String, Object> params = new HashMap<>();
         params.put("propertyDamageReport_", damageReport);
         userTaskService.completeAutoProgress(taskId, "john", params);
-        
+
         // property damage report should be stored in case file data
         CaseFileInstance caseFile = caseService.getCaseFileInstance(CAR_INS_CASE_ID);
         assertNotNull(caseFile);
         PropertyDamageReport casePropertyDamageReport = (PropertyDamageReport) caseFile.getData("propertyDamageReport");
         assertNotNull(casePropertyDamageReport);
     }
-    
+
     protected void assertAndAcceptClaimOffer() {
         List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("john", new QueryFilter());
         assertNotNull(tasks);
-        assertEquals(1, tasks.size());            
+        assertEquals(1, tasks.size());
         assertTask(tasks.get(0), "john", "Present calculated claim", Status.Reserved);
-        
+
         // let's accept the calculated claim 
         Map<String, Object> params = new HashMap<>();
         params.put("accepted", true);
         userTaskService.completeAutoProgress(tasks.get(0).getId(), "john", params);
     }
-    
+
     protected void attachAndAssertPoliceReport() {
         caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Submit police report", null);
 
         List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("john", new QueryFilter());
         assertNotNull(tasks);
-        assertEquals(2, tasks.size());            
+        assertEquals(2, tasks.size());
         assertTask(tasks.get(0), null, "Submit police report", Status.Ready);
         assertTask(tasks.get(1), null, "File property damage claim", Status.Ready);
-        
+
         byte[] docContent = "police report content".getBytes();
         DocumentImpl document = new DocumentImpl(UUID.randomUUID().toString(), "car-accident-police-report.txt", docContent.length, new Date());
         document.setContent(docContent);
@@ -501,7 +431,7 @@ public class CarInsuranceClaimCaseTest extends AbstractCaseServicesBaseTest {
         Map<String, Object> params = new HashMap<>();
         params.put("policeReport_", document);
         userTaskService.completeAutoProgress(tasks.get(0).getId(), "john", params);
-        
+
         // police report should be stored in case file data
         CaseFileInstance caseFile = caseService.getCaseFileInstance(CAR_INS_CASE_ID);
         assertNotNull(caseFile);
@@ -509,84 +439,83 @@ public class CarInsuranceClaimCaseTest extends AbstractCaseServicesBaseTest {
         assertNotNull(policeReport);
         assertEquals("car-accident-police-report.txt", policeReport.getName());
     }
-    
-    protected void attachAndAssertPoliceReport(boolean callback, String callbackAfter) {        
+
+    protected void attachAndAssertPoliceReport(boolean callback, String callbackAfter) {
 
         List<TaskSummary> tasks = runtimeDataService.getTasksOwned("mary", new QueryFilter());
         assertNotNull(tasks);
-        assertEquals(1, tasks.size());            
+        assertEquals(1, tasks.size());
         assertTask(tasks.get(0), "mary", "Contacted by insured", Status.Reserved);
-        
+
         Map<String, Object> params = new HashMap<>();
         params.put("callback_", callback);
         if (callback) {
-            params.put("callbackAfter_", callbackAfter);    
+            params.put("callbackAfter_", callbackAfter);
         }
         userTaskService.completeAutoProgress(tasks.get(0).getId(), "mary", params);
-        
+
         if (callback) {
             CountDownListenerFactory.getExisting("carInsuranceCase").waitTillCompleted();
             tasks = runtimeDataService.getTasksOwned("mary", new QueryFilter());
             assertNotNull(tasks);
-            assertEquals(1, tasks.size());            
+            assertEquals(1, tasks.size());
             assertTask(tasks.get(0), "mary", "Requested callback", Status.Reserved);
-            
+
             userTaskService.completeAutoProgress(tasks.get(0).getId(), "mary", null);
         }
     }
-    
+
     protected void assertAndNegotiateClaimOffer(int numberOfNegotiations) {
         List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("john", new QueryFilter());
         assertNotNull(tasks);
-        assertEquals(1, tasks.size());            
+        assertEquals(1, tasks.size());
         assertTask(tasks.get(0), "john", "Present calculated claim", Status.Reserved);
-        
+
         // let's accept the calculated claim 
         Map<String, Object> params = new HashMap<>();
         params.put("accepted", false);
         userTaskService.completeAutoProgress(tasks.get(0).getId(), "john", params);
-        
+
         Collection<CaseStageInstance> activeStages = caseRuntimeDataService.getCaseInstanceStages(CAR_INS_CASE_ID, true, new QueryContext());
         assertEquals(1, activeStages.size());
         CaseStageInstance stage = activeStages.iterator().next();
         assertEquals("Escalate rejected claim", stage.getName());
-        
+
         while (numberOfNegotiations > 0) {
             params.clear();
             params.put("Offer", 1000);
-            
+
             caseService.triggerAdHocFragment(CAR_INS_CASE_ID, "Negotiation meeting", params);
-            
+
             tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("john", new QueryFilter());
             assertNotNull(tasks);
-            assertEquals(1, tasks.size());            
+            assertEquals(1, tasks.size());
             assertTask(tasks.get(0), null, "Negotiation meeting", Status.Ready);
-            
+
             boolean accepted = false;
             if (numberOfNegotiations == 1) {
                 accepted = true;
             }
-            
+
             params.put("accepted", accepted);
             userTaskService.completeAutoProgress(tasks.get(0).getId(), "john", params);
-            
+
             numberOfNegotiations--;
         }
     }
-    
-    
+
     private void assertAndRunClaimAssessment() {
         List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("krisv", new QueryFilter());
         assertNotNull(tasks);
-        assertEquals(1, tasks.size());            
+        assertEquals(1, tasks.size());
         assertTask(tasks.get(0), "krisv", "Assessor evaluation", Status.Reserved);
-        
+
         long taskId = tasks.get(0).getId();
-        
+
         Map<String, Object> taskInput = userTaskService.getTaskInputContentByTaskId(taskId);
         assertNotNull(taskInput);
         assertTrue(taskInput.containsKey("_claimReport"));
-        
+
         ClaimReport claimReport = (ClaimReport) taskInput.get("_claimReport");
         claimReport.setAmount(20000.0);
         claimReport.setCalculated(Boolean.TRUE);
@@ -598,10 +527,9 @@ public class CarInsuranceClaimCaseTest extends AbstractCaseServicesBaseTest {
     @Override
     protected List<ObjectModel> getProcessListeners() {
         List<ObjectModel> listeners = super.getProcessListeners();
-        
+
         listeners.add(new ObjectModel("mvel", "org.jbpm.casemgmt.impl.util.CountDownListenerFactory.get(\"carInsuranceCase\", \"wait before callback\", 1)"));
-        
+
         return listeners;
     }
-    
 }

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/CaseRuntimeDataServiceDefinitionImplTest.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/CaseRuntimeDataServiceDefinitionImplTest.java
@@ -16,47 +16,28 @@
 
 package org.jbpm.casemgmt.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.kie.scanner.MavenRepository.getMavenRepository;
-
-import java.io.File;
-import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.jbpm.casemgmt.api.model.AdHocFragment;
 import org.jbpm.casemgmt.api.model.CaseDefinition;
 import org.jbpm.casemgmt.api.model.CaseMilestone;
 import org.jbpm.casemgmt.api.model.CaseRole;
 import org.jbpm.casemgmt.api.model.CaseStage;
 import org.jbpm.casemgmt.impl.util.AbstractCaseServicesBaseTest;
-import org.jbpm.kie.services.impl.KModuleDeploymentUnit;
-import org.jbpm.services.api.model.DeploymentUnit;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.kie.api.KieServices;
-import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.query.QueryContext;
-import org.kie.scanner.MavenRepository;
 
+import static org.junit.Assert.*;
 
 public class CaseRuntimeDataServiceDefinitionImplTest extends AbstractCaseServicesBaseTest {
 
-    private List<DeploymentUnit> units = new ArrayList<DeploymentUnit>();
-
     public static final String SORT_BY_CASE_DEFINITION_NAME = "CaseName";
 
-    @Before
-    public void prepare() {
-        configureServices();
-        KieServices ks = KieServices.Factory.get();
-        ReleaseId releaseId = ks.newReleaseId(GROUP_ID, ARTIFACT_ID, VERSION);
+    @Override
+    protected List<String> getProcessDefinitionFiles() {
         List<String> processes = new ArrayList<String>();
         processes.add("cases/EmptyCase.bpmn2");
         processes.add("cases/UserTaskCase.bpmn2");
@@ -66,46 +47,16 @@ public class CaseRuntimeDataServiceDefinitionImplTest extends AbstractCaseServic
         // add processes that can be used by cases but are not cases themselves
         processes.add("processes/DataVerificationProcess.bpmn2");
         processes.add("processes/UserTaskProcess.bpmn2");
-        
-        InternalKieModule kJar1 = createKieJar(ks, releaseId, processes);
-        File pom = new File("target/kmodule", "pom.xml");
-        pom.getParentFile().mkdir();
-        try {
-            FileOutputStream fs = new FileOutputStream(pom);
-            fs.write(getPom(releaseId).getBytes());
-            fs.close();
-        } catch (Exception e) {
-            
-        }
-        MavenRepository repository = getMavenRepository();
-        repository.deployArtifact(releaseId, kJar1, pom);
-    }
-
-    @After
-    public void cleanup() {
-        identityProvider.reset();
-        cleanupSingletonSessionId();
-        if (units != null && !units.isEmpty()) {
-            for (DeploymentUnit unit : units) {
-                deploymentService.undeploy(unit);
-            }
-            units.clear();
-        }
-        close();
+        return processes;
     }
 
     @Test
     public void testGetCaseDefinitions() {
-        assertNotNull(deploymentService);        
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
-
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
         Collection<CaseDefinition> cases = caseRuntimeDataService.getCases(new QueryContext());
         assertNotNull(cases);
         assertEquals(5, cases.size());
 
-        Map<String, CaseDefinition> mappedCases = mapCases(cases);        
+        Map<String, CaseDefinition> mappedCases = mapCases(cases);
         assertTrue(mappedCases.containsKey("EmptyCase"));
         assertTrue(mappedCases.containsKey("UserTaskCase"));
         assertTrue(mappedCases.containsKey("UserTaskCaseBoundary"));
@@ -158,7 +109,7 @@ public class CaseRuntimeDataServiceDefinitionImplTest extends AbstractCaseServic
         assertNotNull(caseDef.getCaseRoles());
         assertEquals(3, caseDef.getCaseRoles().size());
 
-        Map<String, CaseRole> mappedRoles = mapRoles(caseDef.getCaseRoles());        
+        Map<String, CaseRole> mappedRoles = mapRoles(caseDef.getCaseRoles());
         assertTrue(mappedRoles.containsKey("owner"));
         assertTrue(mappedRoles.containsKey("contact"));
         assertTrue(mappedRoles.containsKey("participant"));
@@ -195,11 +146,10 @@ public class CaseRuntimeDataServiceDefinitionImplTest extends AbstractCaseServic
         assertTrue(mappedFragments.containsKey("Verification of data"));
         assertEquals("SubProcessNode", mappedFragments.get("Verification of data").getType());
 
-
         assertNotNull(caseDef.getCaseRoles());
         assertEquals(3, caseDef.getCaseRoles().size());
 
-        mappedRoles = mapRoles(caseDef.getCaseRoles());        
+        mappedRoles = mapRoles(caseDef.getCaseRoles());
         assertTrue(mappedRoles.containsKey("owner"));
         assertTrue(mappedRoles.containsKey("contact"));
         assertTrue(mappedRoles.containsKey("participant"));
@@ -211,12 +161,6 @@ public class CaseRuntimeDataServiceDefinitionImplTest extends AbstractCaseServic
 
     @Test
     public void testGetCaseDefinitionsSorted() {
-        assertNotNull(deploymentService);
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
-
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
-
         Collection<CaseDefinition> cases = caseRuntimeDataService.getCases(new QueryContext(0, 1, SORT_BY_CASE_DEFINITION_NAME, true));
         assertNotNull(cases);
         assertEquals(1, cases.size());
@@ -237,7 +181,7 @@ public class CaseRuntimeDataServiceDefinitionImplTest extends AbstractCaseServic
         assertEquals(5, cases.size());
 
         List<CaseDefinition> sortedCases = new ArrayList<>(cases);
-        assertEquals("UserTaskWithStageCase", sortedCases.get(0).getId());        
+        assertEquals("UserTaskWithStageCase", sortedCases.get(0).getId());
         assertEquals("UserTaskCaseBoundary", sortedCases.get(1).getId());
         assertEquals("UserTaskCase", sortedCases.get(2).getId());
         assertEquals("EmptyCase", sortedCases.get(3).getId());
@@ -245,34 +189,23 @@ public class CaseRuntimeDataServiceDefinitionImplTest extends AbstractCaseServic
 
     @Test
     public void testGetCaseDefinitionsByDeploymentId() {
-        assertNotNull(deploymentService);
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
-
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
         Collection<CaseDefinition> cases = caseRuntimeDataService.getCasesByDeployment(deploymentUnit.getIdentifier(), new QueryContext());
         assertNotNull(cases);
         assertEquals(5, cases.size());
 
-        Map<String, CaseDefinition> mappedCases = mapCases(cases);        
+        Map<String, CaseDefinition> mappedCases = mapCases(cases);
         assertTrue(mappedCases.containsKey("EmptyCase"));
         assertTrue(mappedCases.containsKey("UserTaskCase"));
         assertTrue(mappedCases.containsKey("UserTaskCaseBoundary"));
         assertTrue(mappedCases.containsKey("UserTaskWithStageCase"));
 
         cases = caseRuntimeDataService.getCasesByDeployment("not-existing", new QueryContext());
-        assertNotNull(cases);        
+        assertNotNull(cases);
         assertEquals(0, cases.size());
     }
 
     @Test
     public void testGetCaseDefinitionsByDeploymentIdSorted() {
-        assertNotNull(deploymentService);
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
-
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
-
         Collection<CaseDefinition> cases = caseRuntimeDataService.getCasesByDeployment(deploymentUnit.getIdentifier(), new QueryContext(0, 1, SORT_BY_CASE_DEFINITION_NAME, true));
         assertNotNull(cases);
         assertEquals(1, cases.size());
@@ -295,22 +228,17 @@ public class CaseRuntimeDataServiceDefinitionImplTest extends AbstractCaseServic
         List<CaseDefinition> sortedCases = new ArrayList<>(cases);
         assertEquals("UserTaskWithStageCase", sortedCases.get(0).getId());
         assertEquals("UserTaskCaseBoundary", sortedCases.get(1).getId());
-        assertEquals("UserTaskCase", sortedCases.get(2).getId());        
+        assertEquals("UserTaskCase", sortedCases.get(2).getId());
         assertEquals("EmptyCase", sortedCases.get(3).getId());
     }
 
     @Test
     public void testGetCaseDefinitionsByFilter() {
-        assertNotNull(deploymentService);
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
-
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
         Collection<CaseDefinition> cases = caseRuntimeDataService.getCases("empty", new QueryContext());
         assertNotNull(cases);
         assertEquals(1, cases.size());
 
-        Map<String, CaseDefinition> mappedCases = mapCases(cases);        
+        Map<String, CaseDefinition> mappedCases = mapCases(cases);
         assertTrue(mappedCases.containsKey("EmptyCase"));
 
         cases = caseRuntimeDataService.getCases("User", new QueryContext());
@@ -329,12 +257,6 @@ public class CaseRuntimeDataServiceDefinitionImplTest extends AbstractCaseServic
 
     @Test
     public void testGetCaseDefinitionsByFilterSorted() {
-        assertNotNull(deploymentService);
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
-
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
-
         Collection<CaseDefinition> cases = caseRuntimeDataService.getCases("User", new QueryContext(0, 1, SORT_BY_CASE_DEFINITION_NAME, true));
         assertNotNull(cases);
         assertEquals(1, cases.size());
@@ -349,21 +271,14 @@ public class CaseRuntimeDataServiceDefinitionImplTest extends AbstractCaseServic
         assertNotNull(cases);
         assertEquals(3, cases.size());
 
-        List<CaseDefinition >sortedCases = new ArrayList<>(cases);
+        List<CaseDefinition> sortedCases = new ArrayList<>(cases);
         assertEquals("UserTaskWithStageCase", sortedCases.get(0).getId());
         assertEquals("UserTaskCaseBoundary", sortedCases.get(1).getId());
         assertEquals("UserTaskCase", sortedCases.get(2).getId());
-        
     }
 
     @Test
     public void testGetCaseDefinitionById() {
-        assertNotNull(deploymentService);
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
-
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
-
         CaseDefinition caseDef = caseRuntimeDataService.getCase(deploymentUnit.getIdentifier(), "UserTaskWithStageCase");
         // UserTaskWithStageCase asserts        
         assertNotNull(caseDef);
@@ -404,15 +319,9 @@ public class CaseRuntimeDataServiceDefinitionImplTest extends AbstractCaseServic
         assertEquals(2, mappedRoles.get("contact").getCardinality().intValue());
         assertEquals(-1, mappedRoles.get("participant").getCardinality().intValue());
     }
-    
+
     @Test
     public void testGetCaseDefinitionByIdWithBoundaryEvent() {
-        assertNotNull(deploymentService);
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
-
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
-
         CaseDefinition caseDef = caseRuntimeDataService.getCase(deploymentUnit.getIdentifier(), "UserTaskCaseBoundary");
         // UserTaskWithStageCase asserts        
         assertNotNull(caseDef);
@@ -423,9 +332,9 @@ public class CaseRuntimeDataServiceDefinitionImplTest extends AbstractCaseServic
         assertEquals(2, caseDef.getCaseMilestones().size());
         assertEquals(0, caseDef.getCaseStages().size());
         assertEquals(3, caseDef.getAdHocFragments().size());
-        
+
         assertEquals(deploymentUnit.getIdentifier(), caseDef.getDeploymentId());
-        
+
         Map<String, CaseMilestone> mappedMilestones = mapMilestones(caseDef.getCaseMilestones());
         assertTrue(mappedMilestones.containsKey("Milestone1"));
         assertTrue(mappedMilestones.containsKey("Milestone2"));

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/StageCompletionConditionTest.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/StageCompletionConditionTest.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.casemgmt.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jbpm.casemgmt.api.dynamic.TaskSpecification;
+import org.jbpm.casemgmt.api.model.instance.CaseFileInstance;
+import org.jbpm.casemgmt.api.model.instance.CaseInstance;
+import org.jbpm.casemgmt.impl.model.instance.CaseInstanceImpl;
+import org.jbpm.casemgmt.impl.util.AbstractCaseServicesBaseTest;
+import org.junit.Test;
+import org.kie.api.task.model.TaskSummary;
+import org.kie.internal.query.QueryFilter;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class StageCompletionConditionTest extends AbstractCaseServicesBaseTest {
+
+    private static final String STAGE_WITH_TASK_AUTOCOMPLETE = "StageWithTaskAutocomplete";
+    private static final String STAGE_WITH_TASK_COUNT = "StageWithTaskCount";
+    private static final String STAGE_WITH_TASK_NO_AUTOSTART = "StageWithTaskNoAutoStart";
+    private static final String STAGE_WITH_TASK_PROCESS_VARIABLE = "StageWithTaskProcessVariable";
+    private static final String STAGE_WITH_TASK_CASE_FILE_VARIABLE = "StageWithTaskCaseFileVariable";
+    private static final String STAGE_WITH_TASK_CASE_FILE_VARIABLE_NO_PREFIX = "StageWithTaskCaseFileVariableNoPrefix";
+    private static final String STAGE_WITH_TASK_CASE_DATA_BOOLEAN = "StageWithTaskCaseDataBoolean";
+    private static final String STAGE_WITH_TASK_CASE_DATA_INTEGER = "StageWithTaskCaseDataInteger";
+    private static final String STAGE_WITH_TASK_CASE_DATA_STRING = "StageWithTaskCaseDataString";
+    private static final String STAGE_WITH_TASK_CASE_FILE_AND_PROCESS_VARIABLE = "StageWithTaskCaseFileAndProcessVariable";
+    private static final String USER_TASK_PROCESS = "UserTask";
+
+    private static final String INSIDE_TASK = "InsideTask";
+    private static final String DYNAMIC_TASK = "DynamicTask";
+    private static final String HELLO_TASK = "Hello";
+
+    @Override
+    protected List<String> getProcessDefinitionFiles() {
+        List<String> processes = new ArrayList<>();
+        processes.add("cases/stage/completion/StageWithTaskAutocomplete.bpmn2");
+        processes.add("cases/stage/completion/StageWithTaskCount.bpmn2");
+        processes.add("cases/stage/completion/StageWithTaskNoAutoStart.bpmn2");
+        processes.add("cases/stage/completion/StageWithTaskProcessVariable.bpmn2");
+        processes.add("cases/stage/completion/StageWithTaskCaseFileVariable.bpmn2");
+        processes.add("cases/stage/completion/StageWithTaskCaseFileVariableNoPrefix.bpmn2");
+        processes.add("cases/stage/completion/StageWithTaskCaseDataBoolean.bpmn2");
+        processes.add("cases/stage/completion/StageWithTaskCaseDataInteger.bpmn2");
+        processes.add("cases/stage/completion/StageWithTaskCaseDataString.bpmn2");
+        processes.add("cases/stage/completion/StageWithTaskCaseFileAndProcessVariable.bpmn2");
+        processes.add("processes/UserTaskProcess.bpmn2");
+        return processes;
+    }
+
+    @Test
+    public void testAutoComplete() {
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), STAGE_WITH_TASK_AUTOCOMPLETE);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+
+        userTaskService.completeAutoProgress(tasks.get(0).getId(), USER, null);
+        assertCaseInstanceNotActive(caseId);
+    }
+
+    @Test
+    public void testAutoCompleteNoAutoStartTask() {
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), STAGE_WITH_TASK_NO_AUTOSTART);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).isEmpty();
+
+        caseService.triggerAdHocFragment(caseId, INSIDE_TASK, null);
+        assertCaseInstanceActive(caseId);
+
+        tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary insideTask = tasks.get(0);
+        assertThat(insideTask.getName()).isEqualTo(INSIDE_TASK);
+
+        userTaskService.completeAutoProgress(insideTask.getId(), USER, null);
+        assertCaseInstanceNotActive(caseId);
+    }
+
+    @Test
+    public void testAutoCompleteDynamicTask() {
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), STAGE_WITH_TASK_AUTOCOMPLETE);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary insideTask = tasks.get(0);
+        assertThat(insideTask.getName()).isEqualTo(INSIDE_TASK);
+
+        CaseInstance caseInstance = caseService.getCaseInstance(caseId, false, false, false, true);
+        assertThat(caseInstance).isNotNull();
+        assertThat(caseInstance.getCaseStages()).hasSize(1);
+        String stageId = caseInstance.getCaseStages().iterator().next().getId();
+        TaskSpecification dynamicTaskSpecification = caseService.newHumanTaskSpec(DYNAMIC_TASK, "", USER,
+                null, Collections.emptyMap());
+        caseService.addDynamicTaskToStage(caseId, stageId, dynamicTaskSpecification);
+
+        userTaskService.completeAutoProgress(insideTask.getId(), USER, null);
+        assertCaseInstanceActive(caseId);
+
+        tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary dynamicTask = tasks.get(0);
+        assertThat(dynamicTask.getName()).isEqualTo(DYNAMIC_TASK);
+
+        userTaskService.completeAutoProgress(dynamicTask.getId(), USER, null);
+        assertCaseInstanceNotActive(caseId);
+    }
+
+    @Test
+    public void testAutoCompleteDynamicSubProcess() {
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), STAGE_WITH_TASK_AUTOCOMPLETE);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary insideTask = tasks.get(0);
+        assertThat(insideTask.getName()).isEqualTo(INSIDE_TASK);
+
+        CaseInstance caseInstance = caseService.getCaseInstance(caseId, false, false, false, true);
+        assertThat(caseInstance).isNotNull();
+        assertThat(caseInstance.getCaseStages()).hasSize(1);
+        String stageId = caseInstance.getCaseStages().iterator().next().getId();
+        caseService.addDynamicSubprocessToStage(caseId, stageId, USER_TASK_PROCESS, Collections.emptyMap());
+
+        userTaskService.completeAutoProgress(insideTask.getId(), USER, null);
+        assertCaseInstanceActive(caseId);
+
+        tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary dynamicTask = tasks.get(0);
+        assertThat(dynamicTask.getName()).isEqualTo(HELLO_TASK);
+
+        userTaskService.completeAutoProgress(dynamicTask.getId(), USER, null);
+        assertCaseInstanceNotActive(caseId);
+    }
+
+    @Test
+    public void testNoActiveTasksCondition() {
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), STAGE_WITH_TASK_COUNT);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        CaseInstance caseInstance = caseService.getCaseInstance(caseId);
+        assertThat(caseInstance).isNotNull();
+        Long processInstanceId = ((CaseInstanceImpl) caseInstance).getProcessInstanceId();
+        processService.setProcessVariable(processInstanceId, "taskCount", 0);
+
+        List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+
+        userTaskService.completeAutoProgress(tasks.get(0).getId(), USER, null);
+        assertCaseInstanceNotActive(caseId);
+    }
+
+    @Test
+    public void testProcessVariable() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("continue", false);
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(),
+                STAGE_WITH_TASK_PROCESS_VARIABLE, data, Collections.emptyMap());
+
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), STAGE_WITH_TASK_PROCESS_VARIABLE, caseFile);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        CaseInstance caseInstance = caseService.getCaseInstance(caseId);
+        assertThat(caseInstance).isNotNull();
+        Long processInstanceId = ((CaseInstanceImpl) caseInstance).getProcessInstanceId();
+        processService.setProcessVariable(processInstanceId, "continue", false);
+
+        caseService.addDataToCaseFile(caseId, "continue", true);
+
+        List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary insideTask = tasks.get(0);
+        assertThat(insideTask.getName()).isEqualTo(INSIDE_TASK);
+
+        userTaskService.completeAutoProgress(insideTask.getId(), USER, null);
+        assertCaseInstanceActive(caseId);
+
+        processService.setProcessVariable(processInstanceId, "continue", true);
+
+        caseInstance = caseService.getCaseInstance(caseId, false, false, false, true);
+        assertThat(caseInstance).isNotNull();
+        assertThat(caseInstance.getCaseStages()).hasSize(1);
+        String stageId = caseInstance.getCaseStages().iterator().next().getId();
+        TaskSpecification dynamicTaskSpecification = caseService.newHumanTaskSpec(DYNAMIC_TASK, "", USER,
+                null, Collections.emptyMap());
+        caseService.addDynamicTaskToStage(caseId, stageId, dynamicTaskSpecification);
+
+        tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary dynamicTask = tasks.get(0);
+        assertThat(dynamicTask.getName()).isEqualTo(DYNAMIC_TASK);
+        userTaskService.completeAutoProgress(dynamicTask.getId(), USER, null);
+        assertCaseInstanceNotActive(caseId);
+    }
+
+    @Test
+    public void testCaseFileVariable() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("continue", false);
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(),
+                STAGE_WITH_TASK_CASE_FILE_VARIABLE, data, Collections.emptyMap());
+
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), STAGE_WITH_TASK_CASE_FILE_VARIABLE, caseFile);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary insideTask = tasks.get(0);
+        assertThat(insideTask.getName()).isEqualTo(INSIDE_TASK);
+        userTaskService.completeAutoProgress(insideTask.getId(), USER, null);
+        assertCaseInstanceActive(caseId);
+
+        caseService.addDataToCaseFile(caseId, "continue", true);
+        assertCaseInstanceActive(caseId);
+
+        CaseInstance caseInstance = caseService.getCaseInstance(caseId, false, false, false, true);
+        assertThat(caseInstance).isNotNull();
+        assertThat(caseInstance.getCaseStages()).hasSize(1);
+        String stageId = caseInstance.getCaseStages().iterator().next().getId();
+        TaskSpecification dynamicTaskSpecification = caseService.newHumanTaskSpec(DYNAMIC_TASK, "", USER,
+                null, Collections.emptyMap());
+        caseService.addDynamicTaskToStage(caseId, stageId, dynamicTaskSpecification);
+
+        tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary dynamicTask = tasks.get(0);
+        assertThat(dynamicTask.getName()).isEqualTo(DYNAMIC_TASK);
+        userTaskService.completeAutoProgress(dynamicTask.getId(), USER, null);
+        assertCaseInstanceNotActive(caseId);
+    }
+
+    @Test
+    public void testCaseFileVariableWithoutPrefix() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("continue", false);
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(),
+                STAGE_WITH_TASK_CASE_FILE_VARIABLE_NO_PREFIX, data, Collections.emptyMap());
+
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(),
+                STAGE_WITH_TASK_CASE_FILE_VARIABLE_NO_PREFIX, caseFile);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        caseService.addDataToCaseFile(caseId, "continue", true);
+        assertCaseInstanceActive(caseId);
+
+        List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary insideTask = tasks.get(0);
+        assertThat(insideTask.getName()).isEqualTo(INSIDE_TASK);
+        userTaskService.completeAutoProgress(insideTask.getId(), USER, null);
+        assertCaseInstanceNotActive(caseId);
+    }
+
+    @Test
+    public void testCaseFileVariableWithProcessVariable() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("continue", false);
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(),
+                STAGE_WITH_TASK_CASE_FILE_AND_PROCESS_VARIABLE, data, Collections.emptyMap());
+
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), STAGE_WITH_TASK_CASE_FILE_AND_PROCESS_VARIABLE, caseFile);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        CaseInstance caseInstance = caseService.getCaseInstance(caseId);
+        assertThat(caseInstance).isNotNull();
+        Long processInstanceId = ((CaseInstanceImpl) caseInstance).getProcessInstanceId();
+        processService.setProcessVariable(processInstanceId, "continue", true);
+        assertCaseInstanceActive(caseId);
+
+        List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary insideTask = tasks.get(0);
+        assertThat(insideTask.getName()).isEqualTo(INSIDE_TASK);
+        userTaskService.completeAutoProgress(insideTask.getId(), USER, null);
+        assertCaseInstanceActive(caseId);
+
+        caseService.addDataToCaseFile(caseId, "continue", true);
+        assertCaseInstanceActive(caseId);
+
+        caseInstance = caseService.getCaseInstance(caseId, false, false, false, true);
+        assertThat(caseInstance).isNotNull();
+        assertThat(caseInstance.getCaseStages()).hasSize(1);
+        String stageId = caseInstance.getCaseStages().iterator().next().getId();
+        TaskSpecification dynamicTaskSpecification = caseService.newHumanTaskSpec(DYNAMIC_TASK, "", USER,
+                null, Collections.emptyMap());
+        caseService.addDynamicTaskToStage(caseId, stageId, dynamicTaskSpecification);
+
+        tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary dynamicTask = tasks.get(0);
+        assertThat(dynamicTask.getName()).isEqualTo(DYNAMIC_TASK);
+        userTaskService.completeAutoProgress(dynamicTask.getId(), USER, null);
+        assertCaseInstanceNotActive(caseId);
+    }
+
+    @Test
+    public void testCaseDataVariableBoolean() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("continue", false);
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(),
+                STAGE_WITH_TASK_CASE_DATA_BOOLEAN, data, Collections.emptyMap());
+
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), STAGE_WITH_TASK_CASE_DATA_BOOLEAN, caseFile);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        caseService.addDataToCaseFile(caseId, "continue", true);
+        assertCaseInstanceNotActive(caseId);
+    }
+
+    @Test
+    public void testCaseDataVariableInteger() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("continue", 0);
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(),
+                STAGE_WITH_TASK_CASE_DATA_INTEGER, data, Collections.emptyMap());
+
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), STAGE_WITH_TASK_CASE_DATA_INTEGER, caseFile);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        caseService.addDataToCaseFile(caseId, "continue", 1);
+        assertCaseInstanceNotActive(caseId);
+    }
+
+    @Test
+    public void testCaseDataVariableString() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("continue", "wait");
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(),
+                STAGE_WITH_TASK_CASE_DATA_STRING, data, Collections.emptyMap());
+
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), STAGE_WITH_TASK_CASE_DATA_STRING, caseFile);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        caseService.addDataToCaseFile(caseId, "continue", "continue");
+        assertCaseInstanceNotActive(caseId);
+    }
+
+    @Test
+    public void testCaseDataVariableCompleteTask() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("continue", false);
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(),
+                STAGE_WITH_TASK_CASE_DATA_BOOLEAN, data, Collections.emptyMap());
+
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), STAGE_WITH_TASK_CASE_DATA_BOOLEAN, caseFile);
+        assertThat(caseId).isNotNull().isEqualTo(FIRST_CASE_ID);
+        assertCaseInstanceActive(caseId);
+
+        List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwner(USER, new QueryFilter());
+        assertThat(tasks).hasSize(1);
+        TaskSummary insideTask = tasks.get(0);
+        assertThat(insideTask.getName()).isEqualTo(INSIDE_TASK);
+        userTaskService.completeAutoProgress(insideTask.getId(), USER, null);
+        assertCaseInstanceActive(caseId);
+
+        caseService.addDataToCaseFile(caseId, "continue", true);
+        assertCaseInstanceNotActive(caseId);
+    }
+}

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/CaseWithTwoStagesConditions.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/CaseWithTwoStagesConditions.bpmn2
@@ -145,7 +145,7 @@
     </bpmn2:endEvent>
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="__T-3WO4EEeal0opAuGgvLw">
-    <bpmndi:BPMNPlane id="__T-3We4EEeal0opAuGgvLw" bpmnElement="CaseWithTwoStages">
+    <bpmndi:BPMNPlane id="__T-3We4EEeal0opAuGgvLw" bpmnElement="CaseWithTwoStagesConditions">
       <bpmndi:BPMNShape id="__T-3Wu4EEeal0opAuGgvLw" bpmnElement="_51298678-656D-434C-A1D1-912CA47417AE">
         <dc:Bounds height="160.0" width="200.0" x="184.0" y="134.0"/>
       </bpmndi:BPMNShape>

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskAutocomplete.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskAutocomplete.bpmn2
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_1IFTAEFKEeeiQ4g7Vpoa4g" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:process id="StageWithTaskAutocomplete" drools:adHoc="true" drools:packageName="org.jbpm" drools:version="1.0" name="StageWithTaskAutocomplete" isExecutable="true">
+    <bpmn2:extensionElements>
+      <drools:metaData name="customCaseIdPrefix">
+        <drools:metaValue><![CDATA[CASE]]></drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
+    <bpmn2:adHocSubProcess id="_9023779E-CF24-40EB-9D25-36B315BC525B" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="" ordering="Sequential">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_AD82CE7D-9076-467B-B6A5-797BF3C09E40</bpmn2:incoming>
+      <bpmn2:outgoing>_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_1IFTAUFKEeeiQ4g7Vpoa4g">
+        <bpmn2:inputSet id="_1IFTAkFKEeeiQ4g7Vpoa4g"/>
+        <bpmn2:outputSet id="_1IFTA0FKEeeiQ4g7Vpoa4g"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:userTask id="_845A656D-0000-409A-8330-C73FF9E79B48" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="InsideTask">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[InsideTask]]></drools:metaValue>
+          </drools:metaData>
+          <drools:metaData name="customAutoStart">
+            <drools:metaValue><![CDATA[true]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:ioSpecification id="_1IFTBEFKEeeiQ4g7Vpoa4g">
+          <bpmn2:dataInput id="_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX" drools:dtype="Object" name="Skippable"/>
+          <bpmn2:inputSet id="_1IFTBUFKEeeiQ4g7Vpoa4g">
+            <bpmn2:dataInputRefs>_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:dataInputRefs>
+          </bpmn2:inputSet>
+          <bpmn2:outputSet id="_1IFTBkFKEeeiQ4g7Vpoa4g"/>
+        </bpmn2:ioSpecification>
+        <bpmn2:dataInputAssociation id="_1IFTB0FKEeeiQ4g7Vpoa4g">
+          <bpmn2:targetRef>_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_1IFTCEFKEeeiQ4g7Vpoa4g">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_1IFTCUFKEeeiQ4g7Vpoa4g">true</bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_1IFTCkFKEeeiQ4g7Vpoa4g">_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:potentialOwner id="_1IFTC0FKEeeiQ4g7Vpoa4g">
+          <bpmn2:resourceAssignmentExpression id="_1IFTDEFKEeeiQ4g7Vpoa4g">
+            <bpmn2:formalExpression id="_1IFTDUFKEeeiQ4g7Vpoa4g">john</bpmn2:formalExpression>
+          </bpmn2:resourceAssignmentExpression>
+        </bpmn2:potentialOwner>
+      </bpmn2:userTask>
+      <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression" id="_1IFTDkFKEeeiQ4g7Vpoa4g" language="http://www.mvel.org/2.0"><![CDATA[autocomplete]]></bpmn2:completionCondition>
+    </bpmn2:adHocSubProcess>
+    <bpmn2:startEvent id="_A20B467F-6693-4AB8-A744-55FD62321D42" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_AD82CE7D-9076-467B-B6A5-797BF3C09E40</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_A20B467F-6693-4AB8-A744-55FD62321D42" targetRef="_9023779E-CF24-40EB-9D25-36B315BC525B"/>
+    <bpmn2:sequenceFlow id="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_9023779E-CF24-40EB-9D25-36B315BC525B" targetRef="_B9605743-DA67-414D-84F2-A91FC81C7697"/>
+    <bpmn2:endEvent id="_B9605743-DA67-414D-84F2-A91FC81C7697" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_1IFTD0FKEeeiQ4g7Vpoa4g"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_1IFTEEFKEeeiQ4g7Vpoa4g">
+    <bpmndi:BPMNPlane id="_1IFTEUFKEeeiQ4g7Vpoa4g" bpmnElement="StageWithTaskAutocomplete">
+      <bpmndi:BPMNShape id="_1IFTEkFKEeeiQ4g7Vpoa4g" bpmnElement="_9023779E-CF24-40EB-9D25-36B315BC525B">
+        <dc:Bounds height="160.0" width="200.0" x="225.0" y="105.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_1IFTE0FKEeeiQ4g7Vpoa4g" bpmnElement="_845A656D-0000-409A-8330-C73FF9E79B48">
+        <dc:Bounds height="80.0" width="100.0" x="275.0" y="145.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_1IFTFEFKEeeiQ4g7Vpoa4g" bpmnElement="_A20B467F-6693-4AB8-A744-55FD62321D42">
+        <dc:Bounds height="30.0" width="30.0" x="150.0" y="170.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_1IFTFUFKEeeiQ4g7Vpoa4g" bpmnElement="_B9605743-DA67-414D-84F2-A91FC81C7697">
+        <dc:Bounds height="28.0" width="28.0" x="470.0" y="171.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_1IFTFkFKEeeiQ4g7Vpoa4g" bpmnElement="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" sourceElement="_1IFTFEFKEeeiQ4g7Vpoa4g" targetElement="_1IFTEkFKEeeiQ4g7Vpoa4g">
+        <di:waypoint xsi:type="dc:Point" x="165.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_1IFTF0FKEeeiQ4g7Vpoa4g" bpmnElement="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" sourceElement="_1IFTEkFKEeeiQ4g7Vpoa4g" targetElement="_1IFTFUFKEeeiQ4g7Vpoa4g">
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="484.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_1IFTGEFKEeeiQ4g7Vpoa4g" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" id="_1IFTGUFKEeeiQ4g7Vpoa4g">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9023779E-CF24-40EB-9D25-36B315BC525B" id="_1IFTGkFKEeeiQ4g7Vpoa4g">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A20B467F-6693-4AB8-A744-55FD62321D42" id="_1IFTG0FKEeeiQ4g7Vpoa4g">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" id="_1IFTHEFKEeeiQ4g7Vpoa4g">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_845A656D-0000-409A-8330-C73FF9E79B48" id="_1IFTHUFKEeeiQ4g7Vpoa4g">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B9605743-DA67-414D-84F2-A91FC81C7697" id="_1IFTHkFKEeeiQ4g7Vpoa4g">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_1IFTAEFKEeeiQ4g7Vpoa4g</bpmn2:source>
+    <bpmn2:target>_1IFTAEFKEeeiQ4g7Vpoa4g</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCaseDataBoolean.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCaseDataBoolean.bpmn2
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_WpOQsERnEeeSxP1_nretag" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:process id="StageWithTaskCaseDataBoolean" drools:adHoc="true" drools:packageName="org.jbpm" drools:version="1.0" name="StageWithTaskCaseDataBoolean" isExecutable="true">
+    <bpmn2:extensionElements>
+      <drools:metaData name="customCaseIdPrefix">
+        <drools:metaValue><![CDATA[CASE]]></drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
+    <bpmn2:adHocSubProcess id="_7664D917-23C2-445D-A01F-70F48ACAF6D8" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="" ordering="Sequential">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_48CA047C-376C-4F6D-99B8-41248E25A714</bpmn2:incoming>
+      <bpmn2:outgoing>_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_WpO3wERnEeeSxP1_nretag">
+        <bpmn2:inputSet id="_WpO3wURnEeeSxP1_nretag"/>
+        <bpmn2:outputSet id="_WpO3wkRnEeeSxP1_nretag"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:userTask id="_E0C58707-EFC4-4968-BC23-3186F6359FCF" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="InsideTask">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[InsideTask]]></drools:metaValue>
+          </drools:metaData>
+          <drools:metaData name="customAutoStart">
+            <drools:metaValue><![CDATA[true]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:ioSpecification id="_WpO3w0RnEeeSxP1_nretag">
+          <bpmn2:dataInput id="_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX" drools:dtype="String" name="TaskName"/>
+          <bpmn2:dataInput id="_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX" drools:dtype="Object" name="Skippable"/>
+          <bpmn2:inputSet id="_WpO3xERnEeeSxP1_nretag">
+            <bpmn2:dataInputRefs>_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX</bpmn2:dataInputRefs>
+          </bpmn2:inputSet>
+          <bpmn2:outputSet id="_WpO3xURnEeeSxP1_nretag"/>
+        </bpmn2:ioSpecification>
+        <bpmn2:dataInputAssociation id="_WpO3xkRnEeeSxP1_nretag">
+          <bpmn2:targetRef>_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_WpO3x0RnEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_WpO3yERnEeeSxP1_nretag"><![CDATA[InsideTask]]></bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_WpO3yURnEeeSxP1_nretag">_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_WpO3ykRnEeeSxP1_nretag">
+          <bpmn2:targetRef>_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_WpO3y0RnEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_WpO3zERnEeeSxP1_nretag">true</bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_WpO3zURnEeeSxP1_nretag">_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:potentialOwner id="_WpO3zkRnEeeSxP1_nretag">
+          <bpmn2:resourceAssignmentExpression id="_WpO3z0RnEeeSxP1_nretag">
+            <bpmn2:formalExpression id="_WpO30ERnEeeSxP1_nretag">john</bpmn2:formalExpression>
+          </bpmn2:resourceAssignmentExpression>
+        </bpmn2:potentialOwner>
+      </bpmn2:userTask>
+      <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression" id="_WpO30URnEeeSxP1_nretag" language="http://www.jboss.org/drools/rule"><![CDATA[org.kie.api.runtime.process.CaseData(data.get("continue") == true)]]></bpmn2:completionCondition>
+    </bpmn2:adHocSubProcess>
+    <bpmn2:startEvent id="_E043B6D5-4CE0-418A-A39A-F506F223801C" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_48CA047C-376C-4F6D-99B8-41248E25A714</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="_48CA047C-376C-4F6D-99B8-41248E25A714" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_E043B6D5-4CE0-418A-A39A-F506F223801C" targetRef="_7664D917-23C2-445D-A01F-70F48ACAF6D8"/>
+    <bpmn2:sequenceFlow id="_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_7664D917-23C2-445D-A01F-70F48ACAF6D8" targetRef="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA"/>
+    <bpmn2:endEvent id="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_WpO30kRnEeeSxP1_nretag"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_WpO300RnEeeSxP1_nretag">
+    <bpmndi:BPMNPlane id="_WpO31ERnEeeSxP1_nretag" bpmnElement="StageWithTaskCaseDataBoolean">
+      <bpmndi:BPMNShape id="_WpO31URnEeeSxP1_nretag" bpmnElement="_7664D917-23C2-445D-A01F-70F48ACAF6D8">
+        <dc:Bounds height="160.0" width="200.0" x="225.0" y="105.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_WpO31kRnEeeSxP1_nretag" bpmnElement="_E0C58707-EFC4-4968-BC23-3186F6359FCF">
+        <dc:Bounds height="80.0" width="100.0" x="275.0" y="145.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_WpO310RnEeeSxP1_nretag" bpmnElement="_E043B6D5-4CE0-418A-A39A-F506F223801C">
+        <dc:Bounds height="30.0" width="30.0" x="150.0" y="170.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_WpO32ERnEeeSxP1_nretag" bpmnElement="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA">
+        <dc:Bounds height="28.0" width="28.0" x="470.0" y="171.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_WpO32URnEeeSxP1_nretag" bpmnElement="_48CA047C-376C-4F6D-99B8-41248E25A714" sourceElement="_WpO310RnEeeSxP1_nretag" targetElement="_WpO31URnEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="165.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_WpO32kRnEeeSxP1_nretag" bpmnElement="_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D" sourceElement="_WpO31URnEeeSxP1_nretag" targetElement="_WpO32ERnEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="484.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_WpO320RnEeeSxP1_nretag" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_E043B6D5-4CE0-418A-A39A-F506F223801C" id="_WpO33ERnEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_48CA047C-376C-4F6D-99B8-41248E25A714" id="_WpO33URnEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA" id="_WpO33kRnEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_E0C58707-EFC4-4968-BC23-3186F6359FCF" id="_WpO330RnEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_7664D917-23C2-445D-A01F-70F48ACAF6D8" id="_WpO34ERnEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D" id="_WpO34URnEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_WpOQsERnEeeSxP1_nretag</bpmn2:source>
+    <bpmn2:target>_WpOQsERnEeeSxP1_nretag</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCaseDataInteger.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCaseDataInteger.bpmn2
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_WpOQsERnEeeSxP1_nretag" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:process id="StageWithTaskCaseDataInteger" drools:adHoc="true" drools:packageName="org.jbpm" drools:version="1.0" name="StageWithTaskCaseDataInteger" isExecutable="true">
+    <bpmn2:extensionElements>
+      <drools:metaData name="customCaseIdPrefix">
+        <drools:metaValue><![CDATA[CASE]]></drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
+    <bpmn2:adHocSubProcess id="_7664D917-23C2-445D-A01F-70F48ACAF6D8" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="" ordering="Sequential">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_48CA047C-376C-4F6D-99B8-41248E25A714</bpmn2:incoming>
+      <bpmn2:outgoing>_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_WpO3wERnEeeSxP1_nretag">
+        <bpmn2:inputSet id="_WpO3wURnEeeSxP1_nretag"/>
+        <bpmn2:outputSet id="_WpO3wkRnEeeSxP1_nretag"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:userTask id="_E0C58707-EFC4-4968-BC23-3186F6359FCF" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="InsideTask">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[InsideTask]]></drools:metaValue>
+          </drools:metaData>
+          <drools:metaData name="customAutoStart">
+            <drools:metaValue><![CDATA[true]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:ioSpecification id="_WpO3w0RnEeeSxP1_nretag">
+          <bpmn2:dataInput id="_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX" drools:dtype="String" name="TaskName"/>
+          <bpmn2:dataInput id="_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX" drools:dtype="Object" name="Skippable"/>
+          <bpmn2:inputSet id="_WpO3xERnEeeSxP1_nretag">
+            <bpmn2:dataInputRefs>_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX</bpmn2:dataInputRefs>
+          </bpmn2:inputSet>
+          <bpmn2:outputSet id="_WpO3xURnEeeSxP1_nretag"/>
+        </bpmn2:ioSpecification>
+        <bpmn2:dataInputAssociation id="_WpO3xkRnEeeSxP1_nretag">
+          <bpmn2:targetRef>_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_WpO3x0RnEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_WpO3yERnEeeSxP1_nretag"><![CDATA[InsideTask]]></bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_WpO3yURnEeeSxP1_nretag">_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_WpO3ykRnEeeSxP1_nretag">
+          <bpmn2:targetRef>_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_WpO3y0RnEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_WpO3zERnEeeSxP1_nretag">true</bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_WpO3zURnEeeSxP1_nretag">_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:potentialOwner id="_WpO3zkRnEeeSxP1_nretag">
+          <bpmn2:resourceAssignmentExpression id="_WpO3z0RnEeeSxP1_nretag">
+            <bpmn2:formalExpression id="_WpO30ERnEeeSxP1_nretag">john</bpmn2:formalExpression>
+          </bpmn2:resourceAssignmentExpression>
+        </bpmn2:potentialOwner>
+      </bpmn2:userTask>
+      <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression" id="_WpO30URnEeeSxP1_nretag" language="http://www.jboss.org/drools/rule"><![CDATA[org.kie.api.runtime.process.CaseData(data.get("continue") == 1)]]></bpmn2:completionCondition>
+    </bpmn2:adHocSubProcess>
+    <bpmn2:startEvent id="_E043B6D5-4CE0-418A-A39A-F506F223801C" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_48CA047C-376C-4F6D-99B8-41248E25A714</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="_48CA047C-376C-4F6D-99B8-41248E25A714" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_E043B6D5-4CE0-418A-A39A-F506F223801C" targetRef="_7664D917-23C2-445D-A01F-70F48ACAF6D8"/>
+    <bpmn2:sequenceFlow id="_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_7664D917-23C2-445D-A01F-70F48ACAF6D8" targetRef="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA"/>
+    <bpmn2:endEvent id="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_WpO30kRnEeeSxP1_nretag"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_WpO300RnEeeSxP1_nretag">
+    <bpmndi:BPMNPlane id="_WpO31ERnEeeSxP1_nretag" bpmnElement="StageWithTaskCaseDataInteger">
+      <bpmndi:BPMNShape id="_WpO31URnEeeSxP1_nretag" bpmnElement="_7664D917-23C2-445D-A01F-70F48ACAF6D8">
+        <dc:Bounds height="160.0" width="200.0" x="225.0" y="105.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_WpO31kRnEeeSxP1_nretag" bpmnElement="_E0C58707-EFC4-4968-BC23-3186F6359FCF">
+        <dc:Bounds height="80.0" width="100.0" x="275.0" y="145.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_WpO310RnEeeSxP1_nretag" bpmnElement="_E043B6D5-4CE0-418A-A39A-F506F223801C">
+        <dc:Bounds height="30.0" width="30.0" x="150.0" y="170.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_WpO32ERnEeeSxP1_nretag" bpmnElement="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA">
+        <dc:Bounds height="28.0" width="28.0" x="470.0" y="171.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_WpO32URnEeeSxP1_nretag" bpmnElement="_48CA047C-376C-4F6D-99B8-41248E25A714" sourceElement="_WpO310RnEeeSxP1_nretag" targetElement="_WpO31URnEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="165.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_WpO32kRnEeeSxP1_nretag" bpmnElement="_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D" sourceElement="_WpO31URnEeeSxP1_nretag" targetElement="_WpO32ERnEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="484.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_WpO320RnEeeSxP1_nretag" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_E043B6D5-4CE0-418A-A39A-F506F223801C" id="_WpO33ERnEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_48CA047C-376C-4F6D-99B8-41248E25A714" id="_WpO33URnEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA" id="_WpO33kRnEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_E0C58707-EFC4-4968-BC23-3186F6359FCF" id="_WpO330RnEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_7664D917-23C2-445D-A01F-70F48ACAF6D8" id="_WpO34ERnEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D" id="_WpO34URnEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_WpOQsERnEeeSxP1_nretag</bpmn2:source>
+    <bpmn2:target>_WpOQsERnEeeSxP1_nretag</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCaseDataString.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCaseDataString.bpmn2
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_WpOQsERnEeeSxP1_nretag" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:process id="StageWithTaskCaseDataString" drools:adHoc="true" drools:packageName="org.jbpm" drools:version="1.0" name="StageWithTaskCaseDataString" isExecutable="true">
+    <bpmn2:extensionElements>
+      <drools:metaData name="customCaseIdPrefix">
+        <drools:metaValue><![CDATA[CASE]]></drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
+    <bpmn2:adHocSubProcess id="_7664D917-23C2-445D-A01F-70F48ACAF6D8" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="" ordering="Sequential">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_48CA047C-376C-4F6D-99B8-41248E25A714</bpmn2:incoming>
+      <bpmn2:outgoing>_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_WpO3wERnEeeSxP1_nretag">
+        <bpmn2:inputSet id="_WpO3wURnEeeSxP1_nretag"/>
+        <bpmn2:outputSet id="_WpO3wkRnEeeSxP1_nretag"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:userTask id="_E0C58707-EFC4-4968-BC23-3186F6359FCF" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="InsideTask">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[InsideTask]]></drools:metaValue>
+          </drools:metaData>
+          <drools:metaData name="customAutoStart">
+            <drools:metaValue><![CDATA[true]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:ioSpecification id="_WpO3w0RnEeeSxP1_nretag">
+          <bpmn2:dataInput id="_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX" drools:dtype="String" name="TaskName"/>
+          <bpmn2:dataInput id="_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX" drools:dtype="Object" name="Skippable"/>
+          <bpmn2:inputSet id="_WpO3xERnEeeSxP1_nretag">
+            <bpmn2:dataInputRefs>_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX</bpmn2:dataInputRefs>
+          </bpmn2:inputSet>
+          <bpmn2:outputSet id="_WpO3xURnEeeSxP1_nretag"/>
+        </bpmn2:ioSpecification>
+        <bpmn2:dataInputAssociation id="_WpO3xkRnEeeSxP1_nretag">
+          <bpmn2:targetRef>_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_WpO3x0RnEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_WpO3yERnEeeSxP1_nretag"><![CDATA[InsideTask]]></bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_WpO3yURnEeeSxP1_nretag">_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_WpO3ykRnEeeSxP1_nretag">
+          <bpmn2:targetRef>_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_WpO3y0RnEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_WpO3zERnEeeSxP1_nretag">true</bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_WpO3zURnEeeSxP1_nretag">_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:potentialOwner id="_WpO3zkRnEeeSxP1_nretag">
+          <bpmn2:resourceAssignmentExpression id="_WpO3z0RnEeeSxP1_nretag">
+            <bpmn2:formalExpression id="_WpO30ERnEeeSxP1_nretag">john</bpmn2:formalExpression>
+          </bpmn2:resourceAssignmentExpression>
+        </bpmn2:potentialOwner>
+      </bpmn2:userTask>
+      <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression" id="_WpO30URnEeeSxP1_nretag" language="http://www.jboss.org/drools/rule"><![CDATA[org.kie.api.runtime.process.CaseData(data.get("continue") == "continue")]]></bpmn2:completionCondition>
+    </bpmn2:adHocSubProcess>
+    <bpmn2:startEvent id="_E043B6D5-4CE0-418A-A39A-F506F223801C" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_48CA047C-376C-4F6D-99B8-41248E25A714</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="_48CA047C-376C-4F6D-99B8-41248E25A714" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_E043B6D5-4CE0-418A-A39A-F506F223801C" targetRef="_7664D917-23C2-445D-A01F-70F48ACAF6D8"/>
+    <bpmn2:sequenceFlow id="_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_7664D917-23C2-445D-A01F-70F48ACAF6D8" targetRef="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA"/>
+    <bpmn2:endEvent id="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_WpO30kRnEeeSxP1_nretag"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_WpO300RnEeeSxP1_nretag">
+    <bpmndi:BPMNPlane id="_WpO31ERnEeeSxP1_nretag" bpmnElement="StageWithTaskCaseDataString">
+      <bpmndi:BPMNShape id="_WpO31URnEeeSxP1_nretag" bpmnElement="_7664D917-23C2-445D-A01F-70F48ACAF6D8">
+        <dc:Bounds height="160.0" width="200.0" x="225.0" y="105.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_WpO31kRnEeeSxP1_nretag" bpmnElement="_E0C58707-EFC4-4968-BC23-3186F6359FCF">
+        <dc:Bounds height="80.0" width="100.0" x="275.0" y="145.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_WpO310RnEeeSxP1_nretag" bpmnElement="_E043B6D5-4CE0-418A-A39A-F506F223801C">
+        <dc:Bounds height="30.0" width="30.0" x="150.0" y="170.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_WpO32ERnEeeSxP1_nretag" bpmnElement="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA">
+        <dc:Bounds height="28.0" width="28.0" x="470.0" y="171.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_WpO32URnEeeSxP1_nretag" bpmnElement="_48CA047C-376C-4F6D-99B8-41248E25A714" sourceElement="_WpO310RnEeeSxP1_nretag" targetElement="_WpO31URnEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="165.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_WpO32kRnEeeSxP1_nretag" bpmnElement="_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D" sourceElement="_WpO31URnEeeSxP1_nretag" targetElement="_WpO32ERnEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="484.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_WpO320RnEeeSxP1_nretag" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_E043B6D5-4CE0-418A-A39A-F506F223801C" id="_WpO33ERnEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_48CA047C-376C-4F6D-99B8-41248E25A714" id="_WpO33URnEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA" id="_WpO33kRnEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_E0C58707-EFC4-4968-BC23-3186F6359FCF" id="_WpO330RnEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_7664D917-23C2-445D-A01F-70F48ACAF6D8" id="_WpO34ERnEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D" id="_WpO34URnEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_WpOQsERnEeeSxP1_nretag</bpmn2:source>
+    <bpmn2:target>_WpOQsERnEeeSxP1_nretag</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCaseFileAndProcessVariable.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCaseFileAndProcessVariable.bpmn2
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_DO0O0ERZEeeSxP1_nretag" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_continueItem" structureRef="Boolean"/>
+  <bpmn2:process id="StageWithTaskCaseFileAndProcessVariable" drools:adHoc="true" drools:packageName="org.jbpm" drools:version="1.0" name="StageWithTaskCaseFileAndProcessVariable" isExecutable="true">
+    <bpmn2:extensionElements>
+      <drools:metaData name="customCaseIdPrefix">
+        <drools:metaValue><![CDATA[CASE]]></drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
+    <bpmn2:property id="continue" itemSubjectRef="_continueItem"/>
+    <bpmn2:adHocSubProcess id="_9023779E-CF24-40EB-9D25-36B315BC525B" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="" ordering="Sequential">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_AD82CE7D-9076-467B-B6A5-797BF3C09E40</bpmn2:incoming>
+      <bpmn2:outgoing>_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_DO014ERZEeeSxP1_nretag">
+        <bpmn2:inputSet id="_DO014URZEeeSxP1_nretag"/>
+        <bpmn2:outputSet id="_DO014kRZEeeSxP1_nretag"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:userTask id="_845A656D-0000-409A-8330-C73FF9E79B48" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="InsideTask">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[InsideTask]]></drools:metaValue>
+          </drools:metaData>
+          <drools:metaData name="customAutoStart">
+            <drools:metaValue><![CDATA[true]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:ioSpecification id="_DO0140RZEeeSxP1_nretag">
+          <bpmn2:dataInput id="_845A656D-0000-409A-8330-C73FF9E79B48_TaskNameInputX" drools:dtype="String" name="TaskName"/>
+          <bpmn2:dataInput id="_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX" drools:dtype="Object" name="Skippable"/>
+          <bpmn2:inputSet id="_DO015ERZEeeSxP1_nretag">
+            <bpmn2:dataInputRefs>_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_845A656D-0000-409A-8330-C73FF9E79B48_TaskNameInputX</bpmn2:dataInputRefs>
+          </bpmn2:inputSet>
+          <bpmn2:outputSet id="_DO015URZEeeSxP1_nretag"/>
+        </bpmn2:ioSpecification>
+        <bpmn2:dataInputAssociation id="_DO015kRZEeeSxP1_nretag">
+          <bpmn2:targetRef>_845A656D-0000-409A-8330-C73FF9E79B48_TaskNameInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_DO0150RZEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_DO016ERZEeeSxP1_nretag"><![CDATA[InsideTask]]></bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_DO016URZEeeSxP1_nretag">_845A656D-0000-409A-8330-C73FF9E79B48_TaskNameInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_DO016kRZEeeSxP1_nretag">
+          <bpmn2:targetRef>_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_DO0160RZEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_DO017ERZEeeSxP1_nretag">true</bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_DO017URZEeeSxP1_nretag">_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:potentialOwner id="_DO017kRZEeeSxP1_nretag">
+          <bpmn2:resourceAssignmentExpression id="_DO0170RZEeeSxP1_nretag">
+            <bpmn2:formalExpression id="_DO018ERZEeeSxP1_nretag">john</bpmn2:formalExpression>
+          </bpmn2:resourceAssignmentExpression>
+        </bpmn2:potentialOwner>
+      </bpmn2:userTask>
+      <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression" id="_DO018URZEeeSxP1_nretag" language="http://www.mvel.org/2.0"><![CDATA[return caseFile_continue == continue;]]></bpmn2:completionCondition>
+    </bpmn2:adHocSubProcess>
+    <bpmn2:startEvent id="_A20B467F-6693-4AB8-A744-55FD62321D42" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_AD82CE7D-9076-467B-B6A5-797BF3C09E40</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_A20B467F-6693-4AB8-A744-55FD62321D42" targetRef="_9023779E-CF24-40EB-9D25-36B315BC525B"/>
+    <bpmn2:sequenceFlow id="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_9023779E-CF24-40EB-9D25-36B315BC525B" targetRef="_B9605743-DA67-414D-84F2-A91FC81C7697"/>
+    <bpmn2:endEvent id="_B9605743-DA67-414D-84F2-A91FC81C7697" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_DO018kRZEeeSxP1_nretag"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_DO0180RZEeeSxP1_nretag">
+    <bpmndi:BPMNPlane id="_DO019ERZEeeSxP1_nretag" bpmnElement="StageWithTaskCaseFileAndProcessVariable">
+      <bpmndi:BPMNShape id="_DO019URZEeeSxP1_nretag" bpmnElement="_9023779E-CF24-40EB-9D25-36B315BC525B">
+        <dc:Bounds height="160.0" width="200.0" x="225.0" y="105.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_DO019kRZEeeSxP1_nretag" bpmnElement="_845A656D-0000-409A-8330-C73FF9E79B48">
+        <dc:Bounds height="80.0" width="100.0" x="275.0" y="145.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_DO0190RZEeeSxP1_nretag" bpmnElement="_A20B467F-6693-4AB8-A744-55FD62321D42">
+        <dc:Bounds height="30.0" width="30.0" x="150.0" y="170.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_DO01-ERZEeeSxP1_nretag" bpmnElement="_B9605743-DA67-414D-84F2-A91FC81C7697">
+        <dc:Bounds height="28.0" width="28.0" x="470.0" y="171.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_DO01-URZEeeSxP1_nretag" bpmnElement="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" sourceElement="_DO0190RZEeeSxP1_nretag" targetElement="_DO019URZEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="165.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_DO01-kRZEeeSxP1_nretag" bpmnElement="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" sourceElement="_DO019URZEeeSxP1_nretag" targetElement="_DO01-ERZEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="484.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_DO01-0RZEeeSxP1_nretag" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" id="_DO01_ERZEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9023779E-CF24-40EB-9D25-36B315BC525B" id="_DO01_URZEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A20B467F-6693-4AB8-A744-55FD62321D42" id="_DO01_kRZEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" id="_DO01_0RZEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_845A656D-0000-409A-8330-C73FF9E79B48" id="_DO02AERZEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B9605743-DA67-414D-84F2-A91FC81C7697" id="_DO02AURZEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_DO0O0ERZEeeSxP1_nretag</bpmn2:source>
+    <bpmn2:target>_DO0O0ERZEeeSxP1_nretag</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCaseFileVariable.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCaseFileVariable.bpmn2
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_DO0O0ERZEeeSxP1_nretag" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_continueItem" structureRef="Boolean"/>
+  <bpmn2:process id="StageWithTaskCaseFileVariable" drools:adHoc="true" drools:packageName="org.jbpm" drools:version="1.0" name="StageWithTaskCaseFileVariable" isExecutable="true">
+    <bpmn2:extensionElements>
+      <drools:metaData name="customCaseIdPrefix">
+        <drools:metaValue><![CDATA[CASE]]></drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
+    <bpmn2:property id="continue" itemSubjectRef="_continueItem"/>
+    <bpmn2:adHocSubProcess id="_9023779E-CF24-40EB-9D25-36B315BC525B" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="" ordering="Sequential">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_AD82CE7D-9076-467B-B6A5-797BF3C09E40</bpmn2:incoming>
+      <bpmn2:outgoing>_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_DO014ERZEeeSxP1_nretag">
+        <bpmn2:inputSet id="_DO014URZEeeSxP1_nretag"/>
+        <bpmn2:outputSet id="_DO014kRZEeeSxP1_nretag"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:userTask id="_845A656D-0000-409A-8330-C73FF9E79B48" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="InsideTask">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[InsideTask]]></drools:metaValue>
+          </drools:metaData>
+          <drools:metaData name="customAutoStart">
+            <drools:metaValue><![CDATA[true]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:ioSpecification id="_DO0140RZEeeSxP1_nretag">
+          <bpmn2:dataInput id="_845A656D-0000-409A-8330-C73FF9E79B48_TaskNameInputX" drools:dtype="String" name="TaskName"/>
+          <bpmn2:dataInput id="_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX" drools:dtype="Object" name="Skippable"/>
+          <bpmn2:inputSet id="_DO015ERZEeeSxP1_nretag">
+            <bpmn2:dataInputRefs>_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_845A656D-0000-409A-8330-C73FF9E79B48_TaskNameInputX</bpmn2:dataInputRefs>
+          </bpmn2:inputSet>
+          <bpmn2:outputSet id="_DO015URZEeeSxP1_nretag"/>
+        </bpmn2:ioSpecification>
+        <bpmn2:dataInputAssociation id="_DO015kRZEeeSxP1_nretag">
+          <bpmn2:targetRef>_845A656D-0000-409A-8330-C73FF9E79B48_TaskNameInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_DO0150RZEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_DO016ERZEeeSxP1_nretag"><![CDATA[InsideTask]]></bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_DO016URZEeeSxP1_nretag">_845A656D-0000-409A-8330-C73FF9E79B48_TaskNameInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_DO016kRZEeeSxP1_nretag">
+          <bpmn2:targetRef>_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_DO0160RZEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_DO017ERZEeeSxP1_nretag">true</bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_DO017URZEeeSxP1_nretag">_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:potentialOwner id="_DO017kRZEeeSxP1_nretag">
+          <bpmn2:resourceAssignmentExpression id="_DO0170RZEeeSxP1_nretag">
+            <bpmn2:formalExpression id="_DO018ERZEeeSxP1_nretag">john</bpmn2:formalExpression>
+          </bpmn2:resourceAssignmentExpression>
+        </bpmn2:potentialOwner>
+      </bpmn2:userTask>
+      <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression" id="_DO018URZEeeSxP1_nretag" language="http://www.mvel.org/2.0"><![CDATA[return caseFile_continue;]]></bpmn2:completionCondition>
+    </bpmn2:adHocSubProcess>
+    <bpmn2:startEvent id="_A20B467F-6693-4AB8-A744-55FD62321D42" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_AD82CE7D-9076-467B-B6A5-797BF3C09E40</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_A20B467F-6693-4AB8-A744-55FD62321D42" targetRef="_9023779E-CF24-40EB-9D25-36B315BC525B"/>
+    <bpmn2:sequenceFlow id="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_9023779E-CF24-40EB-9D25-36B315BC525B" targetRef="_B9605743-DA67-414D-84F2-A91FC81C7697"/>
+    <bpmn2:endEvent id="_B9605743-DA67-414D-84F2-A91FC81C7697" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_DO018kRZEeeSxP1_nretag"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_DO0180RZEeeSxP1_nretag">
+    <bpmndi:BPMNPlane id="_DO019ERZEeeSxP1_nretag" bpmnElement="StageWithTaskCaseFileVariable">
+      <bpmndi:BPMNShape id="_DO019URZEeeSxP1_nretag" bpmnElement="_9023779E-CF24-40EB-9D25-36B315BC525B">
+        <dc:Bounds height="160.0" width="200.0" x="225.0" y="105.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_DO019kRZEeeSxP1_nretag" bpmnElement="_845A656D-0000-409A-8330-C73FF9E79B48">
+        <dc:Bounds height="80.0" width="100.0" x="275.0" y="145.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_DO0190RZEeeSxP1_nretag" bpmnElement="_A20B467F-6693-4AB8-A744-55FD62321D42">
+        <dc:Bounds height="30.0" width="30.0" x="150.0" y="170.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_DO01-ERZEeeSxP1_nretag" bpmnElement="_B9605743-DA67-414D-84F2-A91FC81C7697">
+        <dc:Bounds height="28.0" width="28.0" x="470.0" y="171.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_DO01-URZEeeSxP1_nretag" bpmnElement="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" sourceElement="_DO0190RZEeeSxP1_nretag" targetElement="_DO019URZEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="165.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_DO01-kRZEeeSxP1_nretag" bpmnElement="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" sourceElement="_DO019URZEeeSxP1_nretag" targetElement="_DO01-ERZEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="484.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_DO01-0RZEeeSxP1_nretag" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" id="_DO01_ERZEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9023779E-CF24-40EB-9D25-36B315BC525B" id="_DO01_URZEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A20B467F-6693-4AB8-A744-55FD62321D42" id="_DO01_kRZEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" id="_DO01_0RZEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_845A656D-0000-409A-8330-C73FF9E79B48" id="_DO02AERZEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B9605743-DA67-414D-84F2-A91FC81C7697" id="_DO02AURZEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_DO0O0ERZEeeSxP1_nretag</bpmn2:source>
+    <bpmn2:target>_DO0O0ERZEeeSxP1_nretag</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCaseFileVariableNoPrefix.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCaseFileVariableNoPrefix.bpmn2
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_m8ytMERkEeeSxP1_nretag" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_continueItem" structureRef="Boolean"/>
+  <bpmn2:process id="StageWithTaskCaseFileVariableNoPrefix" drools:adHoc="true" drools:packageName="org.jbpm" drools:version="1.0" name="StageWithTaskCaseFileVariableNoPrefix" isExecutable="true">
+    <bpmn2:extensionElements>
+      <drools:metaData name="customCaseIdPrefix">
+        <drools:metaValue><![CDATA[CASE]]></drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
+    <bpmn2:property id="continue" itemSubjectRef="_continueItem"/>
+    <bpmn2:adHocSubProcess id="_7664D917-23C2-445D-A01F-70F48ACAF6D8" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="" ordering="Sequential">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_48CA047C-376C-4F6D-99B8-41248E25A714</bpmn2:incoming>
+      <bpmn2:outgoing>_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_m8ytMURkEeeSxP1_nretag">
+        <bpmn2:inputSet id="_m8ytMkRkEeeSxP1_nretag"/>
+        <bpmn2:outputSet id="_m8ytM0RkEeeSxP1_nretag"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:userTask id="_E0C58707-EFC4-4968-BC23-3186F6359FCF" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="InsideTask">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[InsideTask]]></drools:metaValue>
+          </drools:metaData>
+          <drools:metaData name="customAutoStart">
+            <drools:metaValue><![CDATA[true]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:ioSpecification id="_m8ytNERkEeeSxP1_nretag">
+          <bpmn2:dataInput id="_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX" drools:dtype="String" name="TaskName"/>
+          <bpmn2:dataInput id="_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX" drools:dtype="Object" name="Skippable"/>
+          <bpmn2:inputSet id="_m8ytNURkEeeSxP1_nretag">
+            <bpmn2:dataInputRefs>_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX</bpmn2:dataInputRefs>
+          </bpmn2:inputSet>
+          <bpmn2:outputSet id="_m8ytNkRkEeeSxP1_nretag"/>
+        </bpmn2:ioSpecification>
+        <bpmn2:dataInputAssociation id="_m8ytN0RkEeeSxP1_nretag">
+          <bpmn2:targetRef>_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_m8ytOERkEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_m8ytOURkEeeSxP1_nretag"><![CDATA[InsideTask]]></bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_m8ytOkRkEeeSxP1_nretag">_E0C58707-EFC4-4968-BC23-3186F6359FCF_TaskNameInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_m8ytO0RkEeeSxP1_nretag">
+          <bpmn2:targetRef>_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_m8ytPERkEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_m8ytPURkEeeSxP1_nretag">true</bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_m8ytPkRkEeeSxP1_nretag">_E0C58707-EFC4-4968-BC23-3186F6359FCF_SkippableInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:potentialOwner id="_m8ytP0RkEeeSxP1_nretag">
+          <bpmn2:resourceAssignmentExpression id="_m8ytQERkEeeSxP1_nretag">
+            <bpmn2:formalExpression id="_m8ytQURkEeeSxP1_nretag">john</bpmn2:formalExpression>
+          </bpmn2:resourceAssignmentExpression>
+        </bpmn2:potentialOwner>
+      </bpmn2:userTask>
+      <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression" id="_m8ytQkRkEeeSxP1_nretag" language="http://www.mvel.org/2.0"><![CDATA[return continue == true;]]></bpmn2:completionCondition>
+    </bpmn2:adHocSubProcess>
+    <bpmn2:startEvent id="_E043B6D5-4CE0-418A-A39A-F506F223801C" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_48CA047C-376C-4F6D-99B8-41248E25A714</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="_48CA047C-376C-4F6D-99B8-41248E25A714" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_E043B6D5-4CE0-418A-A39A-F506F223801C" targetRef="_7664D917-23C2-445D-A01F-70F48ACAF6D8"/>
+    <bpmn2:sequenceFlow id="_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_7664D917-23C2-445D-A01F-70F48ACAF6D8" targetRef="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA"/>
+    <bpmn2:endEvent id="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_m8ytQ0RkEeeSxP1_nretag"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_m8ytRERkEeeSxP1_nretag">
+    <bpmndi:BPMNPlane id="_m8ytRURkEeeSxP1_nretag" bpmnElement="StageWithTaskCaseFileVariableNoPrefix">
+      <bpmndi:BPMNShape id="_m8ytRkRkEeeSxP1_nretag" bpmnElement="_7664D917-23C2-445D-A01F-70F48ACAF6D8">
+        <dc:Bounds height="160.0" width="200.0" x="225.0" y="105.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_m8ytR0RkEeeSxP1_nretag" bpmnElement="_E0C58707-EFC4-4968-BC23-3186F6359FCF">
+        <dc:Bounds height="80.0" width="100.0" x="275.0" y="145.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_m8ytSERkEeeSxP1_nretag" bpmnElement="_E043B6D5-4CE0-418A-A39A-F506F223801C">
+        <dc:Bounds height="30.0" width="30.0" x="150.0" y="170.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_m8ytSURkEeeSxP1_nretag" bpmnElement="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA">
+        <dc:Bounds height="28.0" width="28.0" x="470.0" y="171.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_m8ytSkRkEeeSxP1_nretag" bpmnElement="_48CA047C-376C-4F6D-99B8-41248E25A714" sourceElement="_m8ytSERkEeeSxP1_nretag" targetElement="_m8ytRkRkEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="165.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_m8ytS0RkEeeSxP1_nretag" bpmnElement="_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D" sourceElement="_m8ytRkRkEeeSxP1_nretag" targetElement="_m8ytSURkEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="484.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_m8ytTERkEeeSxP1_nretag" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_E043B6D5-4CE0-418A-A39A-F506F223801C" id="_m8ytTURkEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_48CA047C-376C-4F6D-99B8-41248E25A714" id="_m8ytTkRkEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_DAC6933B-C7EE-4DC2-AF33-BE64B8602FEA" id="_m8ytT0RkEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_E0C58707-EFC4-4968-BC23-3186F6359FCF" id="_m8ytUERkEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_7664D917-23C2-445D-A01F-70F48ACAF6D8" id="_m8ytUURkEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_EF7C1BC2-D8E2-4FA7-AEFD-F057C095514D" id="_m8ytUkRkEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_m8ytMERkEeeSxP1_nretag</bpmn2:source>
+    <bpmn2:target>_m8ytMERkEeeSxP1_nretag</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCount.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskCount.bpmn2
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_j3Gv4EFJEeeiQ4g7Vpoa4g" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_taskCountItem" structureRef="Integer"/>
+  <bpmn2:process id="StageWithTaskCount" drools:adHoc="true" drools:packageName="org.jbpm" drools:version="1.0" name="StageWithTaskCount" isExecutable="true">
+    <bpmn2:extensionElements>
+      <drools:metaData name="customCaseIdPrefix">
+        <drools:metaValue><![CDATA[CASE]]></drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
+    <bpmn2:property id="taskCount" itemSubjectRef="_taskCountItem"/>
+    <bpmn2:adHocSubProcess id="_9023779E-CF24-40EB-9D25-36B315BC525B" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="" ordering="Sequential">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_AD82CE7D-9076-467B-B6A5-797BF3C09E40</bpmn2:incoming>
+      <bpmn2:outgoing>_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_j3Gv4UFJEeeiQ4g7Vpoa4g">
+        <bpmn2:inputSet id="_j3Gv4kFJEeeiQ4g7Vpoa4g"/>
+        <bpmn2:outputSet id="_j3Gv40FJEeeiQ4g7Vpoa4g"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:userTask id="_845A656D-0000-409A-8330-C73FF9E79B48" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="InsideTask">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[InsideTask]]></drools:metaValue>
+          </drools:metaData>
+          <drools:metaData name="customAutoStart">
+            <drools:metaValue><![CDATA[true]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:ioSpecification id="_j3Gv5EFJEeeiQ4g7Vpoa4g">
+          <bpmn2:dataInput id="_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX" drools:dtype="Object" name="Skippable"/>
+          <bpmn2:inputSet id="_j3Gv5UFJEeeiQ4g7Vpoa4g">
+            <bpmn2:dataInputRefs>_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:dataInputRefs>
+          </bpmn2:inputSet>
+          <bpmn2:outputSet id="_j3Gv5kFJEeeiQ4g7Vpoa4g"/>
+        </bpmn2:ioSpecification>
+        <bpmn2:dataInputAssociation id="_j3Gv50FJEeeiQ4g7Vpoa4g">
+          <bpmn2:targetRef>_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_j3Gv6EFJEeeiQ4g7Vpoa4g">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_j3Gv6UFJEeeiQ4g7Vpoa4g">true</bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_j3Gv6kFJEeeiQ4g7Vpoa4g">_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:potentialOwner id="_j3Gv60FJEeeiQ4g7Vpoa4g">
+          <bpmn2:resourceAssignmentExpression id="_j3Gv7EFJEeeiQ4g7Vpoa4g">
+            <bpmn2:formalExpression id="_j3Gv7UFJEeeiQ4g7Vpoa4g">john</bpmn2:formalExpression>
+          </bpmn2:resourceAssignmentExpression>
+        </bpmn2:potentialOwner>
+      </bpmn2:userTask>
+      <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression" id="_j3Gv7kFJEeeiQ4g7Vpoa4g" language="http://www.mvel.org/2.0"><![CDATA[getActivityInstanceAttribute("numberOfActiveInstances") == 0]]></bpmn2:completionCondition>
+    </bpmn2:adHocSubProcess>
+    <bpmn2:startEvent id="_A20B467F-6693-4AB8-A744-55FD62321D42" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_AD82CE7D-9076-467B-B6A5-797BF3C09E40</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_A20B467F-6693-4AB8-A744-55FD62321D42" targetRef="_9023779E-CF24-40EB-9D25-36B315BC525B"/>
+    <bpmn2:sequenceFlow id="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_9023779E-CF24-40EB-9D25-36B315BC525B" targetRef="_A983FAE1-99FF-4E94-A6A2-253D4768523C"/>
+    <bpmn2:endEvent id="_A983FAE1-99FF-4E94-A6A2-253D4768523C" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_j3Gv70FJEeeiQ4g7Vpoa4g"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_j3Gv8EFJEeeiQ4g7Vpoa4g">
+    <bpmndi:BPMNPlane id="_j3Gv8UFJEeeiQ4g7Vpoa4g" bpmnElement="StageWithTaskCount">
+      <bpmndi:BPMNShape id="_j3Gv8kFJEeeiQ4g7Vpoa4g" bpmnElement="_9023779E-CF24-40EB-9D25-36B315BC525B">
+        <dc:Bounds height="160.0" width="200.0" x="225.0" y="105.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_j3Gv80FJEeeiQ4g7Vpoa4g" bpmnElement="_845A656D-0000-409A-8330-C73FF9E79B48">
+        <dc:Bounds height="80.0" width="100.0" x="275.0" y="145.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_j3Gv9EFJEeeiQ4g7Vpoa4g" bpmnElement="_A20B467F-6693-4AB8-A744-55FD62321D42">
+        <dc:Bounds height="30.0" width="30.0" x="150.0" y="170.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_j3Gv9UFJEeeiQ4g7Vpoa4g" bpmnElement="_A983FAE1-99FF-4E94-A6A2-253D4768523C">
+        <dc:Bounds height="28.0" width="28.0" x="470.0" y="171.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_j3Gv9kFJEeeiQ4g7Vpoa4g" bpmnElement="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" sourceElement="_j3Gv9EFJEeeiQ4g7Vpoa4g" targetElement="_j3Gv8kFJEeeiQ4g7Vpoa4g">
+        <di:waypoint xsi:type="dc:Point" x="165.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_j3Gv90FJEeeiQ4g7Vpoa4g" bpmnElement="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" sourceElement="_j3Gv8kFJEeeiQ4g7Vpoa4g" targetElement="_j3Gv9UFJEeeiQ4g7Vpoa4g">
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="484.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_j3Gv-EFJEeeiQ4g7Vpoa4g" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" id="_j3Gv-UFJEeeiQ4g7Vpoa4g">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A983FAE1-99FF-4E94-A6A2-253D4768523C" id="_j3Gv-kFJEeeiQ4g7Vpoa4g">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9023779E-CF24-40EB-9D25-36B315BC525B" id="_j3Gv-0FJEeeiQ4g7Vpoa4g">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A20B467F-6693-4AB8-A744-55FD62321D42" id="_j3Gv_EFJEeeiQ4g7Vpoa4g">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" id="_j3Gv_UFJEeeiQ4g7Vpoa4g">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_845A656D-0000-409A-8330-C73FF9E79B48" id="_j3Gv_kFJEeeiQ4g7Vpoa4g">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_j3Gv4EFJEeeiQ4g7Vpoa4g</bpmn2:source>
+    <bpmn2:target>_j3Gv4EFJEeeiQ4g7Vpoa4g</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskNoAutoStart.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskNoAutoStart.bpmn2
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_CXtcYEFTEeeiQ4g7Vpoa4g" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:process id="StageWithTaskNoAutoStart" drools:adHoc="true" drools:packageName="org.jbpm" drools:version="1.0" name="StageWithTaskNoAutoStart" isExecutable="true">
+    <bpmn2:extensionElements>
+      <drools:metaData name="customCaseIdPrefix">
+        <drools:metaValue><![CDATA[CASE]]></drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
+    <bpmn2:adHocSubProcess id="_9023779E-CF24-40EB-9D25-36B315BC525B" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="" ordering="Sequential">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_AD82CE7D-9076-467B-B6A5-797BF3C09E40</bpmn2:incoming>
+      <bpmn2:outgoing>_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_CXtcYUFTEeeiQ4g7Vpoa4g">
+        <bpmn2:inputSet id="_CXtcYkFTEeeiQ4g7Vpoa4g"/>
+        <bpmn2:outputSet id="_CXtcY0FTEeeiQ4g7Vpoa4g"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:userTask id="_845A656D-0000-409A-8330-C73FF9E79B48" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="InsideTask">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[InsideTask]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:ioSpecification id="_CXtcZEFTEeeiQ4g7Vpoa4g">
+          <bpmn2:dataInput id="_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX" drools:dtype="Object" name="Skippable"/>
+          <bpmn2:inputSet id="_CXtcZUFTEeeiQ4g7Vpoa4g">
+            <bpmn2:dataInputRefs>_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:dataInputRefs>
+          </bpmn2:inputSet>
+          <bpmn2:outputSet id="_CXtcZkFTEeeiQ4g7Vpoa4g"/>
+        </bpmn2:ioSpecification>
+        <bpmn2:dataInputAssociation id="_CXtcZ0FTEeeiQ4g7Vpoa4g">
+          <bpmn2:targetRef>_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_CXtcaEFTEeeiQ4g7Vpoa4g">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_CXtcaUFTEeeiQ4g7Vpoa4g">true</bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_CXtcakFTEeeiQ4g7Vpoa4g">_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:potentialOwner id="_CXtca0FTEeeiQ4g7Vpoa4g">
+          <bpmn2:resourceAssignmentExpression id="_CXtcbEFTEeeiQ4g7Vpoa4g">
+            <bpmn2:formalExpression id="_CXtcbUFTEeeiQ4g7Vpoa4g">john</bpmn2:formalExpression>
+          </bpmn2:resourceAssignmentExpression>
+        </bpmn2:potentialOwner>
+      </bpmn2:userTask>
+      <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression" id="_CXtcbkFTEeeiQ4g7Vpoa4g" language="http://www.mvel.org/2.0"><![CDATA[autocomplete]]></bpmn2:completionCondition>
+    </bpmn2:adHocSubProcess>
+    <bpmn2:startEvent id="_A20B467F-6693-4AB8-A744-55FD62321D42" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_AD82CE7D-9076-467B-B6A5-797BF3C09E40</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_A20B467F-6693-4AB8-A744-55FD62321D42" targetRef="_9023779E-CF24-40EB-9D25-36B315BC525B"/>
+    <bpmn2:sequenceFlow id="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_9023779E-CF24-40EB-9D25-36B315BC525B" targetRef="_B9605743-DA67-414D-84F2-A91FC81C7697"/>
+    <bpmn2:endEvent id="_B9605743-DA67-414D-84F2-A91FC81C7697" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_CXtcb0FTEeeiQ4g7Vpoa4g"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_CXtccEFTEeeiQ4g7Vpoa4g">
+    <bpmndi:BPMNPlane id="_CXtccUFTEeeiQ4g7Vpoa4g" bpmnElement="StageWithTaskNoAutoStart">
+      <bpmndi:BPMNShape id="_CXtcckFTEeeiQ4g7Vpoa4g" bpmnElement="_9023779E-CF24-40EB-9D25-36B315BC525B">
+        <dc:Bounds height="160.0" width="200.0" x="225.0" y="105.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_CXtcc0FTEeeiQ4g7Vpoa4g" bpmnElement="_845A656D-0000-409A-8330-C73FF9E79B48">
+        <dc:Bounds height="80.0" width="100.0" x="275.0" y="145.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_CXtcdEFTEeeiQ4g7Vpoa4g" bpmnElement="_A20B467F-6693-4AB8-A744-55FD62321D42">
+        <dc:Bounds height="30.0" width="30.0" x="150.0" y="170.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_CXtcdUFTEeeiQ4g7Vpoa4g" bpmnElement="_B9605743-DA67-414D-84F2-A91FC81C7697">
+        <dc:Bounds height="28.0" width="28.0" x="470.0" y="171.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_CXtcdkFTEeeiQ4g7Vpoa4g" bpmnElement="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" sourceElement="_CXtcdEFTEeeiQ4g7Vpoa4g" targetElement="_CXtcckFTEeeiQ4g7Vpoa4g">
+        <di:waypoint xsi:type="dc:Point" x="165.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_CXtcd0FTEeeiQ4g7Vpoa4g" bpmnElement="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" sourceElement="_CXtcckFTEeeiQ4g7Vpoa4g" targetElement="_CXtcdUFTEeeiQ4g7Vpoa4g">
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="484.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_CXtceEFTEeeiQ4g7Vpoa4g" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" id="_CXtceUFTEeeiQ4g7Vpoa4g">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9023779E-CF24-40EB-9D25-36B315BC525B" id="_CXtcekFTEeeiQ4g7Vpoa4g">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A20B467F-6693-4AB8-A744-55FD62321D42" id="_CXtce0FTEeeiQ4g7Vpoa4g">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" id="_CXtcfEFTEeeiQ4g7Vpoa4g">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_845A656D-0000-409A-8330-C73FF9E79B48" id="_CXtcfUFTEeeiQ4g7Vpoa4g">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B9605743-DA67-414D-84F2-A91FC81C7697" id="_CXtcfkFTEeeiQ4g7Vpoa4g">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_CXtcYEFTEeeiQ4g7Vpoa4g</bpmn2:source>
+    <bpmn2:target>_CXtcYEFTEeeiQ4g7Vpoa4g</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskProcessVariable.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/stage/completion/StageWithTaskProcessVariable.bpmn2
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_DO0O0ERZEeeSxP1_nretag" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_continueItem" structureRef="Boolean"/>
+  <bpmn2:process id="StageWithTaskProcessVariable" drools:adHoc="true" drools:packageName="org.jbpm" drools:version="1.0" name="StageWithTaskProcessVariable" isExecutable="true">
+    <bpmn2:extensionElements>
+      <drools:metaData name="customCaseIdPrefix">
+        <drools:metaValue><![CDATA[CASE]]></drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
+    <bpmn2:property id="continue" itemSubjectRef="_continueItem"/>
+    <bpmn2:adHocSubProcess id="_9023779E-CF24-40EB-9D25-36B315BC525B" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="" ordering="Sequential">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_AD82CE7D-9076-467B-B6A5-797BF3C09E40</bpmn2:incoming>
+      <bpmn2:outgoing>_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_DO014ERZEeeSxP1_nretag">
+        <bpmn2:inputSet id="_DO014URZEeeSxP1_nretag"/>
+        <bpmn2:outputSet id="_DO014kRZEeeSxP1_nretag"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:userTask id="_845A656D-0000-409A-8330-C73FF9E79B48" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="InsideTask">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[InsideTask]]></drools:metaValue>
+          </drools:metaData>
+          <drools:metaData name="customAutoStart">
+            <drools:metaValue><![CDATA[true]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:ioSpecification id="_DO0140RZEeeSxP1_nretag">
+          <bpmn2:dataInput id="_845A656D-0000-409A-8330-C73FF9E79B48_TaskNameInputX" drools:dtype="String" name="TaskName"/>
+          <bpmn2:dataInput id="_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX" drools:dtype="Object" name="Skippable"/>
+          <bpmn2:inputSet id="_DO015ERZEeeSxP1_nretag">
+            <bpmn2:dataInputRefs>_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_845A656D-0000-409A-8330-C73FF9E79B48_TaskNameInputX</bpmn2:dataInputRefs>
+          </bpmn2:inputSet>
+          <bpmn2:outputSet id="_DO015URZEeeSxP1_nretag"/>
+        </bpmn2:ioSpecification>
+        <bpmn2:dataInputAssociation id="_DO015kRZEeeSxP1_nretag">
+          <bpmn2:targetRef>_845A656D-0000-409A-8330-C73FF9E79B48_TaskNameInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_DO0150RZEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_DO016ERZEeeSxP1_nretag"><![CDATA[InsideTask]]></bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_DO016URZEeeSxP1_nretag">_845A656D-0000-409A-8330-C73FF9E79B48_TaskNameInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_DO016kRZEeeSxP1_nretag">
+          <bpmn2:targetRef>_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:targetRef>
+          <bpmn2:assignment id="_DO0160RZEeeSxP1_nretag">
+            <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_DO017ERZEeeSxP1_nretag">true</bpmn2:from>
+            <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_DO017URZEeeSxP1_nretag">_845A656D-0000-409A-8330-C73FF9E79B48_SkippableInputX</bpmn2:to>
+          </bpmn2:assignment>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:potentialOwner id="_DO017kRZEeeSxP1_nretag">
+          <bpmn2:resourceAssignmentExpression id="_DO0170RZEeeSxP1_nretag">
+            <bpmn2:formalExpression id="_DO018ERZEeeSxP1_nretag">john</bpmn2:formalExpression>
+          </bpmn2:resourceAssignmentExpression>
+        </bpmn2:potentialOwner>
+      </bpmn2:userTask>
+      <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression" id="_DO018URZEeeSxP1_nretag" language="http://www.mvel.org/2.0"><![CDATA[return continue;]]></bpmn2:completionCondition>
+    </bpmn2:adHocSubProcess>
+    <bpmn2:startEvent id="_A20B467F-6693-4AB8-A744-55FD62321D42" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_AD82CE7D-9076-467B-B6A5-797BF3C09E40</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_A20B467F-6693-4AB8-A744-55FD62321D42" targetRef="_9023779E-CF24-40EB-9D25-36B315BC525B"/>
+    <bpmn2:sequenceFlow id="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_9023779E-CF24-40EB-9D25-36B315BC525B" targetRef="_B9605743-DA67-414D-84F2-A91FC81C7697"/>
+    <bpmn2:endEvent id="_B9605743-DA67-414D-84F2-A91FC81C7697" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_DO018kRZEeeSxP1_nretag"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_DO0180RZEeeSxP1_nretag">
+    <bpmndi:BPMNPlane id="_DO019ERZEeeSxP1_nretag" bpmnElement="StageWithTaskProcessVariable">
+      <bpmndi:BPMNShape id="_DO019URZEeeSxP1_nretag" bpmnElement="_9023779E-CF24-40EB-9D25-36B315BC525B">
+        <dc:Bounds height="160.0" width="200.0" x="225.0" y="105.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_DO019kRZEeeSxP1_nretag" bpmnElement="_845A656D-0000-409A-8330-C73FF9E79B48">
+        <dc:Bounds height="80.0" width="100.0" x="275.0" y="145.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_DO0190RZEeeSxP1_nretag" bpmnElement="_A20B467F-6693-4AB8-A744-55FD62321D42">
+        <dc:Bounds height="30.0" width="30.0" x="150.0" y="170.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_DO01-ERZEeeSxP1_nretag" bpmnElement="_B9605743-DA67-414D-84F2-A91FC81C7697">
+        <dc:Bounds height="28.0" width="28.0" x="470.0" y="171.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_DO01-URZEeeSxP1_nretag" bpmnElement="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" sourceElement="_DO0190RZEeeSxP1_nretag" targetElement="_DO019URZEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="165.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_DO01-kRZEeeSxP1_nretag" bpmnElement="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" sourceElement="_DO019URZEeeSxP1_nretag" targetElement="_DO01-ERZEeeSxP1_nretag">
+        <di:waypoint xsi:type="dc:Point" x="325.0" y="185.0"/>
+        <di:waypoint xsi:type="dc:Point" x="484.0" y="185.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_DO01-0RZEeeSxP1_nretag" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_AD82CE7D-9076-467B-B6A5-797BF3C09E40" id="_DO01_ERZEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9023779E-CF24-40EB-9D25-36B315BC525B" id="_DO01_URZEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A20B467F-6693-4AB8-A744-55FD62321D42" id="_DO01_kRZEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5BCB7833-DFE7-4DF5-8DF8-0B3203C90BC9" id="_DO01_0RZEeeSxP1_nretag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_845A656D-0000-409A-8330-C73FF9E79B48" id="_DO02AERZEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B9605743-DA67-414D-84F2-A91FC81C7697" id="_DO02AURZEeeSxP1_nretag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_DO0O0ERZEeeSxP1_nretag</bpmn2:source>
+    <bpmn2:target>_DO0O0ERZEeeSxP1_nretag</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION
I have extended case stage completion condition tests as described in [JBPM-6013](https://issues.jboss.org/browse/JBPM-6013).

Most of the tests are failing because of [JBPM-6029](https://issues.jboss.org/browse/JBPM-6029). It seems the engine checks completion condition only when some task is completed but variables used in this condition may be changed in the meantime and the stage should be completed immediately when this happens.

The other thing I am not sure about is using case file variable without `caseFile_` prefix in the completion condition. I was told it should be possible to use case file variables directly if there is no process variable with the same name. However, it seems it does not work. See the ignored test.

