### PR TITLE
Add a check for non-NULL key

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/marshalling/impl/ProtobufProcessMarshaller.java
+++ b/jbpm-flow/src/main/java/org/jbpm/marshalling/impl/ProtobufProcessMarshaller.java
@@ -296,21 +296,23 @@ public class ProtobufProcessMarshaller
     public static VariableContainer marshallVariablesContainer(MarshallerWriteContext context, Map<String, Object> variables) throws IOException{
     	JBPMMessages.VariableContainer.Builder vcbuilder = JBPMMessages.VariableContainer.newBuilder();
         for(String key : variables.keySet()){
-            JBPMMessages.Variable.Builder builder = JBPMMessages.Variable.newBuilder().setName( key );
-            if(variables.get(key) != null){
-                ObjectMarshallingStrategy strategy = context.objectMarshallingStrategyStore.getStrategyObject( variables.get(key) );
-                Integer index = context.getStrategyIndex( strategy );
-                builder.setStrategyIndex( index )
-                   .setValue( ByteString.copyFrom( strategy.marshal( context.strategyContext.get( strategy ),
-                                                                     context,
-                                                                     variables.get(key) ) ) );
-                
-            } 
-                                     
-           
-            
-            vcbuilder.addVariable(builder.build());
-        }
+            if(key != null){
+		    JBPMMessages.Variable.Builder builder = JBPMMessages.Variable.newBuilder().setName( key );
+		    if(variables.get(key) != null){
+			ObjectMarshallingStrategy strategy = context.objectMarshallingStrategyStore.getStrategyObject( variables.get(key) );
+			Integer index = context.getStrategyIndex( strategy );
+			builder.setStrategyIndex( index )
+			   .setValue( ByteString.copyFrom( strategy.marshal( context.strategyContext.get( strategy ),
+									     context,
+									     variables.get(key) ) ) );
+
+		    } 
+
+
+
+		    vcbuilder.addVariable(builder.build());
+		}
+	}
         
         return vcbuilder.build();
     }


### PR DESCRIPTION
In a situation when we complete a task by the kie-client-rest Api, and there is a bidirectional relations between two entities. We have to use @XmlID, @XmlAttribute and @XmlIDREF , but we don't need really to persist both variables. So as a work-around we can send one of them with NULL key in the task's output map and then my update will ignore it and persist only the desired variable. Otherwise we will get an exception of org.hibernate.MappingException: Unknown entity during the unmarshalling.