### PR TITLE
[DON'T MERGE] google calendar integration workitem

### DIFF
--- a/jbpm-workitems/jbpm-workitems-google-calendar/.gitignore
+++ b/jbpm-workitems/jbpm-workitems-google-calendar/.gitignore
@@ -1,0 +1,12 @@
+/target
+/local
+/bin
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml
+

--- a/jbpm-workitems/jbpm-workitems-google-calendar/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-google-calendar/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jbpm</groupId>
+    <artifactId>jbpm-workitems</artifactId>
+    <version>8.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jbpm-workitems-google-calendar</artifactId>
+  <name>jBPM :: WorkItems :: Google :: Calendar</name>
+
+  <properties>
+    <version.google.api.servies.calendar>v3-rev87-1.19.0</version.google.api.servies.calendar>
+    <version.google.http.client>1.19.0</version.google.http.client>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-calendar</artifactId>
+      <version>${version.google.api.servies.calendar}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+      <version>${version.google.http.client}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client-jetty</artifactId>
+      <version>${version.google.http.client}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-workitems-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-workitems-core</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <rules>
+            <AlwaysPass />
+          </rules>
+          <fail>false</fail>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/jbpm-workitems/jbpm-workitems-google-calendar/src/main/java/org/jbpm/process/workitem/google/calendar/CalendarActions.java
+++ b/jbpm-workitems/jbpm-workitems-google-calendar/src/main/java/org/jbpm/process/workitem/google/calendar/CalendarActions.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.google.calendar;
+
+public enum CalendarActions {
+    RETURN_CALENDARS,
+    ADD_CALENDAR,
+    RETURN_EVENTS,
+    ADD_EVENT;
+
+    public static CalendarActions fromInput(String input) {
+        if (input == null) {
+            return null;
+        }
+        if (input.equalsIgnoreCase("returnCalendars")) {
+            return RETURN_CALENDARS;
+        } else if (input.equalsIgnoreCase("addCalendar")) {
+            return ADD_CALENDAR;
+        } else if (input.equalsIgnoreCase("addEvent")) {
+            return ADD_EVENT;
+        } else if (input.equalsIgnoreCase("returnEvents")) {
+            return RETURN_EVENTS;
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/jbpm-workitems/jbpm-workitems-google-calendar/src/main/java/org/jbpm/process/workitem/google/calendar/GoogleCalendarAuth.java
+++ b/jbpm-workitems/jbpm-workitems-google-calendar/src/main/java/org/jbpm/process/workitem/google/calendar/GoogleCalendarAuth.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.google.calendar;
+
+import java.io.StringReader;
+import java.util.Collections;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
+import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.calendar.CalendarScopes;
+
+public class GoogleCalendarAuth {
+
+    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static HttpTransport httpTransport;
+
+    public com.google.api.services.calendar.Calendar getAuthorizedCalendar(String appName,
+                                                                           String clientSecretJSON) {
+        try {
+            httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+            Credential credential = authorize(clientSecretJSON);
+            return new com.google.api.services.calendar.Calendar.Builder(
+                    httpTransport,
+                    JSON_FACTORY,
+                    credential).setApplicationName(appName).build();
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public Credential authorize(String clientSecretJSON) throws Exception {
+        GoogleClientSecrets clientSecrets = GoogleClientSecrets.load(JSON_FACTORY,
+                                                                     new StringReader(clientSecretJSON));
+
+        GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow.Builder(
+                httpTransport,
+                JSON_FACTORY,
+                clientSecrets,
+                Collections.singleton(CalendarScopes.CALENDAR))
+                .build();
+
+        return new AuthorizationCodeInstalledApp(flow,
+                                                 new LocalServerReceiver()).authorize("user");
+    }
+}

--- a/jbpm-workitems/jbpm-workitems-google-calendar/src/main/java/org/jbpm/process/workitem/google/calendar/GoogleCalendarWorkitemHandler.java
+++ b/jbpm-workitems/jbpm-workitems-google-calendar/src/main/java/org/jbpm/process/workitem/google/calendar/GoogleCalendarWorkitemHandler.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.google.calendar;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.MessageFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.model.Calendar;
+import com.google.api.services.calendar.model.CalendarList;
+import com.google.api.services.calendar.model.CalendarListEntry;
+import com.google.api.services.calendar.model.Event;
+import com.google.api.services.calendar.model.Event.Creator;
+import com.google.api.services.calendar.model.EventAttendee;
+import com.google.api.services.calendar.model.EventDateTime;
+import com.google.api.services.calendar.model.Events;
+import org.jbpm.process.workitem.core.AbstractLogOrThrowWorkItemHandler;
+import org.jbpm.process.workitem.core.util.Wid;
+import org.jbpm.process.workitem.core.util.WidMavenDepends;
+import org.jbpm.process.workitem.core.util.WidParameter;
+import org.jbpm.process.workitem.core.util.WidResult;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Wid(widfile = "GoogleCalendarDefinitions.wid", name = "GoogleCalendar",
+        displayName = "GoogleCalendar",
+        defaultHandler = "mvel: new org.jbpm.process.workitem.google.calendar.GoogleCalendarWorkitemHandler()",
+        parameters = {
+                @WidParameter(name = "AppName"),
+                @WidParameter(name = "ClientSecret"),
+                @WidParameter(name = "Action"),
+                @WidParameter(name = "CalendarSummary"),
+                @WidParameter(name = "EventSummary"),
+                @WidParameter(name = "EventStart"),
+                @WidParameter(name = "EventEnd"),
+                @WidParameter(name = "EventAttendees"),
+                @WidParameter(name = "EventCreator")
+        },
+        results = {
+                @WidResult(name = "Calendar"),
+                @WidResult(name = "AllCalendars"),
+                @WidResult(name = "AllEvents")
+        },
+        mavenDepends = {
+                @WidMavenDepends(group = "com.google.apis", artifact = "google-api-services-calendar", version = "v3-rev87-1.19.0"),
+                @WidMavenDepends(group = "com.google.oauth-client", artifact = "google-oauth-client-jetty", version = "1.19.0"),
+                @WidMavenDepends(group = "com.google.http-client", artifact = "google-http-client-jackson2", version = "1.19.0")
+        })
+public class GoogleCalendarWorkitemHandler extends AbstractLogOrThrowWorkItemHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(GoogleCalendarWorkitemHandler.class);
+    private static final String RESULTS_CALENDAR = "Calendar";
+    private static final String RESULTS_ALL_CALENDARS = "AllCalendars";
+    private static final String RESULTS_ALL_EVENTS = "AllEvents";
+
+    private GoogleCalendarAuth auth = new GoogleCalendarAuth();
+
+    public void executeWorkItem(WorkItem workItem,
+                                WorkItemManager workItemManager) {
+
+        String paramAppName = (String) workItem.getParameter("AppName");
+        String paramClientSecretJSON = (String) workItem.getParameter("ClientSecret");
+        String paramAction = (String) workItem.getParameter("Action");
+        String paramCalendarSummary = (String) workItem.getParameter("CalendarSummary");
+        String paramEventSummary = (String) workItem.getParameter("EventSummary");
+        String paramEventStart = (String) workItem.getParameter("EventStart");
+        String paramEventEnd = (String) workItem.getParameter("EventEnd");
+        String paramEventAttendees = (String) workItem.getParameter("EventAttendees");
+        String paramEventCreator = (String) workItem.getParameter("EventCreator");
+
+        Map<String, Object> results = new HashMap<String, Object>();
+
+        CalendarActions calendarAction = CalendarActions.fromInput(paramAction);
+        if (calendarAction == null) {
+            logger.info(MessageFormat.format("Invalid calendar action {0}.",
+                                             paramAction));
+        } else {
+            try {
+                com.google.api.services.calendar.Calendar client = auth.getAuthorizedCalendar(paramAppName,
+                                                                                              paramClientSecretJSON);
+
+                if (calendarAction.equals(CalendarActions.ADD_CALENDAR)) {
+                    results.put(RESULTS_CALENDAR,
+                                addCalendar(client,
+                                            paramCalendarSummary));
+                } else if (calendarAction.equals(CalendarActions.RETURN_CALENDARS)) {
+                    results.put(RESULTS_ALL_CALENDARS,
+                                getAllCalendars(client));
+                } else if (calendarAction.equals(CalendarActions.RETURN_EVENTS)) {
+                    results.put(RESULTS_ALL_EVENTS,
+                                getAllEvents(client,
+                                             getCalendarIdBySummary(client,
+                                                                    paramCalendarSummary)));
+                } else if (calendarAction.equals(CalendarActions.ADD_EVENT)) {
+                    results.put(RESULTS_ALL_EVENTS,
+                                addEvent(client,
+                                         getCalendarIdBySummary(client,
+                                                                paramCalendarSummary),
+                                         paramEventSummary,
+                                         paramEventStart,
+                                         paramEventEnd,
+                                         paramEventAttendees,
+                                         paramEventCreator
+                                ));
+                }
+            } catch (Exception e) {
+                handleException(e);
+            }
+        }
+
+        workItemManager.completeWorkItem(workItem.getId(),
+                                         results);
+    }
+
+    public String getCalendarIdBySummary(com.google.api.services.calendar.Calendar client,
+                                         String summary) {
+        String resultId = null;
+        try {
+            CalendarList calendarList = getAllCalendars(client);
+            List<CalendarListEntry> entryList = calendarList.getItems();
+            for (CalendarListEntry entry : entryList) {
+                if (entry.getSummary().equalsIgnoreCase(summary)) {
+                    resultId = entry.getId();
+                }
+            }
+        } catch (Exception e) {
+            logger.error(MessageFormat.format("Error retrieveing calendars: {0}",
+                                              e.getMessage()));
+        }
+        return resultId;
+    }
+
+    public Calendar addCalendar(com.google.api.services.calendar.Calendar client,
+                                String calendarSummary) throws IOException {
+        Calendar entry = new Calendar();
+        entry.setSummary(calendarSummary);
+        return client.calendars().insert(entry).execute();
+    }
+
+    public CalendarList getAllCalendars(com.google.api.services.calendar.Calendar client) {
+        try {
+            return client.calendarList().list().execute();
+        } catch (Exception e) {
+            logger.error(MessageFormat.format("Error trying to get calendars: {0}.",
+                                              e.getMessage()));
+            return null;
+        }
+    }
+
+    public Events getAllEvents(com.google.api.services.calendar.Calendar client,
+                               String calendarId) throws IOException {
+        return client.events().list(calendarId).execute();
+    }
+
+    public Event addEvent(com.google.api.services.calendar.Calendar client,
+                          String calendarId,
+                          String paramEventSummary,
+                          String paramEventStart,
+                          String paramEventEnd,
+                          String paramEventAttendees,
+                          String paramEventCreator) throws Exception {
+        Event event = createNewEvent(paramEventSummary,
+                                     paramEventStart,
+                                     paramEventEnd,
+                                     paramEventAttendees,
+                                     paramEventCreator);
+        return client.events().insert(calendarId,
+                                      event).execute();
+    }
+
+    private static Event createNewEvent(String paramEventSummary,
+                                        String paramEventStart,
+                                        String paramEventEnd,
+                                        String paramEventAttendees,
+                                        String paramEventCreator) throws Exception {
+        Event event = new Event();
+        event.setSummary(paramEventSummary);
+
+        DateFormat format = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z",
+                                                 Locale.ENGLISH);
+
+        if (paramEventStart != null) {
+            DateTime startDateTime = new DateTime(format.parse(paramEventStart));
+            event.setStart(new EventDateTime().setDateTime(startDateTime));
+        }
+
+        if (paramEventEnd != null) {
+            DateTime endDateTime = new DateTime(format.parse(paramEventEnd));
+            event.setEnd(new EventDateTime().setDateTime(endDateTime));
+        }
+
+        if (paramEventAttendees != null) {
+            List<String> attendees = Arrays.asList(paramEventAttendees.split(","));
+            List<EventAttendee> attendiesList = new ArrayList<>();
+            for (String attendee : attendees) {
+                EventAttendee newAttendee = new EventAttendee();
+                newAttendee.setEmail(attendee);
+                attendiesList.add(newAttendee);
+            }
+            event.setAttendees(attendiesList);
+        }
+
+        if (paramEventCreator != null) {
+            Creator creator = new Creator();
+            creator.setEmail(paramEventCreator);
+            event.setCreator(creator);
+        }
+
+        return event;
+    }
+
+    public void abortWorkItem(WorkItem wi,
+                              WorkItemManager wim) {
+    }
+
+    // for testing
+    public void setAuth(GoogleCalendarAuth auth) {
+        this.auth = auth;
+    }
+}

--- a/jbpm-workitems/jbpm-workitems-google-calendar/src/test/java/org/jbpm/process/workitem/google/calendar/GoogleCalendarWorkitemHandlerTest.java
+++ b/jbpm-workitems/jbpm-workitems-google-calendar/src/test/java/org/jbpm/process/workitem/google/calendar/GoogleCalendarWorkitemHandlerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.google.calendar;
+
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.Calendar.Calendars;
+import com.google.api.services.calendar.model.CalendarList;
+import org.drools.core.process.instance.impl.WorkItemImpl;
+import org.jbpm.process.workitem.core.TestWorkItemManager;
+import org.jbpm.test.AbstractBaseTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GoogleCalendarWorkitemHandlerTest extends AbstractBaseTest {
+
+    @Mock
+    GoogleCalendarAuth auth;
+
+    @Mock
+    Calendar client;
+
+    @Mock
+    Calendars calendars;
+
+    @Mock
+    Calendar.CalendarList calendarsList;
+
+    @Mock
+    Calendar.CalendarList.List calendarsListList;
+
+    @Before
+    public void setUp() {
+        try {
+            CalendarList calendarListModel = new com.google.api.services.calendar.model.CalendarList();
+            when(client.calendars()).thenReturn(calendars);
+            when(client.calendarList()).thenReturn(calendarsList);
+            when(calendarsList.list()).thenReturn(calendarsListList);
+            when(calendarsListList.execute()).thenReturn(calendarListModel);
+            when(auth.getAuthorizedCalendar(anyString(),
+                                            anyString())).thenReturn(client);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testHandler() throws Exception {
+
+        TestWorkItemManager manager = new TestWorkItemManager();
+        WorkItemImpl workItem = new WorkItemImpl();
+        workItem.setParameter("Action",
+                              "returnCalendars");
+
+        GoogleCalendarWorkitemHandler handler = new GoogleCalendarWorkitemHandler();
+        handler.setAuth(auth);
+        handler.executeWorkItem(workItem,
+                                manager);
+
+        handler.executeWorkItem(workItem,
+                                manager);
+        assertNotNull(manager.getResults());
+        assertEquals(1,
+                     manager.getResults().size());
+        assertTrue(manager.getResults().containsKey(workItem.getId()));
+
+        assertTrue((manager.getResults().get(workItem.getId())).get("AllCalendars") instanceof CalendarList);
+    }
+}

--- a/jbpm-workitems/pom.xml
+++ b/jbpm-workitems/pom.xml
@@ -29,6 +29,7 @@
     <module>jbpm-workitems-rss</module>
     <module>jbpm-workitems-transform</module>
     <module>jbpm-workitems-webservice</module>
+    <module>jbpm-workitems-google-calendar</module>
     <module>jbpm-workitems-archetype</module>
   </modules>
 


### PR DESCRIPTION
@mswiderski this will go into the jbpm-work-tems repo when its created. Just wanted to do pr here maybe if you have time take a look and let me know if you see any issues. 
I have turned off maven-enforcer-plugin for the gcal because this will not be merged, but it brings up a question if we want to use as strict enforcement rules as we do in other repos? Especially what I think will come up is transitive dependencies checks and version declaration checks. Google documentation on their api does not take in account transitive depends and just give you a single depends that users that create new workitems will surely use. In these cases users will have to do extra work to contribute back which might be a turnoff. WDYT?