### PR TITLE
Remove duplicated jaxb-core dependency declaration

### DIFF
--- a/jbpm-workitems/jbpm-workitems-bpmn2/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/pom.xml
@@ -137,11 +137,6 @@
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-xjc</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
This removes duplicated dependency which is already declared in this pom with default (compile) scope, which also makes that artifact available on test classpath. I've got a PR https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/639 pending to prevent this kind of duplicated dependency declaration which depends on this PR being merged.