### PR TITLE
JBPM-6487 Jbpm tests stabilisation pr4

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/JbpmBpmn2TestCase.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/JbpmBpmn2TestCase.java
@@ -738,7 +738,7 @@ public abstract class JbpmBpmn2TestCase extends AbstractBaseTest {
             try {
                 logService.clear();
             } catch(Exception e) {
-                log.error("History could not be deleted.");
+                log.error("History could not be deleted.", e);
             }
         } else {
             if (logger != null) {

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/JbpmBpmn2TestCase.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/JbpmBpmn2TestCase.java
@@ -738,7 +738,7 @@ public abstract class JbpmBpmn2TestCase extends AbstractBaseTest {
             try {
                 logService.clear();
             } catch(Exception e) {
-                
+                log.error("History could not be deleted.");
             }
         } else {
             if (logger != null) {

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StartEventTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StartEventTest.java
@@ -43,7 +43,6 @@ import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieRepository;
 import org.kie.api.event.process.DefaultProcessEventListener;
-import org.kie.api.event.process.ProcessCompletedEvent;
 import org.kie.api.event.process.ProcessStartedEvent;
 import org.kie.api.io.Resource;
 import org.kie.api.runtime.KieContainer;

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StartEventTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StartEventTest.java
@@ -34,7 +34,6 @@ import org.jbpm.bpmn2.objects.Person;
 import org.jbpm.bpmn2.objects.TestWorkItemHandler;
 import org.jbpm.test.listener.NodeLeftCountDownProcessEventListener;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -346,7 +345,7 @@ public class StartEventTest extends JbpmBpmn2TestCase {
                 }
             });
             Assertions.assertThat(list.size()).isEqualTo(0);
-            // Timer in the process takes 500ms, so after 2.5 seconds, there should be 5 process IDs in the list.
+            // Timer in the process takes 500ms, so after 1 second, there should be 2 process IDs in the list.
             countDownListener.waitTillCompleted();
             Assertions.assertThat(getNumberOfProcessInstances("MultipleStartEvents")).isEqualTo(2);
         } finally {
@@ -509,7 +508,7 @@ public class StartEventTest extends JbpmBpmn2TestCase {
             }
         });
         Assertions.assertThat(list.size()).isEqualTo(0);
-        // Timer in the process takes 500ms, so after 2.5 seconds, there should be 5 process IDs in the list.
+        // Timer in the process takes 500ms, so after 1 second, there should be 2 process IDs in the list.
         countDownListener.waitTillCompleted();
         Assertions.assertThat(getNumberOfProcessInstances("MultipleStartEvents")).isEqualTo(2);
 

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StartEventTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StartEventTest.java
@@ -43,6 +43,7 @@ import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieRepository;
 import org.kie.api.event.process.DefaultProcessEventListener;
+import org.kie.api.event.process.ProcessCompletedEvent;
 import org.kie.api.event.process.ProcessStartedEvent;
 import org.kie.api.io.Resource;
 import org.kie.api.runtime.KieContainer;
@@ -52,6 +53,8 @@ import org.kie.api.runtime.process.WorkItem;
 import org.kie.internal.io.ResourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @RunWith(Parameterized.class)
 public class StartEventTest extends JbpmBpmn2TestCase {
@@ -290,12 +293,8 @@ public class StartEventTest extends JbpmBpmn2TestCase {
         Assertions.assertThat(getNumberOfProcessInstances("Minimal")).isEqualTo(1);
         // now remove the process from kbase to make sure runtime based listeners are removed from signal manager
         kbase.removeProcess("Minimal");
-        
-        try {
-            ksession.signalEvent("MySignal", "NewValue");
-        } catch (IllegalArgumentException e) {
-            Assertions.assertThat(e.getMessage()).isEqualTo("Unknown process ID: Minimal");
-        }
+        Assertions.assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> { ksession.signalEvent("MySignal", "NewValue"); })
+                    .withMessageContaining("Unknown process ID: Minimal");
         // must be still one as the process was removed
         Assertions.assertThat(getNumberOfProcessInstances("Minimal")).isEqualTo(1);
 
@@ -584,34 +583,37 @@ public class StartEventTest extends JbpmBpmn2TestCase {
 
     }
 
+    /**
+     * Should fail as timer expression is not valid
+     *
+     * @throws Exception
+     */
     @Test
     public void testInvalidDateTimerStart() throws Exception {
-        try {
-            createKnowledgeBase("timer/BPMN2-StartTimerDateInvalid.bpmn2");
-            fail("Should fail as timer expression is not valid");
-        } catch (RuntimeException e) {
-            Assertions.assertThat(e.getMessage().contains("Could not parse date 'abcdef'")).isTrue();
-        }
+        Assertions.assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> { createKnowledgeBase("timer/BPMN2-StartTimerDateInvalid.bpmn2"); })
+                .withMessageContaining("Could not parse date 'abcdef'");
     }
 
+    /**
+     * Should fail as timer expression is not valid
+     *
+     * @throws Exception
+     */
     @Test
     public void testInvalidDurationTimerStart() throws Exception {
-        try {
-            createKnowledgeBase("timer/BPMN2-StartTimerDurationInvalid.bpmn2");
-            fail("Should fail as timer expression is not valid");
-        } catch (Exception e) {
-            Assertions.assertThat(e.getMessage().contains("Could not parse delay 'abcdef'")).isTrue();
-        }
+        Assertions.assertThatExceptionOfType(Exception.class).isThrownBy(() -> { createKnowledgeBase("timer/BPMN2-StartTimerDurationInvalid.bpmn2"); })
+                .withMessageContaining("Could not parse delay 'abcdef'");
     }
 
+    /**
+     * Should fail as timer expression is not valid
+     *
+     * @throws Exception
+     */
     @Test
     public void testInvalidCycleTimerStart() throws Exception {
-        try {
-            createKnowledgeBase("timer/BPMN2-StartTimerCycleInvalid.bpmn2");
-            fail("Should fail as timer expression is not valid");
-        } catch (Exception e) {
-            Assertions.assertThat(e.getMessage().contains("Could not parse delay 'abcdef'")).isTrue();
-        }
+        Assertions.assertThatExceptionOfType(Exception.class).isThrownBy(() -> { createKnowledgeBase("timer/BPMN2-StartTimerCycleInvalid.bpmn2"); })
+                .withMessageContaining("Could not parse delay 'abcdef'");
     }
 
 

--- a/jbpm-bpmn2/src/test/resources/BPMN2-MultipleStartEventProcess.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-MultipleStartEventProcess.bpmn2
@@ -7,7 +7,7 @@
     <startEvent id="StartEvent_1" name="StartTimer">
       <outgoing>SequenceFlow_3</outgoing>
       <timerEventDefinition id="TimerEventDefinition_1">
-        <timeCycle xsi:type="tFormalExpression" id="_FormalExpression_2">500</timeCycle>
+        <timeCycle xsi:type="tFormalExpression" id="_FormalExpression_2">R2/PT0.5S</timeCycle>
       </timerEventDefinition>
     </startEvent>
     <sequenceFlow id="SequenceFlow_2" tns:priority="1" name="" sourceRef="_1" targetRef="ExclusiveGateway_1"/>

--- a/jbpm-bpmn2/src/test/resources/BPMN2-MultipleStartEventProcessLongInterval.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-MultipleStartEventProcessLongInterval.bpmn2
@@ -3,12 +3,11 @@
   <process id="MultipleStartEvents" tns:packageName="defaultPackage" name="MultipleStartEvents" isExecutable="true" processType="Private">
     <startEvent id="_1" name="StartProcess">
       <outgoing>SequenceFlow_2</outgoing>
-      <signalEventDefinition id="SignalEventDefinition_1" signalRef="startSignal"/>
     </startEvent>
     <startEvent id="StartEvent_1" name="StartTimer">
       <outgoing>SequenceFlow_3</outgoing>
       <timerEventDefinition id="TimerEventDefinition_1">
-        <timeCycle xsi:type="tFormalExpression" id="_FormalExpression_2">R2/PT0.5S</timeCycle>
+        <timeDuration xsi:type="tFormalExpression" id="_FormalExpression_2">P10D</timeDuration>
       </timerEventDefinition>
     </startEvent>
     <sequenceFlow id="SequenceFlow_2" tns:priority="1" name="" sourceRef="_1" targetRef="ExclusiveGateway_1"/>
@@ -36,7 +35,7 @@
           <dataInputRefs>_DataInput_6</dataInputRefs>
           <dataInputRefs>_DataInput_7</dataInputRefs>
         </inputSet>
-        <outputSet id="OutputSet_1"/>
+        <outputSet/>
       </ioSpecification>
       <dataInputAssociation id="_DataInputAssociation_2">
         <targetRef>_DataInput_2</targetRef>
@@ -73,16 +72,16 @@
       <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="_1" isHorizontal="true">
         <dc:Bounds height="48.0" width="48.0" x="45.0" y="45.0"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_StartEvent_2" bpmnElement="StartEvent_1" isHorizontal="true">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds height="48.0" width="48.0" x="45.0" y="190.0"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_UserTask_1" bpmnElement="UserTask_1" isHorizontal="true">
+      <bpmndi:BPMNShape id="BPMNShape_UserTask_1" bpmnElement="UserTask_1">
         <dc:Bounds height="50.0" width="110.0" x="330.0" y="111.0"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="EndEvent_1" isHorizontal="true">
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="EndEvent_1">
         <dc:Bounds height="48.0" width="48.0" x="580.0" y="114.0"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_ExclusiveGateway_1" bpmnElement="ExclusiveGateway_1" isHorizontal="true">
+      <bpmndi:BPMNShape id="BPMNShape_ExclusiveGateway_1" bpmnElement="ExclusiveGateway_1">
         <dc:Bounds height="50.0" width="50.0" x="187.0" y="112.0"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="BPMNShape_UserTask_1" targetElement="BPMNShape_EndEvent_1">


### PR DESCRIPTION
Number of instances created by the timer was reduced, aborting of the active processes after test finished was added together with history clearing. New process definition with longer timer duration added.