### PR TITLE
JBPM-6487 Jbpm tests stabilisation

### DIFF
--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/CommandBasedAuditLogServiceTest.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/CommandBasedAuditLogServiceTest.java
@@ -68,6 +68,7 @@ public class CommandBasedAuditLogServiceTest extends AbstractAuditLogServiceTest
     @After
     public void tearDown() throws Exception {
         session.dispose();
+        auditLogService.clear();
         session = null;
         auditLogService = null;
         cleanUp(context);

--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/CommandBasedAuditLogServiceTest.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/CommandBasedAuditLogServiceTest.java
@@ -68,7 +68,6 @@ public class CommandBasedAuditLogServiceTest extends AbstractAuditLogServiceTest
     @After
     public void tearDown() throws Exception {
         session.dispose();
-        auditLogService.clear();
         session = null;
         auditLogService = null;
         cleanUp(context);

--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/jms/AsyncAuditLogProducerTest.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/jms/AsyncAuditLogProducerTest.java
@@ -44,6 +44,7 @@ import javax.naming.InitialContext;
 import javax.persistence.EntityManagerFactory;
 import javax.transaction.UserTransaction;
 
+import org.assertj.core.api.Assertions;
 import org.hornetq.jms.server.embedded.EmbeddedJMS;
 import org.jboss.narayana.jta.jms.ConnectionFactoryProxy;
 import org.jboss.narayana.jta.jms.TransactionHelperImpl;
@@ -409,30 +410,20 @@ public class AsyncAuditLogProducerTest extends AbstractBaseTest {
         }
         
         assertEquals(3, listVariables.size());
-        VariableInstanceLog var = listVariables.get(0);
-        
-        assertEquals("john", var.getValue());
-        assertEquals("", var.getOldValue());
-        assertEquals(processInstance.getId(), var.getProcessInstanceId().longValue());
-        assertEquals(processInstance.getProcessId(), var.getProcessId());
-        assertEquals("list[0]", var.getVariableId());
-        assertEquals("list", var.getVariableInstanceId());
-        
-        var = listVariables.get(1);
-        assertEquals("mary", var.getValue());
-        assertEquals("", var.getOldValue());
-        assertEquals(processInstance.getId(), var.getProcessInstanceId().longValue());
-        assertEquals(processInstance.getProcessId(), var.getProcessId());
-        assertEquals("list[1]", var.getVariableId());
-        assertEquals("list", var.getVariableInstanceId());
-        
-        var = listVariables.get(2);        
-        assertEquals("peter", var.getValue());
-        assertEquals("", var.getOldValue());
-        assertEquals(processInstance.getId(), var.getProcessInstanceId().longValue());
-        assertEquals(processInstance.getProcessId(), var.getProcessId());
-        assertEquals("list[2]", var.getVariableId());
-        assertEquals("list", var.getVariableInstanceId());
+
+        List<String> variableValues = new ArrayList<String>();
+        List<String> variableIds = new ArrayList<String>();
+        for (VariableInstanceLog var : listVariables) {
+            variableValues.add(var.getValue());
+            variableIds.add(var.getVariableId());
+            assertEquals("", var.getOldValue());
+            assertEquals(processInstance.getId(), var.getProcessInstanceId().longValue());
+            assertEquals(processInstance.getProcessId(), var.getProcessId());
+            assertEquals("list", var.getVariableInstanceId());
+        }
+
+        Assertions.assertThat(variableValues).contains("john", "mary", "peter");
+        Assertions.assertThat(variableIds).contains("list[0]", "list[1]", "list[2]");
         
         logService.clear();
         processInstances = logService.findProcessInstances("com.sample.ruleflow3");

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/TaskCommentTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/TaskCommentTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import org.assertj.core.api.Assertions;
 import org.jbpm.services.task.impl.factories.TaskFactory;
 import org.jbpm.test.util.PoolingDataSource;
 import org.junit.After;
@@ -96,7 +97,7 @@ public class TaskCommentTest extends HumanTaskServicesBaseTest{
             Comment commentById = taskService.getCommentById(commentId.longValue());
             assertNotNull(commentById);
             assertEquals(commentId, commentById.getId());
-            assertEquals(date, commentById.getAddedAt());
+            Assertions.assertThat(date).isEqualToIgnoringMillis(commentById.getAddedAt());
             assertEquals(user, commentById.getAddedBy());
             assertEquals(txt, commentById.getText());
 


### PR DESCRIPTION
Fixes CommandBasedAuditLogServiceTest and several asserts in testAsyncAuditLoggerCompleteWithVariablesCustomIndexer related to variable values and IDs loaded from audit log.