### PR TITLE
jbpm-remote-ejb-test cleanup of dependencies

### DIFF
--- a/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-app/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-app/pom.xml
@@ -119,10 +119,6 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.btm</groupId>
-      <artifactId>btm</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
@@ -133,17 +133,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jbpm</groupId>
-      <artifactId>jbpm-test</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.kie</groupId>
-          <artifactId>kie-ci</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-api</artifactId>
       <scope>provided</scope>
@@ -231,6 +220,13 @@
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
       <artifactId>hibernate-jpa-2.1-api</artifactId>
+    </dependency>
+
+    <!--H2 for Cargo plugin-->
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <!-- EJB -->


### PR DESCRIPTION
Hi, @mswiderski @tomjenkinson,

here is the PR which should solve some of the issues with #898. jbpm-remote-ejb-test module shouldn't use BTM or Narayana at all since it runs only with WidlFly 10/EAP 7. Therefore, if you cherry-pick or rebase onto this, I think you shouldn't have any troubles with this module.

Thanks,

Marian
