### PR TITLE
[6.5.x] RHBPMS-4940 - Memory Leak in DefaultSignalManager

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/event/DefaultSignalManager.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/event/DefaultSignalManager.java
@@ -34,11 +34,12 @@ import java.io.ObjectOutput;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class DefaultSignalManager implements SignalManager {
 	
-	private Map<String, List<EventListener>> processEventListeners;
+	private Map<String, List<EventListener>> processEventListeners = new ConcurrentHashMap<String, List<EventListener>>();
 	private InternalKnowledgeRuntime kruntime;
 	
 	public DefaultSignalManager(InternalKnowledgeRuntime kruntime) {
@@ -50,14 +51,17 @@ public class DefaultSignalManager implements SignalManager {
 	}
 
 	public void addEventListener(String type, EventListener eventListener) {
-		if (processEventListeners == null) {
-			processEventListeners = new HashMap<String, List<EventListener>>();
-		}
 		List<EventListener> eventListeners = processEventListeners.get(type);
+		//this first "if" is not pretty, but allows to synchronize only when needed
 		if (eventListeners == null) {
-			eventListeners = new CopyOnWriteArrayList<EventListener>();
-			processEventListeners.put(type, eventListeners);
-		}
+			synchronized(processEventListeners){
+				eventListeners = processEventListeners.get(type);
+				if(eventListeners==null){
+					eventListeners = new CopyOnWriteArrayList<EventListener>();
+					processEventListeners.put(type, eventListeners);
+				}
+			}
+		}		
 		eventListeners.add(eventListener);
 	}
 	
@@ -66,6 +70,10 @@ public class DefaultSignalManager implements SignalManager {
 			List<EventListener> eventListeners = processEventListeners.get(type);
 			if (eventListeners != null) {
 				eventListeners.remove(eventListener);
+				if (eventListeners.isEmpty()) {
+					processEventListeners.remove(type);
+					eventListeners = null;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
JBPM-5400 - Concurrency problem in the class org.jbpm.process.instance.event.DefaultSignalManager
JBPM-5413 - Memory Leak in DefaultSignalManager

* changed DefaultSignalManager for concurrency
* Fix memory leak in processEventListeners