### PR TITLE
Remove empty Private-Package config from maven-bundle

### DIFF
--- a/jbpm-audit/pom.xml
+++ b/jbpm-audit/pom.xml
@@ -190,7 +190,6 @@
               org.hibernate.proxy;resolution:=optional,
               *
             </Import-Package>
-            <Private-Package/>
             <Export-Package>
               org.jbpm.process.audit*
             </Export-Package>

--- a/jbpm-flow/pom.xml
+++ b/jbpm-flow/pom.xml
@@ -68,7 +68,6 @@
                 org.kie.dmn.api.core;resolution:=optional,                
                 *
             </Import-Package>
-            <Private-Package/>
             <Export-Package>
                 org.jbpm.flow.util.*,
                 org.jbpm.marshalling.*,

--- a/jbpm-human-task/jbpm-human-task-audit/pom.xml
+++ b/jbpm-human-task/jbpm-human-task-audit/pom.xml
@@ -174,7 +174,6 @@
               org.jbpm.services.task.lifecycle.listeners,
               *
             </Import-Package>
-            <Private-Package/>
             <Export-Package>
               org.jbpm.services.task.audit*,
               org.jbpm.services.task.lifecycle.listeners

--- a/jbpm-human-task/jbpm-human-task-core/pom.xml
+++ b/jbpm-human-task/jbpm-human-task-core/pom.xml
@@ -283,7 +283,6 @@
               org.drools.persistence.jta;resolution:=optional,
               *
             </Import-Package>
-            <Private-Package/>
             <Export-Package>
               org.jbpm.services.task*
             </Export-Package>

--- a/jbpm-human-task/jbpm-human-task-workitems/pom.xml
+++ b/jbpm-human-task/jbpm-human-task-workitems/pom.xml
@@ -141,7 +141,6 @@
               !org.jbpm.services.task.wih,
               *
             </Import-Package>
-            <Private-Package/>
             <Export-Package>
               org.jbpm.services.task.wih*
             </Export-Package>

--- a/jbpm-query-jpa/pom.xml
+++ b/jbpm-query-jpa/pom.xml
@@ -58,7 +58,6 @@
             <Import-Package>
               *
             </Import-Package>
-            <Private-Package/>
             <Export-Package>
                 org.jbpm.query.*,
             </Export-Package>

--- a/jbpm-runtime-manager/pom.xml
+++ b/jbpm-runtime-manager/pom.xml
@@ -362,7 +362,6 @@
               org.eclipse.aether.artifact;resolution:=optional,
               org.xml.sax
             </Import-Package>
-            <Private-Package/>
             <Export-Package>
               org.jbpm.runtime.manager.api*,
               org.jbpm.runtime.manager.impl*

--- a/jbpm-services/jbpm-shared-services/pom.xml
+++ b/jbpm-services/jbpm-shared-services/pom.xml
@@ -83,8 +83,6 @@
             <Import-Package>
               !org.jbpm.shared.services, org.jboss.solder.core;resolution:=optional,*
             </Import-Package>
-            <Private-Package>
-            </Private-Package>
             <Export-Package>
               org.jbpm.shared.services*
             </Export-Package>


### PR DESCRIPTION
Hi,

I, @psiroky and @baldimir have found that TotalCompletionTimeAssignmentStrategyTest was failing with our automation because of `ClassNotFoundException: org.jbpm.services.task.assignment.impl.TotalCompletionTimeLoadCalculator`. We found out that this class wasn't present inside binaries jbpm-human-task-audit.jar, but was present in sources.jar. The root cause was the maven-bundle-plugin config which had empty Private-Package configuration and this new class was a part of a new package which wasn't in Export-Package either. Therefore, maven-bundle-plugin didn't put this class inside jar. PR builds were passing because they consume target/classes binaries and not resulting jars. To prevent this from happening in future I have removed empty Private-Package configurations from pom.xml files so now it has default value, which is * (all classes). And Export-Package contains exported classes as before, so nothing has changed. To sum up, maven-bundle-plugin presumably puts the union of Private-Package and Export-Package into resulting jar and makes only Export-Package packages exported/public. For more information please see [1].

Thanks,

Marian

[1] http://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html#default-behavior