### PR TITLE
JBPM-6590 - Isolation of Quartz scheduler / triggers per kjar

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/core/timer/NamedJobContext.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/timer/NamedJobContext.java
@@ -22,4 +22,8 @@ public interface NamedJobContext extends JobContext {
     String getJobName();
     
     Long getProcessInstanceId();
+    
+    default String getDeploymentId() {
+        return null;
+    }
 }

--- a/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/QuartzSchedulerService.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/QuartzSchedulerService.java
@@ -15,6 +15,14 @@
  */
 package org.jbpm.process.core.timer.impl;
 
+import java.io.NotSerializableException;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Date;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.drools.core.time.InternalSchedulerService;
 import org.drools.core.time.Job;
 import org.drools.core.time.JobContext;
@@ -29,6 +37,7 @@ import org.jbpm.process.core.timer.TimerServiceRegistry;
 import org.jbpm.process.core.timer.impl.GlobalTimerService.GlobalJobHandle;
 import org.jbpm.process.instance.timer.TimerManager.ProcessJobContext;
 import org.jbpm.process.instance.timer.TimerManager.StartProcessJobContext;
+import org.kie.api.runtime.EnvironmentName;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -44,14 +53,6 @@ import org.quartz.impl.jdbcjobstore.JobStoreSupport;
 import org.quartz.spi.JobStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.NotSerializableException;
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.Date;
-import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Quartz based <code>GlobalSchedulerService</code> that is configured according
@@ -86,6 +87,7 @@ public class QuartzSchedulerService implements GlobalSchedulerService {
     public JobHandle scheduleJob(Job job, JobContext ctx, Trigger trigger) {
         Long id = idCounter.getAndIncrement();
         String jobname = null;
+        String groupName = "jbpm";
         
         if (ctx instanceof ProcessJobContext) {
             ProcessJobContext processCtx = (ProcessJobContext) ctx;
@@ -93,8 +95,16 @@ public class QuartzSchedulerService implements GlobalSchedulerService {
             if (processCtx instanceof StartProcessJobContext) {
                 jobname = "StartProcess-"+((StartProcessJobContext) processCtx).getProcessId()+ "-" + processCtx.getTimer().getId();
             }
+            String deploymentId = (String)processCtx.getKnowledgeRuntime().getEnvironment().get(EnvironmentName.DEPLOYMENT_ID);
+            if (deploymentId != null) {
+                groupName = deploymentId;
+            }
         } else if (ctx instanceof NamedJobContext) {
             jobname = ((NamedJobContext) ctx).getJobName();
+            String deploymentId = ((NamedJobContext) ctx).getDeploymentId();
+            if (deploymentId != null) {
+                groupName = deploymentId;
+            }
         } else {
             jobname = "Timer-"+ctx.getClass().getSimpleName()+ "-" + id;
         
@@ -102,7 +112,7 @@ public class QuartzSchedulerService implements GlobalSchedulerService {
         logger.debug("Scheduling timer with name " + jobname);
         // check if this scheduler already has such job registered if so there is no need to schedule it again        
         try {
-            JobDetail jobDetail = scheduler.getJobDetail(jobname, "jbpm");
+            JobDetail jobDetail = scheduler.getJobDetail(jobname, groupName);
         
             if (jobDetail != null) {
                 TimerJobInstance timerJobInstance = (TimerJobInstance) jobDetail.getJobDataMap().get("timerJobInstance");
@@ -111,7 +121,7 @@ public class QuartzSchedulerService implements GlobalSchedulerService {
         } catch (SchedulerException e) {
             
         }
-        GlobalQuartzJobHandle quartzJobHandle = new GlobalQuartzJobHandle(id, jobname, "jbpm");
+        GlobalQuartzJobHandle quartzJobHandle = new GlobalQuartzJobHandle(id, jobname, groupName);
         TimerJobInstance jobInstance = globalTimerService.
                 getTimerJobFactoryManager().createTimerJobInstance( job,
                                                                     ctx,
@@ -214,7 +224,7 @@ public class QuartzSchedulerService implements GlobalSchedulerService {
         
         if (scheduler == null) {            
             try {
-                scheduler = StdSchedulerFactory.getDefaultScheduler();            
+                scheduler = StdSchedulerFactory.getDefaultScheduler();   
                 scheduler.startDelayed(START_DELAY);
             } catch (SchedulerException e) {
                 throw new RuntimeException("Exception when initializing QuartzSchedulerService", e);

--- a/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/quartz/DeploymentsAwarePostgreSQLDelegate.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/quartz/DeploymentsAwarePostgreSQLDelegate.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.process.core.timer.impl.quartz;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.quartz.impl.jdbcjobstore.PostgreSQLDelegate;
+import org.quartz.utils.Key;
+import org.slf4j.Logger;
+
+public class DeploymentsAwarePostgreSQLDelegate extends PostgreSQLDelegate {
+
+    private QuartzUtils quartzUtils = new QuartzUtils();
+
+    public DeploymentsAwarePostgreSQLDelegate(Logger log, String tablePrefix, String instanceId, Boolean useProperties) {
+        super(log, tablePrefix, instanceId, useProperties);
+    }
+
+    public DeploymentsAwarePostgreSQLDelegate(Logger log, String tablePrefix, String instanceId) {
+        super(log, tablePrefix, instanceId);
+    }
+
+    @Override
+    public List selectTriggerToAcquire(Connection conn, long noLaterThan, long noEarlierThan) throws SQLException {
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        List nextTriggers = new LinkedList();
+        try {
+            List<String> deploymentIds = quartzUtils.getDeployments();
+            ps = conn.prepareStatement(rtp(quartzUtils.nextTriggerQuery(deploymentIds)));
+
+            // Try to give jdbc driver a hint to hopefully not pull over 
+            // more than the few rows we actually need.
+            ps.setFetchSize(5);
+            ps.setMaxRows(5);
+
+            ps.setString(1, STATE_WAITING);
+            ps.setBigDecimal(2, new BigDecimal(String.valueOf(noLaterThan)));
+            ps.setBigDecimal(3, new BigDecimal(String.valueOf(noEarlierThan)));
+            int index = 4;
+            for (String deployment : deploymentIds) {
+                ps.setString(index++, deployment);
+            }
+
+            rs = ps.executeQuery();
+
+            while (rs.next() && nextTriggers.size() < 5) {
+                nextTriggers.add(new Key(
+                                         rs.getString(COL_TRIGGER_NAME),
+                                         rs.getString(COL_TRIGGER_GROUP)));
+            }
+
+            return nextTriggers;
+        } finally {
+            closeResultSet(rs);
+            closeStatement(ps);
+        }
+    }
+
+    @Override
+    public int countMisfiredTriggersInStates(Connection conn, String state1, String state2, long ts) throws SQLException {
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+
+        try {
+            List<String> deploymentIds = quartzUtils.getDeployments();
+
+            ps = conn.prepareStatement(rtp(quartzUtils.countMisfiredTriggersQuery(deploymentIds)));
+            ps.setBigDecimal(1, new BigDecimal(String.valueOf(ts)));
+            ps.setString(2, state1);
+            ps.setString(3, state2);
+            int index = 4;
+            for (String deployment : deploymentIds) {
+                ps.setString(index++, deployment);
+            }
+            rs = ps.executeQuery();
+
+            if (rs.next()) {
+                return rs.getInt(1);
+            }
+
+            throw new SQLException("No misfired trigger count returned.");
+        } finally {
+            closeResultSet(rs);
+            closeStatement(ps);
+        }
+    }
+
+    @Override
+    public boolean selectMisfiredTriggersInStates(Connection conn,
+                                                  String state1,
+                                                  String state2,
+                                                  long ts,
+                                                  int count,
+                                                  List resultList) throws SQLException {
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+
+        try {
+            List<String> deploymentIds = quartzUtils.getDeployments();
+
+            ps = conn.prepareStatement(rtp(quartzUtils.misfiredTriggersQuery(deploymentIds)));
+            ps.setBigDecimal(1, new BigDecimal(String.valueOf(ts)));
+            ps.setString(2, state1);
+            ps.setString(3, state2);
+            int index = 4;
+            for (String deployment : deploymentIds) {
+                ps.setString(index++, deployment);
+            }
+            rs = ps.executeQuery();
+
+            boolean hasReachedLimit = false;
+            while (rs.next() && (hasReachedLimit == false)) {
+                if (resultList.size() == count) {
+                    hasReachedLimit = true;
+                } else {
+                    String triggerName = rs.getString(COL_TRIGGER_NAME);
+                    String groupName = rs.getString(COL_TRIGGER_GROUP);
+                    resultList.add(new Key(triggerName, groupName));
+                }
+            }
+
+            return hasReachedLimit;
+        } finally {
+            closeResultSet(rs);
+            closeStatement(ps);
+        }
+    }
+}

--- a/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/quartz/DeploymentsAwareStdJDBCDelegate.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/quartz/DeploymentsAwareStdJDBCDelegate.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.process.core.timer.impl.quartz;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.quartz.impl.jdbcjobstore.StdJDBCDelegate;
+import org.quartz.utils.Key;
+import org.slf4j.Logger;
+
+
+public class DeploymentsAwareStdJDBCDelegate extends StdJDBCDelegate {
+
+    private QuartzUtils quartzUtils = new QuartzUtils();
+    
+    public DeploymentsAwareStdJDBCDelegate(Logger logger, String tablePrefix, String instanceId, Boolean useProperties) {
+        super(logger, tablePrefix, instanceId, useProperties);
+    }
+
+    public DeploymentsAwareStdJDBCDelegate(Logger logger, String tablePrefix, String instanceId) {
+        super(logger, tablePrefix, instanceId);
+    }
+    
+    @Override
+    public List selectTriggerToAcquire(Connection conn, long noLaterThan, long noEarlierThan)
+        throws SQLException {
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        List nextTriggers = new LinkedList();
+        try {
+            List<String> deploymentIds = quartzUtils.getDeployments();
+            ps = conn.prepareStatement(rtp(quartzUtils.nextTriggerQuery(deploymentIds)));
+            
+            // Try to give jdbc driver a hint to hopefully not pull over 
+            // more than the few rows we actually need.
+            ps.setFetchSize(5);
+            ps.setMaxRows(5);
+            
+            ps.setString(1, STATE_WAITING);
+            ps.setBigDecimal(2, new BigDecimal(String.valueOf(noLaterThan)));
+            ps.setBigDecimal(3, new BigDecimal(String.valueOf(noEarlierThan)));
+            int index = 4;
+            for (String deployment : deploymentIds) {
+                ps.setString(index++, deployment);
+            }
+            
+            rs = ps.executeQuery();
+            
+            while (rs.next() && nextTriggers.size() < 5) {
+                nextTriggers.add(new Key(
+                        rs.getString(COL_TRIGGER_NAME),
+                        rs.getString(COL_TRIGGER_GROUP)));
+            }
+            
+            return nextTriggers;
+        } finally {
+            closeResultSet(rs);
+            closeStatement(ps);
+        }      
+    }
+    
+    @Override
+    public int countMisfiredTriggersInStates(Connection conn, String state1, String state2, long ts) throws SQLException {
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+
+        try {
+            List<String> deploymentIds = quartzUtils.getDeployments();
+            
+            ps = conn.prepareStatement(rtp(quartzUtils.countMisfiredTriggersQuery(deploymentIds)));
+            ps.setBigDecimal(1, new BigDecimal(String.valueOf(ts)));
+            ps.setString(2, state1);
+            ps.setString(3, state2);
+            int index = 4;
+            for (String deployment : deploymentIds) {
+                ps.setString(index++, deployment);
+            }
+            rs = ps.executeQuery();
+
+            if (rs.next()) {
+                return rs.getInt(1);
+            }
+
+            throw new SQLException("No misfired trigger count returned.");
+        } finally {
+            closeResultSet(rs);
+            closeStatement(ps);
+        }
+    }
+    
+    @Override
+    public boolean selectMisfiredTriggersInStates(Connection conn, String state1, String state2,
+                                                  long ts, int count, List resultList) throws SQLException {
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+
+        try {
+            List<String> deploymentIds = quartzUtils.getDeployments();
+            
+            ps = conn.prepareStatement(rtp(quartzUtils.misfiredTriggersQuery(deploymentIds)));
+            ps.setBigDecimal(1, new BigDecimal(String.valueOf(ts)));
+            ps.setString(2, state1);
+            ps.setString(3, state2);
+            int index = 4;
+            for (String deployment : deploymentIds) {
+                ps.setString(index++, deployment);
+            }
+            rs = ps.executeQuery();
+
+            boolean hasReachedLimit = false;
+            while (rs.next() && (hasReachedLimit == false)) {
+                if (resultList.size() == count) {
+                    hasReachedLimit = true;
+                } else {
+                    String triggerName = rs.getString(COL_TRIGGER_NAME);
+                    String groupName = rs.getString(COL_TRIGGER_GROUP);
+                    resultList.add(new Key(triggerName, groupName));
+                }
+            }
+
+            return hasReachedLimit;
+        } finally {
+            closeResultSet(rs);
+            closeStatement(ps);
+        }
+    }
+}

--- a/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/quartz/QuartzUtils.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/quartz/QuartzUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.process.core.timer.impl.quartz;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.internal.runtime.manager.RuntimeManagerRegistry;
+import org.quartz.impl.jdbcjobstore.StdJDBCConstants;
+
+public class QuartzUtils implements StdJDBCConstants {
+
+    // next trigger query extension
+    String SELECT_NEXT_TRIGGER_TO_ACQUIRE = "SELECT "
+            + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + ", "
+            + COL_NEXT_FIRE_TIME + ", " + COL_PRIORITY + " FROM "
+            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
+            + COL_TRIGGER_STATE + " = ? AND " + COL_NEXT_FIRE_TIME + " < ? " 
+            + "AND (" + COL_NEXT_FIRE_TIME + " >= ?) ";
+            
+    String ORDER_BY = "ORDER BY "+ COL_NEXT_FIRE_TIME + " ASC, " + COL_PRIORITY + " DESC";
+    
+    // count misfired triggers query extension
+    String COUNT_MISFIRED_TRIGGERS_IN_STATES = "SELECT COUNT("
+            + COL_TRIGGER_NAME + ") FROM "
+            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
+            + COL_NEXT_FIRE_TIME + " < ? " 
+            + "AND ((" + COL_TRIGGER_STATE + " = ?) OR (" + COL_TRIGGER_STATE + " = ?)) ";
+
+    // misfired triggers query extension
+    String SELECT_MISFIRED_TRIGGERS_IN_STATES = "SELECT "
+            + COL_TRIGGER_NAME + ", " + COL_TRIGGER_GROUP + " FROM "
+            + TABLE_PREFIX_SUBST + TABLE_TRIGGERS + " WHERE "
+            + COL_NEXT_FIRE_TIME + " < ? " 
+            + "AND ((" + COL_TRIGGER_STATE + " = ?) OR (" + COL_TRIGGER_STATE + " = ?)) ";
+            
+    String MISFIRED_ORDER_BY = "ORDER BY " + COL_NEXT_FIRE_TIME + " ASC";
+    
+    public List<String> getDeployments() {
+        List<String> deploymentIds = new ArrayList<>(RuntimeManagerRegistry.get().getRegisteredIdentifiers());
+        // add jbpm as trigger group for backward compatibility
+        deploymentIds.add("jbpm");
+        
+        return deploymentIds;
+    }
+    
+    public String nextTriggerQuery(List<String> deploymentIds) {
+                        
+        String query = SELECT_NEXT_TRIGGER_TO_ACQUIRE + buildGroupFilter(deploymentIds) + ORDER_BY;
+        
+        return query;
+    }
+    
+    public String countMisfiredTriggersQuery(List<String> deploymentIds) {
+        
+        String query = COUNT_MISFIRED_TRIGGERS_IN_STATES + buildGroupFilter(deploymentIds);
+        
+        return query;
+    }
+    
+    public String misfiredTriggersQuery(List<String> deploymentIds) {
+        
+        String query = SELECT_MISFIRED_TRIGGERS_IN_STATES + buildGroupFilter(deploymentIds) + MISFIRED_ORDER_BY;
+        
+        return query;
+    }
+    
+    protected String buildGroupFilter(List<String> deploymentIds) {
+        StringBuilder filter = new StringBuilder(" (");
+        deploymentIds.forEach(s -> filter.append("?,"));                
+        filter.deleteCharAt(filter.length() - 1);
+        filter.append(") ");
+        
+        String groupFilter = "AND " + COL_TRIGGER_GROUP + " IN " + filter;
+        
+        return groupFilter;
+    }
+}

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/TaskDeadlinesServiceImpl.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/TaskDeadlinesServiceImpl.java
@@ -99,7 +99,7 @@ public class TaskDeadlinesServiceImpl implements TaskDeadlinesService {
                     0,
                     null,
                     null ) ;
-            JobHandle handle = timerService.scheduleJob(deadlineJob, new TaskDeadlineJobContext(deadlineJob.getId(), task.getTaskData().getProcessInstanceId()), trigger);
+            JobHandle handle = timerService.scheduleJob(deadlineJob, new TaskDeadlineJobContext(deadlineJob.getId(), task.getTaskData().getProcessInstanceId(), deploymentId), trigger);
             logger.debug( "scheduling timer job for deadline {} and task {}  using timer service {}", deadlineJob.getId(), taskId, timerService);
             jobHandles.put(deadlineJob.getId(), handle);
 
@@ -146,7 +146,7 @@ public class TaskDeadlinesServiceImpl implements TaskDeadlinesService {
                     logger.debug("unscheduling timer job for deadline {} {} and task {}  using timer service {}", deadlineJob.getId(), summary.getDeadlineId(), taskId, timerService);
                     JobHandle jobHandle = jobHandles.remove(deadlineJob.getId()); 
                     if (jobHandle == null) {        
-                        jobHandle = ((GlobalTimerService) timerService).buildJobHandleForContext(new TaskDeadlineJobContext(deadlineJob.getId(), task.getTaskData().getProcessInstanceId()));
+                        jobHandle = ((GlobalTimerService) timerService).buildJobHandleForContext(new TaskDeadlineJobContext(deadlineJob.getId(), task.getTaskData().getProcessInstanceId(), deploymentId));
                     }
                     timerService.removeJob(jobHandle);
                     // mark the deadlines so they won't be rescheduled again
@@ -167,7 +167,7 @@ public class TaskDeadlinesServiceImpl implements TaskDeadlinesService {
                     logger.debug("unscheduling timer job for deadline {} and task {}  using timer service {}", deadlineJob.getId(), taskId, timerService);
                     JobHandle jobHandle = jobHandles.remove(deadlineJob.getId()); 
                     if (jobHandle == null) {        
-                        jobHandle = ((GlobalTimerService) timerService).buildJobHandleForContext(new TaskDeadlineJobContext(deadlineJob.getId(), task.getTaskData().getProcessInstanceId()));
+                        jobHandle = ((GlobalTimerService) timerService).buildJobHandleForContext(new TaskDeadlineJobContext(deadlineJob.getId(), task.getTaskData().getProcessInstanceId(), deploymentId));
                     }
                     timerService.removeJob(jobHandle);
                     // mark the deadlines so they won't be rescheduled again
@@ -217,7 +217,7 @@ public class TaskDeadlinesServiceImpl implements TaskDeadlinesService {
             logger.debug("unscheduling timer job for deadline {} {} and task {}  using timer service {}", deadlineJob.getId(), deadline.getId(), taskId, timerService);
             JobHandle jobHandle = jobHandles.remove(deadlineJob.getId()); 
             if (jobHandle == null) {        
-                jobHandle = ((GlobalTimerService) timerService).buildJobHandleForContext(new TaskDeadlineJobContext(deadlineJob.getId(), task.getTaskData().getProcessInstanceId()));
+                jobHandle = ((GlobalTimerService) timerService).buildJobHandleForContext(new TaskDeadlineJobContext(deadlineJob.getId(), task.getTaskData().getProcessInstanceId(), deploymentId));
             }
             timerService.removeJob(jobHandle);
             // mark the deadlines so they won't be rescheduled again                  
@@ -408,10 +408,12 @@ public class TaskDeadlinesServiceImpl implements TaskDeadlinesService {
         private JobHandle jobHandle;
         private String jobName;
         private Long processInstanceId;
+        private String deploymentId;
         
-        public TaskDeadlineJobContext(String jobName, Long processInstanceId) {
+        public TaskDeadlineJobContext(String jobName, Long processInstanceId, String deploymentId) {
             this.jobName = jobName;
             this.processInstanceId = processInstanceId;
+            this.deploymentId = deploymentId;
         }
         
         @Override
@@ -433,6 +435,11 @@ public class TaskDeadlinesServiceImpl implements TaskDeadlinesService {
 		public Long getProcessInstanceId() {
 			return processInstanceId;
 		}
+
+		@Override
+        public String getDeploymentId() {
+            return deploymentId;
+        }
 
         @Override
         public InternalWorkingMemory getWorkingMemory() {

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/RuntimeManagerFactoryImpl.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/RuntimeManagerFactoryImpl.java
@@ -56,7 +56,7 @@ public class RuntimeManagerFactoryImpl implements RuntimeManagerFactory {
     }
     @Override
     public RuntimeManager newSingletonRuntimeManager(RuntimeEnvironment environment, String identifier) {
-        SessionFactory factory = getSessionFactory(environment);
+        SessionFactory factory = getSessionFactory(environment, identifier);
         TaskServiceFactory taskServiceFactory = getTaskServiceFactory(environment);
         
         RuntimeManager manager = new SingletonRuntimeManager(environment, factory, taskServiceFactory, identifier);
@@ -73,7 +73,7 @@ public class RuntimeManagerFactoryImpl implements RuntimeManagerFactory {
     }
     
     public RuntimeManager newPerRequestRuntimeManager(RuntimeEnvironment environment, String identifier) {
-        SessionFactory factory = getSessionFactory(environment);
+        SessionFactory factory = getSessionFactory(environment, identifier);
         TaskServiceFactory taskServiceFactory = getTaskServiceFactory(environment);
 
         RuntimeManager manager = new PerRequestRuntimeManager(environment, factory, taskServiceFactory, identifier);
@@ -89,7 +89,7 @@ public class RuntimeManagerFactoryImpl implements RuntimeManagerFactory {
     }
     
     public RuntimeManager newPerProcessInstanceRuntimeManager(RuntimeEnvironment environment, String identifier) {
-        SessionFactory factory = getSessionFactory(environment);
+        SessionFactory factory = getSessionFactory(environment, identifier);
         TaskServiceFactory taskServiceFactory = getTaskServiceFactory(environment);
 
         RuntimeManager manager = new PerProcessInstanceRuntimeManager(environment, factory, taskServiceFactory, identifier);
@@ -105,7 +105,7 @@ public class RuntimeManagerFactoryImpl implements RuntimeManagerFactory {
     }
     
     public RuntimeManager newPerCaseRuntimeManager(RuntimeEnvironment environment, String identifier) {
-        SessionFactory factory = getSessionFactory(environment);
+        SessionFactory factory = getSessionFactory(environment, identifier);
         TaskServiceFactory taskServiceFactory = getTaskServiceFactory(environment);
 
         RuntimeManager manager = new PerCaseRuntimeManager(environment, factory, taskServiceFactory, identifier);
@@ -114,12 +114,12 @@ public class RuntimeManagerFactoryImpl implements RuntimeManagerFactory {
         return manager;
     }
     
-    protected SessionFactory getSessionFactory(RuntimeEnvironment environment) {
+    protected SessionFactory getSessionFactory(RuntimeEnvironment environment, String owner) {
         SessionFactory factory = null;
         if (environment.usePersistence()) {
-            factory = new JPASessionFactory(environment);
+            factory = new JPASessionFactory(environment, owner);
         } else {
-            factory = new InMemorySessionFactory(environment);
+            factory = new InMemorySessionFactory(environment, owner);
         }
         
         return factory;

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/factory/InMemorySessionFactory.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/factory/InMemorySessionFactory.java
@@ -24,6 +24,8 @@ import org.jbpm.process.instance.ProcessInstanceManager;
 import org.jbpm.process.instance.ProcessRuntimeImpl;
 import org.jbpm.process.instance.impl.DefaultProcessInstanceManager;
 import org.kie.api.KieBase;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEnvironment;
 import org.kie.internal.runtime.manager.SessionFactory;
@@ -43,15 +45,19 @@ public class InMemorySessionFactory implements SessionFactory {
     private RuntimeEnvironment environment;
     private KieBase kbase;
     private Map<Long, KieSession> sessions = new ConcurrentHashMap<Long, KieSession>();
+    private String owner;
     
-    public InMemorySessionFactory(RuntimeEnvironment environment) {
+    public InMemorySessionFactory(RuntimeEnvironment environment, String owner) {
         this.environment = environment;
         this.kbase = environment.getKieBase();
+        this.owner = owner;
     }
     
     @Override
     public KieSession newKieSession() {
-        KieSession ksession = kbase.newKieSession(environment.getConfiguration(), environment.getEnvironment());
+        Environment env = environment.getEnvironment();
+        env.set(EnvironmentName.DEPLOYMENT_ID, owner);
+        KieSession ksession = kbase.newKieSession(environment.getConfiguration(), env);
         this.sessions.put(ksession.getIdentifier(), ksession);
         
         ProcessInstanceManager piManager = ((ProcessRuntimeImpl)((StatefulKnowledgeSessionImpl)ksession).getProcessRuntime()).getProcessInstanceManager();

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/factory/JPASessionFactory.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/factory/JPASessionFactory.java
@@ -20,6 +20,8 @@ import org.drools.persistence.PersistableRunner;
 import org.drools.persistence.jpa.OptimisticLockRetryInterceptor;
 import org.drools.persistence.jta.TransactionLockInterceptor;
 import org.jbpm.runtime.manager.impl.error.ExecutionErrorHandlerInterceptor;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEnvironment;
 import org.kie.internal.persistence.jpa.JPAKnowledgeService;
@@ -32,16 +34,19 @@ import org.kie.internal.runtime.manager.SessionFactory;
 public class JPASessionFactory implements SessionFactory {
 
     private RuntimeEnvironment environment;
+    private String owner;
     
-    public JPASessionFactory(RuntimeEnvironment environment) {
+    public JPASessionFactory(RuntimeEnvironment environment, String owner) {
         this.environment = environment;
+        this.owner = owner;
     }
     
     @Override
     public KieSession newKieSession() {
-
+        Environment env = environment.getEnvironment();
+        env.set(EnvironmentName.DEPLOYMENT_ID, owner);
         KieSession ksession = JPAKnowledgeService.newStatefulKnowledgeSession(
-                environment.getKieBase(), environment.getConfiguration(), environment.getEnvironment());
+                environment.getKieBase(), environment.getConfiguration(), env);
         addInterceptors(ksession);
         return ksession;
     }
@@ -51,8 +56,10 @@ public class JPASessionFactory implements SessionFactory {
         if (sessionId == null) {
             return null;
         }
+        Environment env = environment.getEnvironment();
+        env.set(EnvironmentName.DEPLOYMENT_ID, owner);
         KieSession ksession = JPAKnowledgeService.loadStatefulKnowledgeSession(sessionId,
-                environment.getKieBase(), environment.getConfiguration(), environment.getEnvironment());
+                environment.getKieBase(), environment.getConfiguration(), env);
         addInterceptors(ksession);
         return ksession;
     }

--- a/jbpm-test-coverage/src/test/resources/quartz-db-short-misfire.properties
+++ b/jbpm-test-coverage/src/test/resources/quartz-db-short-misfire.properties
@@ -25,7 +25,7 @@ org.quartz.threadPool.threadPriority = 5
 org.quartz.jobStore.misfireThreshold = 3000
 
 org.quartz.jobStore.class=org.quartz.impl.jdbcjobstore.JobStoreCMT
-org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.StdJDBCDelegate
+org.quartz.jobStore.driverDelegateClass=org.jbpm.process.core.timer.impl.quartz.DeploymentsAwareStdJDBCDelegate
 org.quartz.jobStore.useProperties=false
 org.quartz.jobStore.dataSource=myDS
 org.quartz.jobStore.nonManagedTXDataSource=notManagedDS

--- a/jbpm-test-coverage/src/test/resources/quartz-db.properties
+++ b/jbpm-test-coverage/src/test/resources/quartz-db.properties
@@ -25,7 +25,7 @@ org.quartz.threadPool.threadPriority = 5
 org.quartz.jobStore.misfireThreshold = 60000
 
 org.quartz.jobStore.class=org.quartz.impl.jdbcjobstore.JobStoreCMT
-org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.StdJDBCDelegate
+org.quartz.jobStore.driverDelegateClass=org.jbpm.process.core.timer.impl.quartz.DeploymentsAwareStdJDBCDelegate
 org.quartz.jobStore.useProperties=false
 org.quartz.jobStore.dataSource=myDS
 org.quartz.jobStore.nonManagedTXDataSource=notManagedDS


### PR DESCRIPTION
this PR provides extension to default SQL delegates that take into considerations deployments that are present in the system. By that queries done by quartz will filter triggers by the deployments that are actually able to execute the job.

To make this possible, trigger (and job) group name is now set to deployment id (if available).