### PR TITLE
RHBPMS-4761 - Transaction timeout when running EJB Timers on WAS

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/timer/TimerManager.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/timer/TimerManager.java
@@ -253,7 +253,7 @@ public class TimerManager {
             // check if the timer instance is not already registered to avoid duplicated timers
             if (!tm.getTimerMap().containsKey(timerInstance.getId())) {
                 ProcessJobContext pctx = new ProcessJobContext(timerInstance, trigger, processInstanceId,
-                        inCtx.wm.getKnowledgeRuntime());
+                        inCtx.wm.getKnowledgeRuntime(), false);
                 Date date = trigger.hasNextFireTime();
 
                 if (date != null) {
@@ -373,6 +373,8 @@ public class TimerManager {
 
         private JobHandle jobHandle;
         private Long sessionId;
+        
+        private boolean newTimer;
 
         public ProcessJobContext(final TimerInstance timer, final Trigger trigger, final Long processInstanceId,
                 final InternalKnowledgeRuntime kruntime) {
@@ -381,6 +383,17 @@ public class TimerManager {
             this.processInstanceId = processInstanceId;
             this.kruntime = kruntime;
             this.sessionId = timer.getSessionId();
+            this.newTimer = true;
+        }
+        
+        public ProcessJobContext(final TimerInstance timer, final Trigger trigger, final Long processInstanceId,
+                final InternalKnowledgeRuntime kruntime, boolean newTimer) {
+            this.timer = timer;
+            this.trigger = trigger;
+            this.processInstanceId = processInstanceId;
+            this.kruntime = kruntime;
+            this.sessionId = timer.getSessionId();
+            this.newTimer = newTimer;
         }
 
         public Long getProcessInstanceId() {
@@ -418,6 +431,10 @@ public class TimerManager {
         @Override
         public InternalWorkingMemory getWorkingMemory() {
             return kruntime instanceof InternalWorkingMemory ? (InternalWorkingMemory)kruntime : null;
+        }
+        
+        public boolean isNewTimer() {
+            return newTimer;
         }
     }
 

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
@@ -53,11 +53,15 @@ public class EjbSchedulerService implements GlobalSchedulerService {
 		String jobName = getJobName(ctx, id);
 		EjbGlobalJobHandle jobHandle = new EjbGlobalJobHandle(id, jobName, ((GlobalTimerService) globalTimerService).getTimerServiceId());
 		
-		TimerJobInstance jobInstance = scheduler.getTimerByName(jobName);
-		if (jobInstance != null) {
-			return jobInstance.getJobHandle();
+		TimerJobInstance jobInstance = null;
+		// check if given timer job is marked as new timer meaning it was never scheduled before, 
+		// if so skip the check by timer name as it has no way to exist
+		if (!isNewTimer(ctx)) {
+    		jobInstance = scheduler.getTimerByName(jobName);
+    		if (jobInstance != null) {
+    			return jobInstance.getJobHandle();
+    		}
 		}
-		
 		jobInstance = globalTimerService.getTimerJobFactoryManager().createTimerJobInstance(
 														job, 
 														ctx, 
@@ -144,5 +148,15 @@ public class EjbSchedulerService implements GlobalSchedulerService {
         }
         return jobname;
 	}
+	
+   private boolean isNewTimer(JobContext ctx) {
+
+        boolean isNewTimer = true;
+        if (ctx instanceof ProcessJobContext) {
+            ProcessJobContext processCtx = (ProcessJobContext) ctx;
+            isNewTimer = processCtx.isNewTimer();
+        }
+        return isNewTimer;
+    }
 
 }


### PR DESCRIPTION
Added local cache for ejb timer service to improve performance after restart
Marked new timers as new to skip the timer service check by name to improve performance