### PR TITLE
[JBPM-6075] JBPM-Audit: fix failing tests

### DIFF
--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/AbstractAuditLogServiceTest.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/AbstractAuditLogServiceTest.java
@@ -488,7 +488,7 @@ public abstract class AbstractAuditLogServiceTest extends AbstractBaseTest {
         assertEquals("One", var.getValue());
         // Various DBs return various empty values. (E.g. Oracle returns null.)
         assertThat(var.getOldValue(), AnyOf.anyOf(Is.is(""), Is.is((String) null), Is.is(" ")));
-        assertEquals(processInstance.getId(), var.getProcessInstanceId().longValue());
+        assertEquals(processInstance.getProcessInstanceId(), var.getProcessInstanceId());
         assertEquals(processInstance.getProcessId(), var.getProcessId());
         assertEquals("list[0]", var.getVariableId());
         assertEquals("list", var.getVariableInstanceId());
@@ -496,7 +496,7 @@ public abstract class AbstractAuditLogServiceTest extends AbstractBaseTest {
         var = listVariables.get(1);
         assertEquals("Two", var.getValue());
         assertThat(var.getOldValue(), AnyOf.anyOf(Is.is(""), Is.is((String) null), Is.is(" ")));
-        assertEquals(processInstance.getId(), var.getProcessInstanceId().longValue());
+        assertEquals(processInstance.getProcessInstanceId(), var.getProcessInstanceId());
         assertEquals(processInstance.getProcessId(), var.getProcessId());
         assertEquals("list[1]", var.getVariableId());
         assertEquals("list", var.getVariableInstanceId());
@@ -504,7 +504,7 @@ public abstract class AbstractAuditLogServiceTest extends AbstractBaseTest {
         var = listVariables.get(2);        
         assertEquals("Three", var.getValue());
         assertThat(var.getOldValue(), AnyOf.anyOf(Is.is(""), Is.is((String) null), Is.is(" ")));
-        assertEquals(processInstance.getId(), var.getProcessInstanceId().longValue());
+        assertEquals(processInstance.getProcessInstanceId(), var.getProcessInstanceId());
         assertEquals(processInstance.getProcessId(), var.getProcessId());
         assertEquals("list[2]", var.getVariableId());
         assertEquals("list", var.getVariableInstanceId());

--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/query/AuditDeleteTest.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/query/AuditDeleteTest.java
@@ -21,6 +21,7 @@ import static org.jbpm.persistence.util.PersistenceUtil.setupWithPoolingDataSour
 import static org.junit.Assert.assertEquals;
 import static org.kie.api.runtime.EnvironmentName.ENTITY_MANAGER_FACTORY;
 
+import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -61,13 +62,12 @@ public class AuditDeleteTest extends JPAAuditLogService {
     private ProcessInstanceLog [] pilTestData;
     private VariableInstanceLog [] vilTestData;
     private NodeInstanceLog [] nilTestData;
-    
+
+    private boolean firstRun = true;
     
     @BeforeClass
     public static void configure() { 
         LoggingPrintStream.interceptSysOutSysErr();
-        
-        
     }
     
     @AfterClass
@@ -80,17 +80,23 @@ public class AuditDeleteTest extends JPAAuditLogService {
     public void setUp() throws Exception {
     	context = setupWithPoolingDataSource(JBPM_PERSISTENCE_UNIT_NAME);
         emf = (EntityManagerFactory) context.get(ENTITY_MANAGER_FACTORY);
-        if( pilTestData == null ) { 
+        this.persistenceStrategy = new StandaloneJtaStrategy(emf);
+
+        if (firstRun) {
+            clearTables(ProcessInstanceLog.class, VariableInstanceLog.class, NodeInstanceLog.class);
+            firstRun = false;
+        }
+        if (pilTestData == null) {
             pilTestData = createTestProcessInstanceLogData();
             vilTestData = createTestVariableInstanceLogData();
             nilTestData = createTestNodeInstanceLogData();
         }
-        this.persistenceStrategy = new StandaloneJtaStrategy(emf);
     }
     
     @After
     public void cleanup() {
-    	cleanUp(context);
+        clearTables(ProcessInstanceLog.class, VariableInstanceLog.class, NodeInstanceLog.class);
+        cleanUp(context);
     }
    
     private static Random random = new Random();
@@ -478,4 +484,17 @@ public class AuditDeleteTest extends JPAAuditLogService {
         int result = updateBuilder.build().execute();
         assertEquals(2, result);
     }
+
+    private void clearTables(Class<? extends Serializable>... entities) {
+        EntityManager em = getEntityManager();
+        Object newTx = joinTransaction(em);
+        try {
+            for (Class<? extends Serializable> entity : entities) {
+                em.createQuery("DELETE FROM " + entity.getSimpleName()).executeUpdate();
+            }
+        } finally {
+            closeEntityManager(em, newTx);
+        }
+    }
+
 }


### PR DESCRIPTION
Added cleaning tables in the beginning and after each test for AuditDeleteTest
Fixed comparing wrong values in CommandBasedAuditLogServiceTest

(cherry picked from commit fee7a89)