### PR TITLE
[JBPM-6066]  Allow usage of configuration entries in creation of MarshallingStrategies

### DIFF
--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/RuntimeEnvironmentBuilder.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/RuntimeEnvironmentBuilder.java
@@ -240,6 +240,7 @@ public class RuntimeEnvironmentBuilder implements RuntimeEnvironmentBuilderFacto
 		for (NamedObjectModel model : descriptor.getConfiguration()) {
 			Object entry = getInstanceFromModel(model, kieContainer, contaxtParams);
 			builder.addConfiguration(model.getName(), (String) entry);
+			contaxtParams.put( model.getName(), (String) entry);
 		}
 		ObjectMarshallingStrategy[] mStrategies = new ObjectMarshallingStrategy[descriptor.getMarshallingStrategies().size() + 1];
 		int index = 0;

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/KModuleDeploymentService.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/KModuleDeploymentService.java
@@ -281,6 +281,7 @@ public class KModuleDeploymentService extends AbstractDeploymentService {
 		for (NamedObjectModel model : descriptor.getConfiguration()) {
 			Object entry = getInstanceFromModel(model, kieContainer, contaxtParams);
 			builder.addConfiguration(model.getName(), (String) entry);
+			contaxtParams.put( model.getName(), (String) entry );
 		}
 		ObjectMarshallingStrategy[] mStrategies = new ObjectMarshallingStrategy[descriptor.getMarshallingStrategies().size() + 1];
 		int index = 0;


### PR DESCRIPTION
We are using complex deployment descriptors full of configuration entries, but we are not able to use them in creation of object marshalling strategies. With this small change we can define a configuration entry named project_persistence_unit and use it in the calling to the creation of our custom marshalling strategy.