### PR TITLE
JBPM-6720 - Test AsyncIntermediateCatchSignalTest.testCorrectProcessS…

### DIFF
--- a/jbpm-test-coverage/src/main/java/org/jbpm/test/wih/FirstErrorWorkItemHandler.java
+++ b/jbpm-test-coverage/src/main/java/org/jbpm/test/wih/FirstErrorWorkItemHandler.java
@@ -16,7 +16,9 @@
 
 package org.jbpm.test.wih;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemHandler;
@@ -24,15 +26,17 @@ import org.kie.api.runtime.process.WorkItemManager;
 
 public class FirstErrorWorkItemHandler implements WorkItemHandler {
 
-    private boolean first = false;
+    private List<Long> processedWorkItems = new ArrayList<Long>();
 
     @Override
     public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
-        first = !first;
-        if (first) {
+        long processInstanceId = workItem.getProcessInstanceId();
+        if (!processedWorkItems.contains(processInstanceId)) {
+            processedWorkItems.add(processInstanceId);
             throw new RuntimeException("Error");
         }
         manager.completeWorkItem(workItem.getId(), new HashMap<String, Object>());
+        processedWorkItems.remove(processInstanceId);
     }
 
     @Override

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/async/AsyncIntermediateCatchSignalTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/async/AsyncIntermediateCatchSignalTest.java
@@ -25,7 +25,6 @@ import org.jbpm.test.JbpmTestCase;
 import org.jbpm.test.wih.FirstErrorWorkItemHandler;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.event.process.DefaultProcessEventListener;
 import org.kie.api.event.process.ProcessCompletedEvent;
@@ -55,7 +54,6 @@ public class AsyncIntermediateCatchSignalTest extends JbpmTestCase {
         executorService = ExecutorServiceFactory.newExecutorService(getEmf());
         executorService.setInterval(1);
         executorService.setThreadPoolSize(3);
-        executorService.init();
         addEnvironmentEntry("ExecutorService", executorService);
         addWorkItemHandler("SyncError", new FirstErrorWorkItemHandler());
         addProcessEventListener(new DefaultProcessEventListener() {
@@ -64,6 +62,7 @@ public class AsyncIntermediateCatchSignalTest extends JbpmTestCase {
                 latch.countDown();
             }
         });
+        executorService.init();
     }
 
     @After
@@ -92,20 +91,20 @@ public class AsyncIntermediateCatchSignalTest extends JbpmTestCase {
         latch.await();
     }
 
-    @Ignore("JBPM-6720 Possible jBPM bug, test fails randomly. Ignored till resolved.")
+    
     @Test(timeout = 20000)
     public void testCorrectProcessStateAfterExceptionSignalCommandMulti() throws InterruptedException {
         latch = new CountDownLatch(5);
         RuntimeManager runtimeManager = createRuntimeManager(BPMN_AICS);
         KieSession ksession = getRuntimeEngine().getKieSession();
         long[] pid = new long[5];
-        for (int i = 0; i < 5; ++i) {
+        for (int i = 0; i < 5; i++) {
             ProcessInstance pi = ksession.startProcess(PROCESS_AICS, null);
             pid[i] = pi.getId();
 
             CommandContext ctx = new CommandContext();
             ctx.setData("DeploymentId", runtimeManager.getIdentifier());
-            ctx.setData("ProcessInstanceId", pid[i]);
+            ctx.setData("ProcessInstanceId", pi.getId());
             ctx.setData("Signal", "MySignal");
             ctx.setData("Event", null);
 


### PR DESCRIPTION
…tateAfterExceptionSignalCommandMulti fails randomly

@baldimir do you mind to take a look?

In general the problem was with work item handler that assumed that calls to the executeWorkItem method will go in sync for given process instance while it is not really the case as executor can pick any job and thus it led to execution of same process instance twice in a roll and thus not completing the other instance that was tried next as it set the first back to true.