### PR TITLE
Initial implementation of JBPM-6502. Support collection of documents.

### DIFF
--- a/jbpm-document/src/main/java/org/jbpm/document/Documents.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/Documents.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.document;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * A collection of {@link Document Documents}.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "documents-object")
+public class Documents implements Serializable {
+
+	private static final long serialVersionUID = 6962662228758156488L;
+	
+	private List<Document> documents = new ArrayList<>();
+
+	public Documents() {
+	}
+
+	public Documents(List<Document> documents) {
+		this.documents = new ArrayList<Document>(documents);
+	}
+	
+	public void addDocument(Document document) {
+		documents.add(document);
+	}
+	
+	public List<Document> getDocuments() {
+		return Collections.unmodifiableList(documents);
+	}	
+	
+}
+

--- a/jbpm-document/src/main/java/org/jbpm/document/marshalling/DocumentsMarshallingStrategy.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/marshalling/DocumentsMarshallingStrategy.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.document.marshalling;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.drools.core.common.DroolsObjectInputStream;
+import org.jbpm.document.Document;
+import org.jbpm.document.Documents;
+import org.kie.api.marshalling.ObjectMarshallingStrategy;
+
+
+/**
+ * {@link ObjectMarshallingStrategy} for a collection (List) of {@link Document Documents}.
+ */
+public class DocumentsMarshallingStrategy implements ObjectMarshallingStrategy {
+
+	/**
+	 * Marshalling strategy that marshalls the individual documents of our collection.
+	 */
+	private DocumentMarshallingStrategy docMarshallingStrategy;
+	
+	public DocumentsMarshallingStrategy(DocumentMarshallingStrategy docMarshallingStrategy) {
+		this.docMarshallingStrategy = docMarshallingStrategy;
+	}
+	
+	public boolean accept(Object o) {
+		return o instanceof Documents;
+	}
+
+	public byte[] marshal(Context ctx, ObjectOutputStream objectOutputStream, Object o) throws IOException {
+		Documents documents = (Documents) o;
+		
+		ByteArrayOutputStream buff = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(buff);
+		//Write the number of documents in the list.
+		oos.writeInt(documents.getDocuments().size());
+		for (Document nextDocument: documents.getDocuments()) {
+			//Use the DocumentMarshallingStrategy to marshall individual documents.
+			byte[] nextMarshalledDocument = docMarshallingStrategy.marshal(ctx, objectOutputStream, nextDocument);
+			oos.writeInt(nextMarshalledDocument.length);
+			oos.write(nextMarshalledDocument);
+			//Need to call reset on the stream in order for the Document bytes tom be written correctly.
+			oos.reset();
+		}
+		
+		return buff.toByteArray();
+	}
+
+	public Object unmarshal(Context ctx, ObjectInputStream objectInputStream, byte[] object, ClassLoader classLoader)
+			throws IOException, ClassNotFoundException {
+		
+		DroolsObjectInputStream is = new DroolsObjectInputStream(new ByteArrayInputStream(object), classLoader);
+		// first we read out the object class and size of the list we stored.
+		int size = is.readInt();
+		
+		Documents documents = new Documents();
+		
+		for (int i = 0; i < size; i++) {
+			//Use the DocumentMarshallingStrategy to unmarshall the individual documents.
+			int length = is.readInt();
+			byte[] marshalledDocument = new byte[length];
+			is.readFully(marshalledDocument);
+			Document nextDocument = (Document) docMarshallingStrategy.unmarshal(ctx, objectInputStream, marshalledDocument, classLoader);
+			documents.addDocument(nextDocument);
+		}
+		
+		return documents;
+	}
+	
+	public Object read(ObjectInputStream arg0) throws IOException, ClassNotFoundException {
+		// Read and write are only used in previous versions of jBPM before the platform used protobuf storage for sessions.
+		throw new UnsupportedOperationException("This marshalling strategy supports jBPM 6.5 and higher.");
+	}
+
+	public void write(ObjectOutputStream arg0, Object arg1) throws IOException {
+		// Read and write are only used in previous versions of jBPM before the platform used protobuf storage for sessions.
+		throw new UnsupportedOperationException("This marshalling strategy supports jBPM 6.5 and higher.");
+	}
+	
+	public Context createContext() {
+		return null;
+	}		
+	
+}

--- a/jbpm-document/src/main/java/org/jbpm/document/marshalling/DocumentsMarshallingStrategy.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/marshalling/DocumentsMarshallingStrategy.java
@@ -34,7 +34,7 @@ import org.kie.api.marshalling.ObjectMarshallingStrategy;
 public class DocumentsMarshallingStrategy implements ObjectMarshallingStrategy {
 
 	/**
-	 * Marshalling strategy that marshalls the individual documents of our collection.
+	 * Marshalling strategy that marshals the individual documents of our collection.
 	 */
 	private DocumentMarshallingStrategy docMarshallingStrategy;
 	
@@ -54,11 +54,11 @@ public class DocumentsMarshallingStrategy implements ObjectMarshallingStrategy {
 		//Write the number of documents in the list.
 		oos.writeInt(documents.getDocuments().size());
 		for (Document nextDocument: documents.getDocuments()) {
-			//Use the DocumentMarshallingStrategy to marshall individual documents.
+			//Use the DocumentMarshallingStrategy to marshal individual documents.
 			byte[] nextMarshalledDocument = docMarshallingStrategy.marshal(ctx, objectOutputStream, nextDocument);
 			oos.writeInt(nextMarshalledDocument.length);
 			oos.write(nextMarshalledDocument);
-			//Need to call reset on the stream in order for the Document bytes tom be written correctly.
+			//Need to call reset on the stream in order for the Document bytes to be written correctly.
 			oos.reset();
 		}
 		
@@ -69,13 +69,13 @@ public class DocumentsMarshallingStrategy implements ObjectMarshallingStrategy {
 			throws IOException, ClassNotFoundException {
 		
 		DroolsObjectInputStream is = new DroolsObjectInputStream(new ByteArrayInputStream(object), classLoader);
-		// first we read out the object class and size of the list we stored.
+		// first we read the size of the list we've stored.
 		int size = is.readInt();
 		
 		Documents documents = new Documents();
 		
 		for (int i = 0; i < size; i++) {
-			//Use the DocumentMarshallingStrategy to unmarshall the individual documents.
+			//Use the DocumentMarshallingStrategy to unmarshal the individual documents.
 			int length = is.readInt();
 			byte[] marshalledDocument = new byte[length];
 			is.readFully(marshalledDocument);

--- a/jbpm-document/src/test/java/org/jbpm/document/marshalling/DocumentsMarshallingStrategyTest.java
+++ b/jbpm-document/src/test/java/org/jbpm/document/marshalling/DocumentsMarshallingStrategyTest.java
@@ -60,7 +60,7 @@ public class DocumentsMarshallingStrategyTest {
 	@Test
 	public void testSingleDocMarshallUnmarshall() throws IOException, ClassNotFoundException {
 		DocumentMarshallingStrategy docMarshallingStrategy = new DocumentMarshallingStrategy();
-		Document document = getDocument();
+		Document document = getDocument("docOne");
 		byte[] marshalledDocument = docMarshallingStrategy.marshal(null, null, document);
 		Document unmarshalledDocument = (Document) docMarshallingStrategy.unmarshal(null, null, marshalledDocument, this.getClass().getClassLoader());
 	
@@ -70,14 +70,14 @@ public class DocumentsMarshallingStrategyTest {
 	}
 	
 	
-	private Document getDocument() {
+	private Document getDocument(String documentName) {
 		Document documentOne = new DocumentImpl();
-		documentOne.setIdentifier("docOne");
+		documentOne.setIdentifier(documentName);
 		documentOne.setLastModified(new Date());
-		documentOne.setLink("http://documentOne");
-		documentOne.setName("DocumentOne Name");
+		documentOne.setLink("http://" +  documentName);
+		documentOne.setName(documentName + " Name");
 		documentOne.setSize(1);
-		documentOne.setContent("documentOne".getBytes());	
+		documentOne.setContent(documentName.getBytes());
 		return documentOne;
 	}
 	
@@ -85,27 +85,8 @@ public class DocumentsMarshallingStrategyTest {
 		
 		List<Document> documents = new ArrayList<>();
 		
-		
-		Document documentOne = new DocumentImpl();
-		documentOne.setIdentifier("docOne");
-		documentOne.setLastModified(new Date());
-		documentOne.setLink("http://documentOne");
-		documentOne.setName("DocumentOne Name");
-		documentOne.setSize(1);
-		documentOne.setContent("documentOne".getBytes());
-		
-		documents.add(documentOne);
-		
-		
-		Document documentTwo = new DocumentImpl();
-		documentTwo.setIdentifier("docTwo");
-		documentTwo.setLastModified(new Date());
-		documentTwo.setLink("http://documentTwo");
-		documentTwo.setName("DocumentTwo Name");
-		documentTwo.setSize(1);
-		documentTwo.setContent("documentTwo".getBytes());
-		
-		documents.add(documentTwo);
+		documents.add(getDocument("documentOne"));
+		documents.add(getDocument("documentTwo"));
 		
 		return documents;
 	}

--- a/jbpm-document/src/test/java/org/jbpm/document/marshalling/DocumentsMarshallingStrategyTest.java
+++ b/jbpm-document/src/test/java/org/jbpm/document/marshalling/DocumentsMarshallingStrategyTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.document.marshalling;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.jbpm.document.Document;
+import org.jbpm.document.Documents;
+import org.jbpm.document.service.impl.DocumentImpl;
+import org.junit.Test;
+
+
+
+public class DocumentsMarshallingStrategyTest {
+	
+	private DocumentsMarshallingStrategy docsMarshallingStrategy = new DocumentsMarshallingStrategy(new DocumentMarshallingStrategy());
+	
+	@Test
+	public void testMarshallUnmarshall() throws IOException, ClassNotFoundException {
+		
+		List<Document> documents = getDocuments();
+		Documents docs = new Documents(documents);
+		
+		byte[] marshalledDocs = docsMarshallingStrategy.marshal(null, null, docs);
+		
+		Documents unmarshalledDocs = (Documents) docsMarshallingStrategy.unmarshal(null, null, marshalledDocs, this.getClass().getClassLoader());
+		
+		assertEquals(docs.getDocuments().size(), unmarshalledDocs.getDocuments().size());
+		
+		List<Document> unmarshalledDocumentsList = unmarshalledDocs.getDocuments();
+		
+		assertEquals(documents.size(), unmarshalledDocumentsList.size());
+		
+		assertEquals(unmarshalledDocumentsList.get(0).getName(), docs.getDocuments().get(0).getName());
+		assertEquals(unmarshalledDocumentsList.get(0).getLink(), docs.getDocuments().get(0).getLink());
+		assertEquals(unmarshalledDocumentsList.get(1).getName(), docs.getDocuments().get(1).getName());
+		assertEquals(unmarshalledDocumentsList.get(1).getLink(), docs.getDocuments().get(1).getLink());
+	}
+	
+	
+	@Test
+	public void testSingleDocMarshallUnmarshall() throws IOException, ClassNotFoundException {
+		DocumentMarshallingStrategy docMarshallingStrategy = new DocumentMarshallingStrategy();
+		Document document = getDocument();
+		byte[] marshalledDocument = docMarshallingStrategy.marshal(null, null, document);
+		Document unmarshalledDocument = (Document) docMarshallingStrategy.unmarshal(null, null, marshalledDocument, this.getClass().getClassLoader());
+	
+		assertEquals(document.getName(), unmarshalledDocument.getName());
+		assertEquals(document.getLink(), unmarshalledDocument.getLink());
+		
+	}
+	
+	
+	private Document getDocument() {
+		Document documentOne = new DocumentImpl();
+		documentOne.setIdentifier("docOne");
+		documentOne.setLastModified(new Date());
+		documentOne.setLink("http://documentOne");
+		documentOne.setName("DocumentOne Name");
+		documentOne.setSize(1);
+		documentOne.setContent("documentOne".getBytes());	
+		return documentOne;
+	}
+	
+	private List<Document> getDocuments() {
+		
+		List<Document> documents = new ArrayList<>();
+		
+		
+		Document documentOne = new DocumentImpl();
+		documentOne.setIdentifier("docOne");
+		documentOne.setLastModified(new Date());
+		documentOne.setLink("http://documentOne");
+		documentOne.setName("DocumentOne Name");
+		documentOne.setSize(1);
+		documentOne.setContent("documentOne".getBytes());
+		
+		documents.add(documentOne);
+		
+		
+		Document documentTwo = new DocumentImpl();
+		documentTwo.setIdentifier("docTwo");
+		documentTwo.setLastModified(new Date());
+		documentTwo.setLink("http://documentTwo");
+		documentTwo.setName("DocumentTwo Name");
+		documentTwo.setSize(1);
+		documentTwo.setContent("documentTwo".getBytes());
+		
+		documents.add(documentTwo);
+		
+		return documents;
+	}
+
+}


### PR DESCRIPTION
Documents is a new type that wraps a List<Document>. The new MarshallingStrategy re-used the existing DocumentMarshallingStrategy for individual document persistence.