### PR TITLE
JBPM-6665 - Add 'before' TaskInputVariableChanged and TaskOutputVaria…

### DIFF
--- a/jbpm-human-task/jbpm-human-task-audit/src/main/java/org/jbpm/services/task/audit/JPATaskLifeCycleEventListener.java
+++ b/jbpm-human-task/jbpm-human-task-audit/src/main/java/org/jbpm/services/task/audit/JPATaskLifeCycleEventListener.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.persistence.EntityManagerFactory;
 
@@ -35,6 +36,7 @@ import org.jbpm.services.task.lifecycle.listeners.TaskLifeCycleEventListener;
 import org.jbpm.services.task.persistence.PersistableEventListener;
 import org.jbpm.services.task.utils.ClassUtil;
 import org.kie.api.task.TaskEvent;
+import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.Task;
 import org.kie.internal.task.api.TaskContext;
 import org.kie.internal.task.api.TaskPersistenceContext;
@@ -62,13 +64,11 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskStartedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
         try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+            
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.STARTED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId ));
                  
     
@@ -78,7 +78,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
                 return;
             }
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
         } finally {
@@ -88,13 +88,10 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskActivatedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
-        try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+        try {            
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.ACTIVATED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
                   
             AuditTaskImpl auditTaskImpl = getAuditTask(event, persistenceContext, ti);
@@ -103,7 +100,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
                 return;
             }
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             auditTaskImpl.setDescription(ti.getDescription());    
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
@@ -114,13 +111,10 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskClaimedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
-        try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+        try {            
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.CLAIMED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
             
             AuditTaskImpl auditTaskImpl = getAuditTask(event, persistenceContext, ti);
@@ -129,7 +123,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
                 return;
             }
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             auditTaskImpl.setDescription(ti.getDescription());
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
@@ -140,13 +134,10 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskSkippedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
-        try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+        try {            
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.SKIPPED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
            
             AuditTaskImpl auditTaskImpl = getAuditTask(event, persistenceContext, ti);
@@ -155,7 +146,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
                 return;
             }
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             auditTaskImpl.setDescription(ti.getDescription());
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
@@ -168,16 +159,12 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskStoppedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
-        try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+        try {            
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.STOPPED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
-            
-          
+                      
             AuditTaskImpl auditTaskImpl = getAuditTask(event, persistenceContext, ti);
             if (auditTaskImpl == null) {
                 logger.warn("Unable find audit task entry for task id {} '{}', skipping audit task update", ti.getId(), ti.getName());
@@ -185,7 +172,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
             }
             auditTaskImpl.setDescription(ti.getDescription());
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
         } finally {
@@ -196,15 +183,11 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskCompletedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
-        try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
-            persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.COMPLETED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
-    
+        try {            
+            persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.COMPLETED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));    
             
             AuditTaskImpl auditTaskImpl = getAuditTask(event, persistenceContext, ti);
             if (auditTaskImpl == null) {
@@ -212,7 +195,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
                 return;
             }
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
         } finally {
@@ -222,16 +205,11 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskFailedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
-        try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+        try {            
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.FAILED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
-            
-            
             
             AuditTaskImpl auditTaskImpl = getAuditTask(event, persistenceContext, ti);
             if (auditTaskImpl == null) {
@@ -239,7 +217,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
                 return;
             }
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
         } finally {
@@ -249,14 +227,12 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskAddedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
         try {
             if(ti.getTaskData().getProcessId() != null){
                 userId = ti.getTaskData().getProcessId();
-            }else if(ti.getTaskData().getActualOwner() != null){
-                userId = ti.getTaskData().getActualOwner().getId();
             }
             AuditTaskImpl auditTaskImpl = new AuditTaskImpl(
                 ti.getId(),
@@ -285,16 +261,11 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskExitedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
-        try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+        try {            
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.EXITED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
-            
-           
     
             AuditTaskImpl auditTaskImpl = getAuditTask(event, persistenceContext, ti);
             if (auditTaskImpl == null) {
@@ -308,7 +279,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
             auditTaskImpl.setPriority(ti.getPriority());
             auditTaskImpl.setDueDate(ti.getTaskData().getExpirationTime());
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
         } finally {
@@ -319,7 +290,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskReleasedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
         try {
@@ -329,10 +300,6 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
                 logger.warn("Unable find audit task entry for task id {} '{}', skipping audit task update", ti.getId(), ti.getName());
                 return;
             }
-
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
    
             auditTaskImpl.setDescription(ti.getDescription());
             auditTaskImpl.setName(ti.getName());  
@@ -340,7 +307,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
             auditTaskImpl.setPriority(ti.getPriority());
             auditTaskImpl.setDueDate(ti.getTaskData().getExpirationTime());
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
         } finally {
@@ -351,13 +318,10 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskResumedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
-        try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+        try {            
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.RESUMED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
     
             
@@ -372,7 +336,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
             auditTaskImpl.setPriority(ti.getPriority());
             auditTaskImpl.setDueDate(ti.getTaskData().getExpirationTime());
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
         } finally {
@@ -382,13 +346,11 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskSuspendedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
         try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+            
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.SUSPENDED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
     
             AuditTaskImpl auditTaskImpl = getAuditTask(event, persistenceContext, ti);
@@ -402,7 +364,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
             auditTaskImpl.setPriority(ti.getPriority());
             auditTaskImpl.setDueDate(ti.getTaskData().getExpirationTime());
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
         } finally {
@@ -412,13 +374,10 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskForwardedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
         try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.FORWARDED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
     
     
@@ -433,7 +392,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
             auditTaskImpl.setPriority(ti.getPriority());
             auditTaskImpl.setDueDate(ti.getTaskData().getExpirationTime());
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
         } finally {
@@ -443,13 +402,10 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskDelegatedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
-        try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+        try {           
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.DELEGATED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
             
     
@@ -464,7 +420,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
             auditTaskImpl.setPriority(ti.getPriority());
             auditTaskImpl.setDueDate(ti.getTaskData().getExpirationTime());
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
         } finally {
@@ -474,13 +430,10 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
     
     @Override
     public void afterTaskNominatedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
-        try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+        try {           
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.NOMINATED, userId, new Date()));
     
             AuditTaskImpl auditTaskImpl = getAuditTask(event, persistenceContext, ti);
@@ -494,7 +447,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
             auditTaskImpl.setPriority(ti.getPriority());
             auditTaskImpl.setDueDate(ti.getTaskData().getExpirationTime());
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
         } finally {
@@ -565,13 +518,10 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void beforeTaskReleasedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
-        try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+        try {            
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.RELEASED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
           
         } finally {
@@ -634,11 +584,9 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskUpdatedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
-        if (ti.getTaskData().getActualOwner() != null) {
-            userId = ti.getTaskData().getActualOwner().getId();
-        }
+        
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
         try {
             
@@ -708,13 +656,11 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskReassignedEvent(TaskEvent event) {
-        String userId = "";
+        String userId = event.getTaskContext().getUserId();
         Task ti = event.getTask();
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
         try {
-            if (ti.getTaskData().getActualOwner() != null) {
-                userId = ti.getTaskData().getActualOwner().getId();
-            }
+           
             persistenceContext.persist(new TaskEventImpl(ti.getId(), org.kie.internal.task.api.model.TaskEvent.TaskEventType.DELEGATED, ti.getTaskData().getProcessInstanceId(), ti.getTaskData().getWorkItemId(), userId));
             
     
@@ -729,7 +675,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
             auditTaskImpl.setPriority(ti.getPriority());
             auditTaskImpl.setDueDate(ti.getTaskData().getExpirationTime());
             auditTaskImpl.setStatus(ti.getTaskData().getStatus().name());
-            auditTaskImpl.setActualOwner(userId);
+            auditTaskImpl.setActualOwner(getActualOwner(ti));
             updateLastModifiedDate(auditTaskImpl);
             persistenceContext.merge(auditTaskImpl);
         } finally {
@@ -749,7 +695,7 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
 
     @Override
     public void afterTaskOutputVariableChangedEvent(TaskEvent event, Map<String, Object> variables) {
-
+        String userId = event.getTaskContext().getUserId();
         Task task = event.getTask();        
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
         // first cleanup previous values if any
@@ -764,6 +710,19 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
         }
         
         indexAndPersistVariables(task, variables, persistenceContext, VariableType.OUTPUT);
+        String message = "Task output data updated";
+        persistenceContext.persist(new TaskEventImpl(task.getId(), 
+                                                     org.kie.internal.task.api.model.TaskEvent.TaskEventType.UPDATED, 
+                                                     task.getTaskData().getProcessInstanceId(), 
+                                                     task.getTaskData().getWorkItemId(), 
+                                                     userId, message));
+        AuditTaskImpl auditTaskImpl = getAuditTask(event, persistenceContext, task);
+        if (auditTaskImpl == null) {
+            logger.warn("Unable find audit task entry for task id {} '{}', skipping audit task update", task.getId(), task.getName());
+            return;
+        }
+        updateLastModifiedDate(auditTaskImpl);
+        persistenceContext.merge(auditTaskImpl);
     }
 
     @Override
@@ -771,11 +730,11 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
         if (variables == null || variables.isEmpty()) {
             return;
         }
-        
         Task task = event.getTask();        
         TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
 
         indexAndPersistVariables(task, variables, persistenceContext, VariableType.INPUT);
+        
     }
     
     protected void indexAndPersistVariables(Task task, Map<String, Object> variables, TaskPersistenceContext persistenceContext, VariableType type) {
@@ -796,8 +755,60 @@ public class JPATaskLifeCycleEventListener extends PersistableEventListener impl
         }
     }
     
+    @Override
+    public void afterTaskAssignmentsAddedEvent(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities) {                
+        assignmentsUpadted(event, type, entities, "] have been added");    
+    }
+
+    @Override
+    public void afterTaskAssignmentsRemovedEvent(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities) {
+        assignmentsUpadted(event, type, entities, "] have been removed");
+    }
+    
+    protected void assignmentsUpadted(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities, String messageSufix) {
+        if (entities == null || entities.isEmpty()) {
+            return;
+        }
+        String userId = event.getTaskContext().getUserId();
+        Task task = event.getTask();        
+        TaskPersistenceContext persistenceContext = getPersistenceContext(((TaskContext)event.getTaskContext()).getPersistenceContext());
+        StringBuilder message = new StringBuilder();
+        
+        switch (type) {
+            case POT_OWNER:
+                message.append("Potential owners [");
+                break;
+            case EXCL_OWNER:
+                message.append("Excluded owners [");
+                break;
+            case ADMIN:
+                message.append("Business administrators [");
+                break;
+            default:
+                break;
+        }
+        String entitiesAsString = entities.stream().map(oe -> oe.getId()).collect(Collectors.joining(","));
+        message.append(entitiesAsString);
+        message.append(messageSufix);
+        
+        persistenceContext.persist(new TaskEventImpl(task.getId(), 
+                                                     org.kie.internal.task.api.model.TaskEvent.TaskEventType.UPDATED, 
+                                                     task.getTaskData().getProcessInstanceId(), 
+                                                     task.getTaskData().getWorkItemId(), 
+                                                     userId, message.toString()));
+    }
+
     private void updateLastModifiedDate(AuditTaskImpl auditTaskImpl){
         auditTaskImpl.setLastModificationDate(new Date());
+    }
+    
+    protected String getActualOwner(Task ti) {
+        String userId = "";
+        if (ti.getTaskData().getActualOwner() != null) {
+            userId = ti.getTaskData().getActualOwner().getId();
+        }
+        
+        return userId;
     }
 
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/commands/TaskContext.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/commands/TaskContext.java
@@ -61,6 +61,8 @@ public class TaskContext implements org.kie.internal.task.api.TaskContext, Reque
     
     private org.kie.internal.task.api.TaskContext delegate;
     
+    private String userId;
+    
     public TaskContext() {
     }   
     
@@ -210,5 +212,14 @@ public class TaskContext implements org.kie.internal.task.api.TaskContext, Reque
     @Override
     public Context getApplicationContext() {
         throw new UnsupportedOperationException("Not supported for this type of context.");
+    }
+
+    @Override
+    public String getUserId() {
+        return userId;
+    }
+    
+    public void setUserId(String userId) {
+        this.userId = userId;
     }
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/events/TaskEventSupport.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/events/TaskEventSupport.java
@@ -17,10 +17,13 @@
 package org.jbpm.services.task.events;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import org.drools.core.event.AbstractEventSupport;
 import org.kie.api.task.TaskLifeCycleEventListener;
+import org.kie.api.task.TaskLifeCycleEventListener.AssignmentType;
+import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.Task;
 import org.kie.internal.task.api.TaskContext;
 
@@ -188,6 +191,47 @@ public class TaskEventSupport extends AbstractEventSupport<TaskLifeCycleEventLis
             do{
                 TaskLifeCycleEventListener listener = iter.next();
                 listener.beforeTaskNominatedEvent(new TaskEventImpl(task, context));
+            } while (iter.hasNext());
+        }
+    }
+    
+    public void fireBeforeTaskInputVariablesChanged(final Task task, TaskContext context, Map<String, Object> variables) {
+        final Iterator<TaskLifeCycleEventListener> iter = getEventListenersIterator();
+        if (iter.hasNext()) {
+            do{
+                TaskLifeCycleEventListener listener = iter.next();
+                listener.beforeTaskInputVariableChangedEvent(new TaskEventImpl(task, context), variables);                
+            } while (iter.hasNext());
+        }
+    }
+    
+    
+    public void fireBeforeTaskOutputVariablesChanged(final Task task, TaskContext context, Map<String, Object> variables) {
+        final Iterator<TaskLifeCycleEventListener> iter = getEventListenersIterator();
+        if (iter.hasNext()) {
+            do{
+                TaskLifeCycleEventListener listener = iter.next();
+                listener.beforeTaskOutputVariableChangedEvent(new TaskEventImpl(task, context), variables);                
+            } while (iter.hasNext());
+        }
+    }
+    
+    public void fireBeforeTaskAssignmentsAddedEvent(final Task task, TaskContext context, AssignmentType type, List<OrganizationalEntity> entities) {
+        final Iterator<TaskLifeCycleEventListener> iter = getEventListenersIterator();
+        if (iter.hasNext()) {
+            do{
+                TaskLifeCycleEventListener listener = iter.next();
+                listener.beforeTaskAssignmentsAddedEvent(new TaskEventImpl(task, context), type, entities);                
+            } while (iter.hasNext());
+        }
+    }
+    
+    public void fireBeforeTaskAssignmentsRemovedEvent(final Task task, TaskContext context, AssignmentType type, List<OrganizationalEntity> entities) {
+        final Iterator<TaskLifeCycleEventListener> iter = getEventListenersIterator();
+        if (iter.hasNext()) {
+            do{
+                TaskLifeCycleEventListener listener = iter.next();
+                listener.beforeTaskAssignmentsRemovedEvent(new TaskEventImpl(task, context), type, entities);                
             } while (iter.hasNext());
         }
     }
@@ -377,6 +421,26 @@ public class TaskEventSupport extends AbstractEventSupport<TaskLifeCycleEventLis
             do{
                 TaskLifeCycleEventListener listener = iter.next();
                 listener.afterTaskOutputVariableChangedEvent(new TaskEventImpl(task, context), variables);                
+            } while (iter.hasNext());
+        }
+    }
+    
+    public void fireAfterTaskAssignmentsAddedEvent(final Task task, TaskContext context, AssignmentType type, List<OrganizationalEntity> entities) {
+        final Iterator<TaskLifeCycleEventListener> iter = getEventListenersIterator();
+        if (iter.hasNext()) {
+            do{
+                TaskLifeCycleEventListener listener = iter.next();
+                listener.afterTaskAssignmentsAddedEvent(new TaskEventImpl(task, context), type, entities);                
+            } while (iter.hasNext());
+        }
+    }
+    
+    public void fireAfterTaskAssignmentsRemovedEvent(final Task task, TaskContext context, AssignmentType type, List<OrganizationalEntity> entities) {
+        final Iterator<TaskLifeCycleEventListener> iter = getEventListenersIterator();
+        if (iter.hasNext()) {
+            do{
+                TaskLifeCycleEventListener listener = iter.next();
+                listener.afterTaskAssignmentsRemovedEvent(new TaskEventImpl(task, context), type, entities);                
             } while (iter.hasNext());
         }
     }

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/persistence/TaskTransactionInterceptor.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/persistence/TaskTransactionInterceptor.java
@@ -122,7 +122,8 @@ public class TaskTransactionInterceptor extends AbstractInterceptor {
 
 	public class TransactionContext implements TaskContext, RequestContext {
 		private final TaskPersistenceContext persistenceContext;
-
+		private String userId;
+		
 		public TransactionContext( TaskPersistenceContext persistenceContext ) {
 			this.persistenceContext = persistenceContext;
 		}
@@ -204,6 +205,14 @@ public class TaskTransactionInterceptor extends AbstractInterceptor {
 
 		}
 
+	    @Override
+	    public String getUserId() {
+	        return userId;
+	    }
+	    
+	    public void setUserId(String userId) {
+	        this.userId = userId;
+	    }
 	}
 	
 	public void initTransactionManager(Environment env) {

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/KModuleDeploymentService.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/KModuleDeploymentService.java
@@ -301,6 +301,9 @@ public class KModuleDeploymentService extends AbstractDeploymentService {
 		if (executorService != null) {
 		    builder.addEnvironmentEntry("ExecutorService", executorService);
 		}
+		if (identityProvider != null) {
+            builder.addEnvironmentEntry(EnvironmentName.IDENTITY_PROVIDER, identityProvider);
+        }
 		// populate all assets with roles for this deployment unit
 		List<String> requiredRoles = descriptor.getRequiredRoles(DeploymentDescriptor.TYPE_VIEW);
 		if (requiredRoles != null && !requiredRoles.isEmpty()) {

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/admin/commands/UpdateTaskCommand.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/admin/commands/UpdateTaskCommand.java
@@ -70,6 +70,7 @@ public class UpdateTaskCommand extends UserGroupCallbackTaskCommand<Void> {
                 && !isOwner(userId, task.getPeopleAssignments().getPotentialOwners(), task.getTaskData().getActualOwner(), context)) {
             throw new PermissionDeniedException("User " + userId + " is not business admin or potential owner of task " + taskId);
         }
+        taskEventSupport.fireBeforeTaskUpdated(task, context);
         
         // process task meta data
         if (userTask.getFormName() != null) {

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/admin/UserTaskAdminServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/admin/UserTaskAdminServiceImplTest.java
@@ -16,6 +16,8 @@
 
 package org.jbpm.kie.services.impl.admin;
 
+import static org.kie.scanner.KieMavenRepository.getKieMavenRepository;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
@@ -52,11 +54,10 @@ import org.kie.internal.runtime.conf.ObjectModel;
 import org.kie.internal.task.api.TaskModelFactory;
 import org.kie.internal.task.api.TaskModelProvider;
 import org.kie.internal.task.api.model.EmailNotification;
+import org.kie.internal.task.api.model.TaskEvent;
 import org.kie.scanner.KieMavenRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.kie.scanner.KieMavenRepository.getKieMavenRepository;
 
 public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
 
@@ -217,6 +218,11 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         
         userTaskAdminService.addPotentialOwners(task.getId(), false, factory.newUser("john"));
         
+        List<TaskEvent> events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
+        Assertions.assertThat(events).hasSize(3);
+        TaskEvent updatedEvent = events.get(2);
+        Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Potential owners [john] have been added");
+        
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("salaboy", new QueryFilter());
         Assertions.assertThat(tasks).hasSize(1);
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("john", new QueryFilter());
@@ -241,6 +247,10 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         userTaskService.release(task.getId(), "salaboy");
         
         userTaskAdminService.addExcludedOwners(task.getId(), false, factory.newUser("salaboy"));
+        List<TaskEvent> events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
+        Assertions.assertThat(events).hasSize(3);
+        TaskEvent updatedEvent = events.get(2);
+        Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Excluded owners [salaboy] have been added");
         
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("salaboy", new QueryFilter());
         Assertions.assertThat(tasks).hasSize(0);
@@ -269,6 +279,10 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         Assertions.assertThat(tasks).hasSize(0);
         
         userTaskAdminService.addBusinessAdmins(task.getId(), false, factory.newUser("salaboy"));
+        List<TaskEvent> events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
+        Assertions.assertThat(events).hasSize(3);
+        TaskEvent updatedEvent = events.get(2);
+        Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Business administrators [salaboy] have been added");
         
         tasks = runtimeDataService.getTasksAssignedAsBusinessAdministrator("salaboy", new QueryFilter());
         Assertions.assertThat(tasks).hasSize(1);
@@ -294,6 +308,10 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         userTaskService.release(task.getId(), "salaboy");
         
         userTaskAdminService.removePotentialOwners(task.getId(), factory.newUser("salaboy"));
+        List<TaskEvent> events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
+        Assertions.assertThat(events).hasSize(3);
+        TaskEvent updatedEvent = events.get(2);
+        Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Potential owners [salaboy] have been removed");
         
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("salaboy", new QueryFilter());
         Assertions.assertThat(tasks).hasSize(0);
@@ -310,11 +328,21 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         
         userTaskService.release(task.getId(), "salaboy");
         
-        userTaskAdminService.addExcludedOwners(task.getId(), false, factory.newUser("salaboy"));        
+        userTaskAdminService.addExcludedOwners(task.getId(), false, factory.newUser("salaboy"));
+        List<TaskEvent> events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
+        Assertions.assertThat(events).hasSize(3);
+        TaskEvent updatedEvent = events.get(2);
+        Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Excluded owners [salaboy] have been added");
+        
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("salaboy", new QueryFilter());
         Assertions.assertThat(tasks).hasSize(0);
         
         userTaskAdminService.removeExcludedOwners(task.getId(), factory.newUser("salaboy"));
+        events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
+        Assertions.assertThat(events).hasSize(4);
+        updatedEvent = events.get(3);
+        Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Excluded owners [salaboy] have been removed");
+        
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("salaboy", new QueryFilter());
         Assertions.assertThat(tasks).hasSize(1);
     }
@@ -329,6 +357,10 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         TaskSummary task = tasks.get(0);
         
         userTaskAdminService.removeBusinessAdmins(task.getId(), factory.newUser("Administrator"));
+        List<TaskEvent> events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
+        Assertions.assertThat(events).hasSize(2);
+        TaskEvent updatedEvent = events.get(1);
+        Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Business administrators [Administrator] have been removed");
 
         List<Status> readyStatuses = Arrays.asList(new Status[]{
                 org.kie.api.task.model.Status.Ready

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/UserTaskServiceCDIImplTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/UserTaskServiceCDIImplTest.java
@@ -24,6 +24,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jbpm.kie.services.test.TestIdentityProvider;
 import org.jbpm.kie.services.test.UserTaskServiceImplTest;
 import org.jbpm.services.api.DefinitionService;
 import org.jbpm.services.api.DeploymentService;
@@ -33,7 +34,9 @@ import org.jbpm.services.api.UserTaskService;
 import org.jbpm.shared.services.impl.TransactionalCommandService;
 import org.jbpm.shared.services.impl.commands.UpdateStringCommand;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.kie.internal.identity.IdentityProvider;
 
 @RunWith(Arquillian.class)
 public class UserTaskServiceCDIImplTest extends UserTaskServiceImplTest {
@@ -158,6 +161,12 @@ public class UserTaskServiceCDIImplTest extends UserTaskServiceImplTest {
 	public void setUserTaskService(UserTaskService userTaskService) {
 		
 		super.setUserTaskService(userTaskService);
+	}
+	
+	@Inject
+	public void setIdentityProvider(TestIdentityProvider identityProvider) {
+	    this.identityProvider = identityProvider;
+	    
 	}
 	
 	@After


### PR DESCRIPTION
…bleChanged events to TaskLifeCycleEventListener

depends on https://github.com/kiegroup/droolsjbpm-knowledge/pull/281

@krisv @mcivantos-tribalyte  here is a PR that introduces task event to be updated when data change, before and after data change and user id to always be available, either from the task command or from security context if none was found on command. That way task events have always some user id attached.