### PR TITLE
Remove dead code in BusinessCalendarImpl

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/core/timer/BusinessCalendarImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/timer/BusinessCalendarImpl.java
@@ -199,10 +199,7 @@ public class BusinessCalendarImpl implements BusinessCalendar {
     
     public long calculateBusinessTimeAsDuration(String timeExpression) {
     	timeExpression = adoptISOFormat(timeExpression);
-        if (businessCalendarConfiguration == null) {
-            return TimeUtils.parseTimeString(timeExpression);
-        }
-        
+
         Date calculatedDate = calculateBusinessTimeAsDate(timeExpression);
         
         return (calculatedDate.getTime() - getCurrentTime());
@@ -210,11 +207,7 @@ public class BusinessCalendarImpl implements BusinessCalendar {
     
     public Date calculateBusinessTimeAsDate(String timeExpression) {
     	timeExpression = adoptISOFormat(timeExpression);
-    	if (businessCalendarConfiguration == null) {
-            return new Date(TimeUtils.parseTimeString(getCurrentTime() + timeExpression));
-        }
-        
-        
+
         String trimmed = timeExpression.trim();
         int weeks = 0;
         int days = 0;

--- a/jbpm-flow/src/test/java/org/jbpm/process/core/timer/BusinessCalendarImplTest.java
+++ b/jbpm-flow/src/test/java/org/jbpm/process/core/timer/BusinessCalendarImplTest.java
@@ -324,7 +324,18 @@ public class BusinessCalendarImplTest extends AbstractBaseTest {
 
         assertEquals(expectedDate, formatDate("yyyy-MM-dd HH:mm:ss.SSS", result));
     }
-    
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingConfigurationDualArgConstructor() {
+        SessionPseudoClock clock = new StaticPseudoClock(parseToDateWithTime("2012-05-04 13:45").getTime());
+        BusinessCalendarImpl businessCal = new BusinessCalendarImpl(null, clock);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingConfigurationSingleArgConstructor() {
+        BusinessCalendarImpl businessCal = new BusinessCalendarImpl(null);
+    }
+
     private Date parseToDate(String dateString) {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         


### PR DESCRIPTION
Since the #init method doesn't allow a null `businessCalendarConfiguration`, any checks against `null` will never pass. 