### PR TITLE
jbpm-in-container-test: Exclude xml-apis on WebSphere 9

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/shrinkwrap-war-profiles/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/shrinkwrap-war-profiles/pom.xml
@@ -246,6 +246,12 @@
         <dependency>
           <groupId>xerces</groupId>
           <artifactId>xercesImpl</artifactId>
+          <exclusions><!-- conflicts on WAS -->
+            <exclusion>
+              <groupId>xml-apis</groupId>
+              <artifactId>xml-apis</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
           <groupId>xalan</groupId>


### PR DESCRIPTION
Hi, @mswiderski 

this PR only covers simple exclusion of xml-apis for WebSphere 9. Tests were failing with productization builds because of different version of xercesImpl artifact to the version used in community.

Thanks,

Marian
