### PR TITLE
[7.4.x] Stabilize jbpm-container tests

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
@@ -146,6 +146,10 @@
       <artifactId>drools-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency> <!-- To make use of TransactionManager in CountDownProcessEventListener -->
+      <groupId>org.drools</groupId>
+      <artifactId>drools-persistence-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-human-task-core</artifactId>

--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/main/java/org/jbpm/test/container/listeners/CountDownProcessEventListener.java
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/main/java/org/jbpm/test/container/listeners/CountDownProcessEventListener.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.test.container.listeners;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.drools.persistence.api.TransactionManager;
+import org.drools.persistence.api.TransactionManagerFactory;
+import org.drools.persistence.api.TransactionSynchronization;
+import org.kie.api.event.process.DefaultProcessEventListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class CountDownProcessEventListener extends DefaultProcessEventListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(CountDownProcessEventListener.class);
+
+    private CountDownLatch latch;
+
+    public CountDownProcessEventListener() {
+
+    }
+
+    public CountDownProcessEventListener(int threads) {
+        this.latch = new CountDownLatch(threads);
+    }
+
+    public void waitTillCompleted() {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            logger.debug("Interrputed thread while waiting for all triggers");
+        }
+    }
+
+    public void waitTillCompleted(long timeOut) {
+        try {
+            latch.await(timeOut, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            logger.debug("Interrputed thread while waiting for all triggers");
+        }
+    }
+
+    public void reset(int threads) {
+        this.latch = new CountDownLatch(threads);
+    }
+
+    protected void countDown() {
+        try {
+            TransactionManager tm = TransactionManagerFactory.get().newTransactionManager();
+            if (tm != null && tm.getStatus() != TransactionManager.STATUS_NO_TRANSACTION
+                    && tm.getStatus() != TransactionManager.STATUS_ROLLEDBACK
+                    && tm.getStatus() != TransactionManager.STATUS_COMMITTED) {
+                tm.registerTransactionSynchronization(new TransactionSynchronization() {
+
+                    @Override
+                    public void beforeCompletion() {
+                    }
+
+                    @Override
+                    public void afterCompletion(int status) {
+                        latch.countDown();
+                    }
+                });
+            } else {
+                latch.countDown();
+            }
+        } catch (Exception e) {
+            latch.countDown();
+        }
+    }
+}

--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/archive/EJBService.java
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/archive/EJBService.java
@@ -36,6 +36,7 @@ import org.jbpm.services.api.model.DeploymentUnit;
 import org.jbpm.test.container.AbstractEJBServicesTest;
 import org.jbpm.test.container.AbstractRuntimeEJBServicesTest;
 import org.jbpm.test.container.JbpmContainerTest;
+import org.jbpm.test.container.listeners.CountDownProcessEventListener;
 import org.jbpm.test.container.listeners.TrackingAgendaEventListener;
 import org.jbpm.test.container.tools.IntegrationMavenResolver;
 import org.jbpm.test.container.webspherefix.WebSphereFixedJtaPlatform;
@@ -95,6 +96,7 @@ public class EJBService {
                 .addClass(EJBService.class)
                 // Workaroud for https://hibernate.atlassian.net/browse/HHH-11606
                 .addClass(WebSphereFixedJtaPlatform.class)
+                .addClass(CountDownProcessEventListener.class)
                 .addClass(JbpmContainerTest.class)
                 .addClass(AbstractEJBServicesTest.class)
                 .addClass(AbstractRuntimeEJBServicesTest.class)

--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/test/ejbservices/ejbcompl/EThreadInfoTest.java
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/test/ejbservices/ejbcompl/EThreadInfoTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.jbpm.test.container.AbstractRuntimeEJBServicesTest;
 import org.jbpm.test.container.groups.EAP;
+import org.jbpm.test.container.listeners.CountDownProcessEventListener;
 import org.jbpm.test.container.mock.RestService;
 import org.jbpm.services.api.model.VariableDesc;
 import org.junit.AfterClass;
@@ -32,7 +33,6 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runners.MethodSorters;
-import org.kie.api.event.process.DefaultProcessEventListener;
 import org.kie.api.event.process.ProcessCompletedEvent;
 import org.kie.api.event.process.ProcessNodeTriggeredEvent;
 import org.kie.api.runtime.manager.RuntimeEngine;
@@ -46,8 +46,21 @@ import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
 @Category({EAP.class})
 public class EThreadInfoTest extends AbstractRuntimeEJBServicesTest {
 
-    private static final Object LOCK = new Object();
-    public static final int TIMEOUT = 4000;
+    private static CountDownProcessEventListener listener = new CountDownProcessEventListener() {
+        @Override
+        public void afterProcessCompleted(ProcessCompletedEvent event) {
+            if ("org.jboss.qa.bpms.ThreadInfo".equals(event.getProcessInstance().getProcessId())) {
+                countDown();
+            }
+        }
+
+        @Override
+        public void afterNodeTriggered(ProcessNodeTriggeredEvent event) {
+            if ("User Task".equals(event.getNodeInstance().getNodeName())) {
+                countDown();
+            }
+        }
+    };
 
     @BeforeClass
     public static void startRestService() {
@@ -62,25 +75,9 @@ public class EThreadInfoTest extends AbstractRuntimeEJBServicesTest {
         }
         RuntimeManager manager = deploymentService.getRuntimeManager(kieJar);
         RuntimeEngine engine = manager.getRuntimeEngine(ProcessInstanceIdContext.get());
-        engine.getKieSession().addEventListener(new DefaultProcessEventListener() {
-            @Override
-            public void afterProcessCompleted(ProcessCompletedEvent event) {
-                if (event.getProcessInstance().getProcessId().equals("org.jboss.qa.bpms.ThreadInfo")) {
-                    synchronized (LOCK) {
-                        LOCK.notifyAll();
-                    }
-                }
-            }
 
-            @Override
-            public void afterNodeTriggered(ProcessNodeTriggeredEvent event) {
-                if (event.getNodeInstance().getNodeName().equals("User Task")) {
-                    synchronized (LOCK) {
-                        LOCK.notifyAll();
-                    }
-                }
-            }
-        });
+        engine.getKieSession().addEventListener(listener);
+        listener.reset(1);
     }
 
     @AfterClass
@@ -94,9 +91,7 @@ public class EThreadInfoTest extends AbstractRuntimeEJBServicesTest {
 
         processService.signalProcessInstance(pid, "start", "timer");
 
-        waitTillPrepared();             //to make sure the timer is completed
-        Thread.sleep(TIMEOUT);
-        System.out.println("After LOCK");
+        listener.waitTillCompleted();
 
         Assertions.assertThat(hasNodeLeft(pid, "timer")).isTrue();
         Assertions.assertThat(hasNodeLeft(pid, "Timer")).isTrue();
@@ -127,8 +122,7 @@ public class EThreadInfoTest extends AbstractRuntimeEJBServicesTest {
 
         processService.signalProcessInstance(pid, "start", "log");
 
-        waitTillPrepared();             //to make sure the async task is completed
-        Thread.sleep(TIMEOUT);
+        listener.waitTillCompleted();
 
         Assertions.assertThat(hasNodeLeft(pid, "log")).isTrue();
         Assertions.assertThat(hasNodeLeft(pid, "Log")).isTrue();
@@ -163,8 +157,7 @@ public class EThreadInfoTest extends AbstractRuntimeEJBServicesTest {
 
         processService.signalProcessInstance(pid, "start", "rest");
 
-        waitTillPrepared();             //to make sure the rest request is completed
-        Thread.sleep(TIMEOUT);
+        listener.waitTillCompleted();
 
         Assertions.assertThat(hasNodeLeft(pid, "rest")).isTrue();
         Assertions.assertThat(hasNodeLeft(pid, "REST")).isTrue();
@@ -206,8 +199,7 @@ public class EThreadInfoTest extends AbstractRuntimeEJBServicesTest {
 
         processService.signalProcessInstance(pid, "start", "script");
 
-        waitTillPrepared();             //to make sure the script task is completed
-        Thread.sleep(TIMEOUT);
+        listener.waitTillCompleted();
 
         Assertions.assertThat(hasNodeLeft(pid, "script")).isTrue();
         Assertions.assertThat(hasNodeLeft(pid, "Script")).isTrue();
@@ -237,8 +229,7 @@ public class EThreadInfoTest extends AbstractRuntimeEJBServicesTest {
 
         processService.signalProcessInstance(pid, "start", "usertask");
 
-        waitTillPrepared();             //to make sure the task is created and available to start
-        Thread.sleep(TIMEOUT);
+        listener.waitTillCompleted();
 
         List<TaskSummary> taskSummaries = runtimeDataService.getTasksAssignedAsPotentialOwner("john", new QueryFilter());
         Assertions.assertThat(taskSummaries).isNotNull().hasSize(1);
@@ -273,9 +264,7 @@ public class EThreadInfoTest extends AbstractRuntimeEJBServicesTest {
 
         processService.signalProcessInstance(pid, "start", "rule");
 
-        waitTillPrepared();             //to make sure the rule is fired
-        Thread.sleep(TIMEOUT);
-        System.out.println("After LOCK");
+        listener.waitTillCompleted();
 
         Assertions.assertThat(hasNodeLeft(pid, "rule")).isTrue();
         Assertions.assertThat(hasNodeLeft(pid, "Rule")).isTrue();
@@ -305,9 +294,7 @@ public class EThreadInfoTest extends AbstractRuntimeEJBServicesTest {
 
         processService.signalProcessInstance(pid, "start", "embedded");
 
-        waitTillPrepared();             //to make sure the embedded process is completed
-        Thread.sleep(TIMEOUT);
-        System.out.println("After LOCK");
+        listener.waitTillCompleted();
 
         Assertions.assertThat(hasNodeLeft(pid, "embedded")).isTrue();
         Assertions.assertThat(hasNodeLeft(pid, "Embedded")).isTrue();
@@ -337,9 +324,7 @@ public class EThreadInfoTest extends AbstractRuntimeEJBServicesTest {
 
         processService.signalProcessInstance(pid, "start", "subprocess");
 
-        waitTillPrepared();             //to make sure the subprocess is completed
-        Thread.sleep(TIMEOUT);
-        System.out.println("After LOCK");
+        listener.waitTillCompleted();
 
         Assertions.assertThat(hasNodeLeft(pid, "subprocess")).isTrue();
         Assertions.assertThat(hasNodeLeft(pid, "HelloWorld_1.0")).isTrue();
@@ -379,12 +364,6 @@ public class EThreadInfoTest extends AbstractRuntimeEJBServicesTest {
         query.setAscending(false);
 
         return runtimeDataService.getVariableHistory(pid, "threadName", query);
-    }
-
-    private void waitTillPrepared() throws InterruptedException {
-        synchronized (LOCK) {
-            LOCK.wait();
-        }
     }
 
 }

--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/test/ejbservices/tx/ETransactionTest.java
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/test/ejbservices/tx/ETransactionTest.java
@@ -34,12 +34,14 @@ import org.jbpm.test.container.AbstractRuntimeEJBServicesTest;
 import org.jbpm.test.container.groups.EAP;
 import org.jbpm.test.container.groups.WAS;
 import org.jbpm.test.container.groups.WLS;
+import org.jbpm.test.container.listeners.CountDownProcessEventListener;
 import org.jbpm.test.container.listeners.TrackingAgendaEventListener;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runners.MethodSorters;
+import org.kie.api.event.process.ProcessNodeLeftEvent;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.manager.RuntimeManager;
 import org.kie.api.runtime.process.ProcessInstance;
@@ -243,6 +245,18 @@ public class ETransactionTest extends AbstractRuntimeEJBServicesTest {
 
     @Test
     public void testTimer() throws Exception {
+        CountDownProcessEventListener listener = new CountDownProcessEventListener(0) {
+            @Override
+            public void afterNodeLeft(ProcessNodeLeftEvent event) {
+                if ("Timer".equals(event.getNodeInstance().getNodeName())) {
+                    countDown();
+                }
+            }
+        };
+        RuntimeManager manager = deploymentService.getRuntimeManager(kieJar);
+        RuntimeEngine engine = manager.getRuntimeEngine(ProcessInstanceIdContext.get());
+        engine.getKieSession().addEventListener(listener);
+
         Long processInstanceId = startProcessInstance(PROCESS_ID);
 
         UserTransaction ut = InitialContext.doLookup(USER_TRANSACTION_NAME);
@@ -270,7 +284,8 @@ public class ETransactionTest extends AbstractRuntimeEJBServicesTest {
 
         ut.commit();
 
-        Thread.sleep(2000);             //to make sure the timer is completed
+        listener.reset(1);
+        listener.waitTillCompleted();
 
         Assertions.assertThat(hasNodeLeft(processInstanceId, "timer")).isTrue();
         Assertions.assertThat(hasNodeLeft(processInstanceId, "Timer")).isTrue();


### PR DESCRIPTION
Hi, @mswiderski,

I have made a couple of enhancements to stabilize jbpm-container tests. I have removed quite a lot of timers and changed them for CountDown listener synchronization. There are still some timers in other tests, however, I decided to leave this portion as is for now since they are stable.