### PR TITLE
JBPM-6309: Investigate and fix jBPM community DB tests with Narayana

### DIFF
--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/AuditLogServiceTest.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/AuditLogServiceTest.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 
 import org.jbpm.process.audit.AuditLoggerFactory.Type;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.api.KieBase;
@@ -59,7 +60,12 @@ public class AuditLogServiceTest extends AbstractAuditLogServiceTest {
         KieBase kbase = createKnowledgeBase();
         // create a new session
         Environment env = createEnvironment(context);
-        session = createKieSession(kbase, env);
+        try {
+            session = createKieSession(kbase, env);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assert.fail("Exception thrown while trying to create a session.");
+        }
        
         // working memory logger
         AbstractAuditLogger dblogger = AuditLoggerFactory.newInstance(Type.JPA, session, null);
@@ -71,7 +77,9 @@ public class AuditLogServiceTest extends AbstractAuditLogServiceTest {
 
     @After
     public void tearDown() throws Exception {        
-        session.dispose();
+        if (session != null) {
+            session.dispose();
+        }
         session = null;
         auditLogService = null;
         cleanUp(context);

--- a/jbpm-audit/src/test/resources/logback-test.xml
+++ b/jbpm-audit/src/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
     </encoder>
   </appender>
 
-  <logger name="com.arjuna" level="error"/>
+  <logger name="com.arjuna" level="warn"/>
   <logger name="org.hibernate" level="warn"/>
   <logger name="org.hibernate.tool.hbm2ddl" level="error"/>
   <logger name="org.hibernate.ejb.internal" level="error"/>

--- a/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/correlation/CorrelationPersistenceTest.java
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/correlation/CorrelationPersistenceTest.java
@@ -36,6 +36,7 @@ import javax.transaction.UserTransaction;
 
 import org.jbpm.test.util.AbstractBaseTest;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,9 +69,8 @@ public class CorrelationPersistenceTest extends AbstractBaseTest {
         EntityManagerFactory emf = (EntityManagerFactory) context.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
         UserTransaction ut = InitialContext.doLookup("java:comp/UserTransaction");
         ut.begin();
-        EntityManager em = emf.createEntityManager();
-
         try {
+            EntityManager em = emf.createEntityManager();
             em.persist(factory.newCorrelationKey("test123"));
 
             List<String> props = new ArrayList<String>();
@@ -78,30 +78,26 @@ public class CorrelationPersistenceTest extends AbstractBaseTest {
             props.add("123test");
 
             em.persist(factory.newCorrelationKey(props));
+            ut.commit();
         } catch (Exception ex) {
-            ex.printStackTrace();
             ut.rollback();
+            Assert.fail("Exception thrown while trying to prepare correlation data.");
         }
-        ut.commit();
     }
     
     @After
-    public void after() {  
+    public void after() throws Exception {
+        EntityManagerFactory emf = (EntityManagerFactory) context.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
+        UserTransaction ut = InitialContext.doLookup("java:comp/UserTransaction");
+        ut.begin();
         try {
-            EntityManagerFactory emf = (EntityManagerFactory) context.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
-            UserTransaction ut = InitialContext.doLookup("java:comp/UserTransaction");
-            ut.begin();
             EntityManager em = emf.createEntityManager();
-            try {
-                em.createQuery("delete from CorrelationPropertyInfo").executeUpdate();
-                em.createQuery("delete from CorrelationKeyInfo").executeUpdate();
-            } catch (Exception ex) {
-                ex.printStackTrace();
-                ut.rollback();
-            }
+            em.createQuery("delete from CorrelationPropertyInfo").executeUpdate();
+            em.createQuery("delete from CorrelationKeyInfo").executeUpdate();
             ut.commit();
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (Exception ex) {
+            ut.rollback();
+            Assert.fail("Exception thrown while trying to cleanup correlation data.");
         }
         cleanUp(context);
     }

--- a/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/correlation/CorrelationPersistenceTest.java
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/correlation/CorrelationPersistenceTest.java
@@ -70,13 +70,18 @@ public class CorrelationPersistenceTest extends AbstractBaseTest {
         ut.begin();
         EntityManager em = emf.createEntityManager();
 
-        em.persist(factory.newCorrelationKey("test123"));
+        try {
+            em.persist(factory.newCorrelationKey("test123"));
 
-        List<String> props = new ArrayList<String>();
-        props.add("test123");
-        props.add("123test");
-        em.persist(factory.newCorrelationKey(props));
-        
+            List<String> props = new ArrayList<String>();
+            props.add("test123");
+            props.add("123test");
+
+            em.persist(factory.newCorrelationKey(props));
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            ut.rollback();
+        }
         ut.commit();
     }
     
@@ -87,8 +92,13 @@ public class CorrelationPersistenceTest extends AbstractBaseTest {
             UserTransaction ut = InitialContext.doLookup("java:comp/UserTransaction");
             ut.begin();
             EntityManager em = emf.createEntityManager();
-            em.createQuery("delete from CorrelationPropertyInfo").executeUpdate();
-            em.createQuery("delete from CorrelationKeyInfo").executeUpdate();
+            try {
+                em.createQuery("delete from CorrelationPropertyInfo").executeUpdate();
+                em.createQuery("delete from CorrelationKeyInfo").executeUpdate();
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                ut.rollback();
+            }
             ut.commit();
         } catch (Exception e) {
             e.printStackTrace();

--- a/jbpm-persistence/jbpm-persistence-jpa/src/test/resources/logback-test.xml
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
   </appender>
 
   <logger name="org.jbpm" level="info"/>
-  <logger name="com.arjuna" level="error"/>
+  <logger name="com.arjuna" level="warn"/>
   <logger name="org.hibernate" level="warn"/>
   
   <logger name="org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl" level="error" />

--- a/jbpm-test-util/src/main/java/org/jbpm/test/util/PoolingDataSource.java
+++ b/jbpm-test-util/src/main/java/org/jbpm/test/util/PoolingDataSource.java
@@ -63,7 +63,15 @@ public class PoolingDataSource implements DataSource {
         try {
             xads = (XADataSource)Class.forName(className).newInstance();
             String url = driverProperties.getProperty("url", driverProperties.getProperty("URL"));
-            xads.getClass().getMethod("setURL", new Class[] {String.class}).invoke(xads, new Object[] {url});
+            logger.info(url);
+            try {
+                xads.getClass().getMethod("setUrl", new Class[]{String.class}).invoke(xads, new Object[]{url});
+            } catch (NoSuchMethodException ex) {
+                logger.info("Unable to find \"setUrl\" method in db driver JAR. Trying \"setURL\" ");
+                xads.getClass().getMethod("setURL", new Class[]{String.class}).invoke(xads, new Object[]{url});
+            } catch (InvocationTargetException ex) {
+                logger.info("Caught InvocationTargetException when calling setURL on driver:  " + ex);
+            }
             
             try {
                 InitialContext initContext = new InitialContext();

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <maven.jdbc.driver.jar/>
         <maven.jdbc.username>root</maven.jdbc.username>
         <maven.jdbc.password>admin1234</maven.jdbc.password>
-        <maven.jdbc.url>jdbc:mariadb://localhost:3306/mysql</maven.jdbc.url>
+        <maven.jdbc.url>jdbc:mariadb://localhost:3306/mysql?pinGlobalTxToPhysicalConnection=true</maven.jdbc.url>
         <maven.jdbc.schema>mysql</maven.jdbc.schema>
       </properties>
     </profile>


### PR DESCRIPTION
Surrounds "setURL" method invocation on db driver with try-catch and tries to use "setUrl" method in case no "setURL" method is present when initializing datasource. (Some drivers have setUrl some setURL)
Catch InvocationTargetException and log it.

Adds try-catch blocks around DB operation calls. Some operations throw exceptions when DB configuration is bad and these exception are hiding the configuration problem.
Sets _logLevel_ to _warn_ for narayana for some modules, since some relevant information wasn't being logged on _error_ level. 
