### PR TITLE
[7.3.x] JBPM-6309: Fix jBPM community DB tests with Narayana

### DIFF
--- a/jbpm-test-util/src/main/java/org/jbpm/test/util/PoolingDataSource.java
+++ b/jbpm-test-util/src/main/java/org/jbpm/test/util/PoolingDataSource.java
@@ -65,13 +65,16 @@ public class PoolingDataSource implements DataSource {
             logger.info(url);
             if (!(className.startsWith("com.ibm.db2") || className.startsWith("com.sybase"))) {
                 try {
-                    xads.getClass().getMethod("setUrl", new Class[]{String.class}).invoke(xads, new Object[]{url});
+                    xads.getClass().getMethod("setUrl", new Class[]{String.class}).invoke(xads, url);
                 } catch (NoSuchMethodException ex) {
                     logger.info("Unable to find \"setUrl\" method in db driver JAR. Trying \"setURL\" ");
-                    xads.getClass().getMethod("setURL", new Class[]{String.class}).invoke(xads, new Object[]{url});
+                    xads.getClass().getMethod("setURL", new Class[]{String.class}).invoke(xads, url);
                 } catch (InvocationTargetException ex) {
-                    logger.info("Caught InvocationTargetException when calling setURL on driver:  " + ex);
+                    logger.info("Driver does not support setURL and setUrl method.");
+                    throw new RuntimeException(ex);
                 }
+            } else {
+                setupAdditionalDriverProperties(className);
             }
             
             try {
@@ -168,5 +171,25 @@ public class PoolingDataSource implements DataSource {
     @Override
     public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
         return null;
+    }
+
+    private void setupAdditionalDriverProperties(String className) {
+        try {
+            xads.getClass().getMethod("setServerName", new Class[]{String.class}).invoke(xads, driverProperties.getProperty("serverName"));
+            xads.getClass().getMethod("setDatabaseName", new Class[]{String.class}).invoke(xads, driverProperties.getProperty("databaseName"));
+            if (className.startsWith("com.ibm.db2")) {
+                xads.getClass().getMethod("setDriverType", new Class[]{int.class}).invoke(xads, 4);
+                xads.getClass().getMethod("setPortNumber", new Class[]{int.class}).invoke(xads, 50000);
+                xads.getClass().getMethod("setResultSetHoldability", new Class[]{int.class}).invoke(xads, 1);
+                xads.getClass().getMethod("setDowngradeHoldCursorsUnderXa", new Class[]{boolean.class}).invoke(xads, true);
+            } else if (className.startsWith("com.sybase")) {
+                xads.getClass().getMethod("setPortNumber", new Class[]{int.class}).invoke(xads, 5000);
+                xads.getClass().getMethod("setPassword", new Class[]{String.class}).invoke(xads, driverProperties.getProperty("password"));
+                xads.getClass().getMethod("setUser", new Class[]{String.class}).invoke(xads, driverProperties.getProperty("user"));
+            }
+        } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException ex) {
+            logger.error("Exception thrown while setting properties for {} driver", className);
+            throw new RuntimeException(ex);
+        }
     }
 }

--- a/jbpm-test-util/src/main/java/org/jbpm/test/util/PoolingDataSource.java
+++ b/jbpm-test-util/src/main/java/org/jbpm/test/util/PoolingDataSource.java
@@ -179,11 +179,11 @@ public class PoolingDataSource implements DataSource {
             xads.getClass().getMethod("setDatabaseName", new Class[]{String.class}).invoke(xads, driverProperties.getProperty("databaseName"));
             if (className.startsWith("com.ibm.db2")) {
                 xads.getClass().getMethod("setDriverType", new Class[]{int.class}).invoke(xads, 4);
-                xads.getClass().getMethod("setPortNumber", new Class[]{int.class}).invoke(xads, 50000);
+                xads.getClass().getMethod("setPortNumber", new Class[]{int.class}).invoke(xads, driverProperties.getProperty("portNumber"));
                 xads.getClass().getMethod("setResultSetHoldability", new Class[]{int.class}).invoke(xads, 1);
                 xads.getClass().getMethod("setDowngradeHoldCursorsUnderXa", new Class[]{boolean.class}).invoke(xads, true);
             } else if (className.startsWith("com.sybase")) {
-                xads.getClass().getMethod("setPortNumber", new Class[]{int.class}).invoke(xads, 5000);
+                xads.getClass().getMethod("setPortNumber", new Class[]{int.class}).invoke(xads,  driverProperties.getProperty("portNumber"));
                 xads.getClass().getMethod("setPassword", new Class[]{String.class}).invoke(xads, driverProperties.getProperty("password"));
                 xads.getClass().getMethod("setUser", new Class[]{String.class}).invoke(xads, driverProperties.getProperty("user"));
             }


### PR DESCRIPTION
cherry-pick of #970 for 7.3.x

This adds additional method that handles setting up properties
for Sybase and DB2. For DB2 there are 2 specific properties
and Sybase requires username and password setup before
actuall getConnection() call.
Removes redundant array creations and enhances logging.