### PR TITLE
Add missing EE spec jars to support Java 9 build

### DIFF
--- a/jbpm-audit/pom.xml
+++ b/jbpm-audit/pom.xml
@@ -64,6 +64,16 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.annotation</groupId>
+      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
     </dependency>

--- a/jbpm-human-task/jbpm-human-task-audit/pom.xml
+++ b/jbpm-human-task/jbpm-human-task-audit/pom.xml
@@ -163,6 +163,11 @@
     	<groupId>com.google.guava</groupId>
     	<artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/jbpm-human-task/jbpm-human-task-jpa/pom.xml
+++ b/jbpm-human-task/jbpm-human-task-jpa/pom.xml
@@ -73,8 +73,16 @@
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>
-
-
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.annotation</groupId>
+      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/jbpm-services/jbpm-executor/pom.xml
+++ b/jbpm-services/jbpm-executor/pom.xml
@@ -88,6 +88,11 @@
       <artifactId>jboss-jms-api_2.0_spec</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/jbpm-workitems/jbpm-workitems-core/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-core/pom.xml
@@ -17,6 +17,12 @@
       <groupId>com.google.testing.compile</groupId>
       <artifactId>compile-testing</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
I ma not 100% sure this is the best option, but it seems to work without much fuzz. I've declared the deps as `<scope>provided</scope>` to keep this backwards compatible - e.g. the deps won't be transitively brought to the other modules depending on these.

This only makes sure that the the simple `mvn clean install` works. Fixing all the tests to run successfully on JDK9 will be a different task.