### PR TITLE
AF-593+: Move uberfire-maven-utils to kie-soup.

### DIFF
--- a/jbpm-services/jbpm-kie-services/pom.xml
+++ b/jbpm-services/jbpm-kie-services/pom.xml
@@ -98,8 +98,8 @@
       </exclusions>
     </dependency>  
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-maven-support</artifactId>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-maven-support</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Please see this [PR](https://github.com/kiegroup/kie-soup/pull/8) for general discussion.