### PR TITLE
Avoid generation of NPE while launching a Process without Parent

### DIFF
--- a/jbpm-audit/src/main/java/org/jbpm/process/audit/event/DefaultAuditEventBuilderImpl.java
+++ b/jbpm-audit/src/main/java/org/jbpm/process/audit/event/DefaultAuditEventBuilderImpl.java
@@ -54,18 +54,10 @@ public class DefaultAuditEventBuilderImpl implements AuditEventBuilder {
         if (correlationKey != null) {
         	log.setCorrelationKey(correlationKey.toExternalForm());
         }
-        try {
-            Object value = pi.getMetaData().get("ParentProcessInstanceId");
-	    if( value != null ){
-	        long parentProcessInstanceId = (Long) value;
-                log.setParentProcessInstanceId( parentProcessInstanceId );
-	     }else{
-		log.setParentProcessInstanceId(-1L);
-	     }
-        } catch (Exception e) {
-            //in case of problems with getting hold of parentProcessInstanceId don't break the operation
-            log.setParentProcessInstanceId(-1L);
-        }
+        
+        long parentProcessInstanceId = (Long) pi.getMetaData().getOrDefault("ParentProcessInstanceId", -1L);
+	log.setParentProcessInstanceId( parentProcessInstanceId );	     
+        
 
         return log;
     }

--- a/jbpm-audit/src/main/java/org/jbpm/process/audit/event/DefaultAuditEventBuilderImpl.java
+++ b/jbpm-audit/src/main/java/org/jbpm/process/audit/event/DefaultAuditEventBuilderImpl.java
@@ -55,8 +55,13 @@ public class DefaultAuditEventBuilderImpl implements AuditEventBuilder {
         	log.setCorrelationKey(correlationKey.toExternalForm());
         }
         try {
-            long parentProcessInstanceId = (Long) pi.getMetaData().get("ParentProcessInstanceId");
-            log.setParentProcessInstanceId(parentProcessInstanceId);
+            Object value = pi.getMetaData().get("ParentProcessInstanceId");
+	    if( value != null ){
+	        long parentProcessInstanceId = (Long) value;
+                log.setParentProcessInstanceId( parentProcessInstanceId );
+	     }else{
+		log.setParentProcessInstanceId(-1L);
+	     }
         } catch (Exception e) {
             //in case of problems with getting hold of parentProcessInstanceId don't break the operation
             log.setParentProcessInstanceId(-1L);


### PR DESCRIPTION
The proposed code avoids the generation of NPE every time you launch a process with no parent.

The inboxing performed by the JVM to create a Long with a NULL value and the later outboxing to assign a long from a NULL Long value generates a NPE every time you launch a process without parent.

This is a performance fix, please apply it.

Regards