### PR TITLE
JBPM-6463 - Clustered EJB timers start duplicated process instances w…

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/timer/TimerManager.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/timer/TimerManager.java
@@ -467,6 +467,11 @@ public class TimerManager {
             this.paramaeters = paramaeters;
         }
 
+        @Override
+        public boolean isNewTimer() {
+            return false;
+        }
+
     }
 
     /**


### PR DESCRIPTION
…hen used inside startEvent

start event timers should always be checked thus can be marked as new timer as it will be then skipped by ejb timer service to check the already scheduled with same name.