### PR TITLE
JBPM-6487 JBPM tests stabilisation

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/DeadlinesBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/DeadlinesBaseTest.java
@@ -16,14 +16,12 @@
 package org.jbpm.services.task;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.*;
 
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.*;
 
-import org.assertj.core.api.Assertions;
 import org.jbpm.services.task.deadlines.NotificationListener;
 import org.jbpm.services.task.deadlines.notifications.impl.MockNotificationListener;
 import org.jbpm.services.task.impl.factories.TaskFactory;
@@ -79,12 +77,12 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         checkContentSubjectAndBody(unmarshallObject);
 
         // emails should not be set yet
-        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
+        assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         
         countDownListener.waitTillCompleted();
 
         // 1 email with two recipients should now exist
-        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(1);
+        assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(1);
         
     }
     @Test(timeout=10000)
@@ -110,14 +108,14 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
       
         content = (InternalContent) taskService.getContentById(contentId);
         Object unmarshallObject = ContentMarshallerHelper.unmarshall(content.getContent(), null);
-        Assertions.assertThat(unmarshallObject.toString()).isEqualTo("'singleobject'");
+        assertThat(unmarshallObject.toString()).isEqualTo("'singleobject'");
 
         // emails should not be set yet
-        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
+        assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         countDownListener.waitTillCompleted();
 
         // 1 email with two recipients should now exist
-        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(1);
+        assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(1);
 
     }
     @Test(timeout=10000)
@@ -165,16 +163,16 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         taskService.start(taskId, "Administrator");
         taskService.complete(taskId, "Administrator", null);
         // emails should not be set yet
-        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
+        assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
 
         countDownListener.waitTillCompleted();
 
         // no email should ne sent as task was completed before deadline was triggered
-        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
+        assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         task = (InternalTask) taskService.getTaskById(taskId);
-        Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Completed);
-        Assertions.assertThat(((InternalTask) task).getDeadlines().getStartDeadlines().size()).isEqualTo(0);
-        Assertions.assertThat(((InternalTask) task).getDeadlines().getEndDeadlines().size()).isEqualTo(0);
+        assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Completed);
+        assertThat(((InternalTask) task).getDeadlines().getStartDeadlines().size()).isEqualTo(0);
+        assertThat(((InternalTask) task).getDeadlines().getEndDeadlines().size()).isEqualTo(0);
         
         
     }
@@ -224,16 +222,16 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         taskService.start(taskId, "Administrator");
         taskService.fail(taskId, "Administrator", null);
         // emails should not be set yet
-        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
+        assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         
         countDownListener.waitTillCompleted();
         
         // no email should ne sent as task was completed before deadline was triggered
-        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
+        assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         task = (InternalTask) taskService.getTaskById(taskId);
-        Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Failed);
-        Assertions.assertThat(task.getDeadlines().getStartDeadlines().size()).isEqualTo(0);
-        Assertions.assertThat(task.getDeadlines().getEndDeadlines().size()).isEqualTo(0);
+        assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Failed);
+        assertThat(task.getDeadlines().getStartDeadlines().size()).isEqualTo(0);
+        assertThat(task.getDeadlines().getEndDeadlines().size()).isEqualTo(0);
     }
     
     @Test(timeout=10000)
@@ -279,16 +277,16 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         
         taskService.skip(taskId, "Administrator");
         // emails should not be set yet
-        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
+        assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         
         countDownListener.waitTillCompleted();
 
         // no email should ne sent as task was completed before deadline was triggered
-        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
+        assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         task = (InternalTask) taskService.getTaskById(taskId);
-        Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Obsolete);
-        Assertions.assertThat(task.getDeadlines().getStartDeadlines().size()).isEqualTo(0);
-        Assertions.assertThat(task.getDeadlines().getEndDeadlines().size()).isEqualTo(0);
+        assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Obsolete);
+        assertThat(task.getDeadlines().getStartDeadlines().size()).isEqualTo(0);
+        assertThat(task.getDeadlines().getEndDeadlines().size()).isEqualTo(0);
     }
     
     @Test(timeout=10000)   
@@ -334,16 +332,16 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         
         taskService.exit(taskId, "Administrator");
         // emails should not be set yet
-        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
+        assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
 
         countDownListener.waitTillCompleted();
 
         // no email should ne sent as task was completed before deadline was triggered
-        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
+        assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         task = (InternalTask) taskService.getTaskById(taskId);
-        Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Exited);
-        Assertions.assertThat(task.getDeadlines().getStartDeadlines().size()).isEqualTo(0);
-        Assertions.assertThat(task.getDeadlines().getEndDeadlines().size()).isEqualTo(0);
+        assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Exited);
+        assertThat(task.getDeadlines().getStartDeadlines().size()).isEqualTo(0);
+        assertThat(task.getDeadlines().getEndDeadlines().size()).isEqualTo(0);
     }
 
 
@@ -366,22 +364,22 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         for (OrganizationalEntity entity : potentialOwners) {
             ids.add(entity.getId());
         }
-        Assertions.assertThat(ids.contains("Tony Stark")).isTrue();
-        Assertions.assertThat(ids.contains("Luke Cage")).isTrue();
+        assertThat(ids.contains("Tony Stark")).isTrue();
+        assertThat(ids.contains("Luke Cage")).isTrue();
 
         // should have re-assigned by now
         countDownListener.waitTillCompleted();
         
         task = taskService.getTaskById(taskId);
-        Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Ready);
+        assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Ready);
         potentialOwners = (List<OrganizationalEntity>) task.getPeopleAssignments().getPotentialOwners();
 
         ids = new ArrayList<String>(potentialOwners.size());
         for (OrganizationalEntity entity : potentialOwners) {
             ids.add(entity.getId());
         }
-        Assertions.assertThat(ids.contains("Bobba Fet")).isTrue();
-        Assertions.assertThat(ids.contains("Jabba Hutt")).isTrue();
+        assertThat(ids.contains("Bobba Fet")).isTrue();
+        assertThat(ids.contains("Jabba Hutt")).isTrue();
     }
 
       @Test(timeout=12000)
@@ -444,23 +442,23 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
           taskService.start(taskId, "Administrator");
           taskService.complete(taskId, "Administrator", null);
           // emails should not be set yet
-          Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
+          assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
  
           countDownListener.waitTillCompleted();
 
           // no email should be sent as task was completed before deadline was triggered
-          Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(1);
+          assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(1);
           task = (InternalTask) taskService.getTaskById(taskId);
-          Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Completed);
-          Assertions.assertThat(((InternalTask) task).getDeadlines().getStartDeadlines().size()).isEqualTo(0);
-          Assertions.assertThat(((InternalTask) task).getDeadlines().getEndDeadlines().size()).isEqualTo(0);
+          assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Completed);
+          assertThat(((InternalTask) task).getDeadlines().getStartDeadlines().size()).isEqualTo(0);
+          assertThat(((InternalTask) task).getDeadlines().getEndDeadlines().size()).isEqualTo(0);
           
           taskService.start(task2.getId(), "Administrator");
           taskService.complete(task2.getId(), "Administrator", null);
           
           task = (InternalTask) taskService.getTaskById(task2.getId());
-          Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Completed);
-          Assertions.assertThat(((InternalTask) task).getDeadlines().getStartDeadlines().size()).isEqualTo(0);
-          Assertions.assertThat(((InternalTask) task).getDeadlines().getEndDeadlines().size()).isEqualTo(0);
+          assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Completed);
+          assertThat(((InternalTask) task).getDeadlines().getStartDeadlines().size()).isEqualTo(0);
+          assertThat(((InternalTask) task).getDeadlines().getEndDeadlines().size()).isEqualTo(0);
       }
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/DeadlinesBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/DeadlinesBaseTest.java
@@ -384,7 +384,7 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         Assertions.assertThat(ids.contains("Jabba Hutt")).isTrue();
     }
 
-      @Test(timeout=10000)
+      @Test(timeout=12000)
       public void testDelayedEmailNotificationOnDeadlineTaskCompletedMultipleTasks() throws Exception {
           CountDownTaskEventListener countDownListener = new CountDownTaskEventListener(2, false, true);
           addCountDownListner(countDownListener);

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/DeadlinesBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/DeadlinesBaseTest.java
@@ -23,6 +23,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.*;
 
+import org.assertj.core.api.Assertions;
 import org.jbpm.services.task.deadlines.NotificationListener;
 import org.jbpm.services.task.deadlines.notifications.impl.MockNotificationListener;
 import org.jbpm.services.task.impl.factories.TaskFactory;
@@ -78,13 +79,12 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         checkContentSubjectAndBody(unmarshallObject);
 
         // emails should not be set yet
-        //assertEquals(0, getWiser().getMessages().size());
-        assertEquals(0, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         
         countDownListener.waitTillCompleted();
 
         // 1 email with two recipients should now exist
-        assertEquals(1, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(1);
         
     }
     @Test(timeout=10000)
@@ -110,15 +110,14 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
       
         content = (InternalContent) taskService.getContentById(contentId);
         Object unmarshallObject = ContentMarshallerHelper.unmarshall(content.getContent(), null);
-        assertEquals("'singleobject'", unmarshallObject.toString());
+        Assertions.assertThat(unmarshallObject.toString()).isEqualTo("'singleobject'");
 
         // emails should not be set yet
-        assertEquals(0, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         countDownListener.waitTillCompleted();
 
         // 1 email with two recipients should now exist
-        assertEquals(1, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
-        
+        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(1);
 
     }
     @Test(timeout=10000)
@@ -166,16 +165,16 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         taskService.start(taskId, "Administrator");
         taskService.complete(taskId, "Administrator", null);
         // emails should not be set yet
-        assertEquals(0, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
 
         countDownListener.waitTillCompleted();
 
         // no email should ne sent as task was completed before deadline was triggered
-        assertEquals(0, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         task = (InternalTask) taskService.getTaskById(taskId);
-        assertEquals(Status.Completed, task.getTaskData().getStatus());
-        assertEquals(0, ((InternalTask) task).getDeadlines().getStartDeadlines().size());
-        assertEquals(0, ((InternalTask) task).getDeadlines().getEndDeadlines().size());
+        Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Completed);
+        Assertions.assertThat(((InternalTask) task).getDeadlines().getStartDeadlines().size()).isEqualTo(0);
+        Assertions.assertThat(((InternalTask) task).getDeadlines().getEndDeadlines().size()).isEqualTo(0);
         
         
     }
@@ -225,16 +224,16 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         taskService.start(taskId, "Administrator");
         taskService.fail(taskId, "Administrator", null);
         // emails should not be set yet
-        assertEquals(0, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         
         countDownListener.waitTillCompleted();
         
         // no email should ne sent as task was completed before deadline was triggered
-        assertEquals(0, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         task = (InternalTask) taskService.getTaskById(taskId);
-        assertEquals(Status.Failed, task.getTaskData().getStatus());
-        assertEquals(0, task.getDeadlines().getStartDeadlines().size());
-        assertEquals(0, task.getDeadlines().getEndDeadlines().size());
+        Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Failed);
+        Assertions.assertThat(task.getDeadlines().getStartDeadlines().size()).isEqualTo(0);
+        Assertions.assertThat(task.getDeadlines().getEndDeadlines().size()).isEqualTo(0);
     }
     
     @Test(timeout=10000)
@@ -280,16 +279,16 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         
         taskService.skip(taskId, "Administrator");
         // emails should not be set yet
-        assertEquals(0, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         
         countDownListener.waitTillCompleted();
 
         // no email should ne sent as task was completed before deadline was triggered
-        assertEquals(0, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         task = (InternalTask) taskService.getTaskById(taskId);
-        assertEquals(Status.Obsolete, task.getTaskData().getStatus());
-        assertEquals(0, task.getDeadlines().getStartDeadlines().size());
-        assertEquals(0, task.getDeadlines().getEndDeadlines().size());
+        Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Obsolete);
+        Assertions.assertThat(task.getDeadlines().getStartDeadlines().size()).isEqualTo(0);
+        Assertions.assertThat(task.getDeadlines().getEndDeadlines().size()).isEqualTo(0);
     }
     
     @Test(timeout=10000)   
@@ -335,16 +334,16 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         
         taskService.exit(taskId, "Administrator");
         // emails should not be set yet
-        assertEquals(0, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
 
         countDownListener.waitTillCompleted();
 
         // no email should ne sent as task was completed before deadline was triggered
-        assertEquals(0, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+        Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
         task = (InternalTask) taskService.getTaskById(taskId);
-        assertEquals(Status.Exited, task.getTaskData().getStatus());
-        assertEquals(0, task.getDeadlines().getStartDeadlines().size());
-        assertEquals(0, task.getDeadlines().getEndDeadlines().size());
+        Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Exited);
+        Assertions.assertThat(task.getDeadlines().getStartDeadlines().size()).isEqualTo(0);
+        Assertions.assertThat(task.getDeadlines().getEndDeadlines().size()).isEqualTo(0);
     }
 
 
@@ -367,22 +366,22 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
         for (OrganizationalEntity entity : potentialOwners) {
             ids.add(entity.getId());
         }
-        assertTrue(ids.contains("Tony Stark"));
-        assertTrue(ids.contains("Luke Cage"));
+        Assertions.assertThat(ids.contains("Tony Stark")).isTrue();
+        Assertions.assertThat(ids.contains("Luke Cage")).isTrue();
 
         // should have re-assigned by now
         countDownListener.waitTillCompleted();
         
         task = taskService.getTaskById(taskId);
-        assertEquals(Status.Ready, task.getTaskData().getStatus());
+        Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Ready);
         potentialOwners = (List<OrganizationalEntity>) task.getPeopleAssignments().getPotentialOwners();
 
         ids = new ArrayList<String>(potentialOwners.size());
         for (OrganizationalEntity entity : potentialOwners) {
             ids.add(entity.getId());
         }
-        assertTrue(ids.contains("Bobba Fet"));
-        assertTrue(ids.contains("Jabba Hutt"));
+        Assertions.assertThat(ids.contains("Bobba Fet")).isTrue();
+        Assertions.assertThat(ids.contains("Jabba Hutt")).isTrue();
     }
 
       @Test(timeout=10000)
@@ -438,30 +437,30 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
           checkContentSubjectAndBody(unmarshallObject);
 
           Calendar cal = Calendar.getInstance();
-          cal.add(Calendar.SECOND, 4);
+          cal.add(Calendar.SECOND, 5);
           task.getDeadlines().getStartDeadlines().get(0).setDate(cal.getTime());
           task2.getDeadlines().getStartDeadlines().get(0).setDate(cal.getTime());
 
           taskService.start(taskId, "Administrator");
           taskService.complete(taskId, "Administrator", null);
           // emails should not be set yet
-          assertEquals(0, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+          Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(0);
  
           countDownListener.waitTillCompleted();
 
           // no email should be sent as task was completed before deadline was triggered
-          assertEquals(1, ((MockNotificationListener)notificationListener).getEventsRecieved().size());
+          Assertions.assertThat(((MockNotificationListener)notificationListener).getEventsRecieved().size()).isEqualTo(1);
           task = (InternalTask) taskService.getTaskById(taskId);
-          assertEquals(Status.Completed, task.getTaskData().getStatus());
-          assertEquals(0, ((InternalTask) task).getDeadlines().getStartDeadlines().size());
-          assertEquals(0, ((InternalTask) task).getDeadlines().getEndDeadlines().size());
+          Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Completed);
+          Assertions.assertThat(((InternalTask) task).getDeadlines().getStartDeadlines().size()).isEqualTo(0);
+          Assertions.assertThat(((InternalTask) task).getDeadlines().getEndDeadlines().size()).isEqualTo(0);
           
           taskService.start(task2.getId(), "Administrator");
           taskService.complete(task2.getId(), "Administrator", null);
           
           task = (InternalTask) taskService.getTaskById(task2.getId());
-          assertEquals(Status.Completed, task.getTaskData().getStatus());
-          assertEquals(0, ((InternalTask) task).getDeadlines().getStartDeadlines().size());
-          assertEquals(0, ((InternalTask) task).getDeadlines().getEndDeadlines().size());
+          Assertions.assertThat(task.getTaskData().getStatus()).isEqualTo(Status.Completed);
+          Assertions.assertThat(((InternalTask) task).getDeadlines().getStartDeadlines().size()).isEqualTo(0);
+          Assertions.assertThat(((InternalTask) task).getDeadlines().getEndDeadlines().size()).isEqualTo(0);
       }
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/DeadlinesBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/DeadlinesBaseTest.java
@@ -21,11 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.jbpm.services.task.deadlines.NotificationListener;
 import org.jbpm.services.task.deadlines.notifications.impl.MockNotificationListener;
@@ -440,7 +436,12 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
           content = (InternalContent) taskService.getContentById(contentId);
           Object unmarshallObject = ContentMarshallerHelper.unmarshall(content.getContent(), null);
           checkContentSubjectAndBody(unmarshallObject);
-          
+
+          Calendar cal = Calendar.getInstance();
+          cal.add(Calendar.SECOND, 4);
+          task.getDeadlines().getStartDeadlines().get(0).setDate(cal.getTime());
+          task2.getDeadlines().getStartDeadlines().get(0).setDate(cal.getTime());
+
           taskService.start(taskId, "Administrator");
           taskService.complete(taskId, "Administrator", null);
           // emails should not be set yet


### PR DESCRIPTION
* tasks deadline dates are set just before the task start to avoid premature notification sending
* junit methods replaced by assertj