### PR TITLE
JBPM-6713 - Fluent Rule Flow API - signal example

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ProcessFactoryTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ProcessFactoryTest.java
@@ -21,67 +21,79 @@ import org.jbpm.persistence.session.objects.TestWorkItemHandler;
 import org.jbpm.ruleflow.core.RuleFlowProcess;
 import org.jbpm.ruleflow.core.RuleFlowProcessFactory;
 import org.jbpm.test.listener.NodeLeftCountDownProcessEventListener;
+
 import org.junit.Test;
-import org.kie.internal.io.ResourceFactory;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
+
 import org.kie.api.KieBase;
 import org.kie.api.io.Resource;
 import org.kie.api.runtime.process.ProcessInstance;
 
+import org.kie.internal.io.ResourceFactory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
 import static org.junit.Assert.*;
 
 public class ProcessFactoryTest extends JbpmBpmn2TestCase {
-    
+
     public ProcessFactoryTest() {
         super(false);
     }
 
     @Test
-	public void testProcessFactory() throws Exception {
-		RuleFlowProcessFactory factory = RuleFlowProcessFactory.createProcess("org.jbpm.process");
-		factory
-			// header
-			.name("My process").packageName("org.jbpm")
-			// nodes
-			.startNode(1).name("Start").done()
-			.actionNode(2).name("Action")
-				.action("java", "System.out.println(\"Action\");").done()
-			.endNode(3).name("End").done()
-			// connections
-			.connection(1, 2)
-			.connection(2, 3);
-		RuleFlowProcess process = factory.validate().getProcess();
-		Resource res = ResourceFactory.newByteArrayResource(XmlBPMNProcessDumper.INSTANCE.dump(process).getBytes());
-		res.setSourcePath("/tmp/processFactory.bpmn2"); // source path or target path must be set to be added into kbase
-		KieBase kbase = createKnowledgeBaseFromResources(res);
-		StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-		ksession.startProcess("org.jbpm.process");
-		ksession.dispose();
-	}
+    public void testProcessFactory() throws Exception {
+        RuleFlowProcessFactory factory = RuleFlowProcessFactory.createProcess("org.jbpm.process");
+        factory
+                // header
+                .name("My process").packageName("org.jbpm")
+                // nodes
+                .startNode(1).name("Start").done()
+                .actionNode(2).name("Action")
+                .action("java",
+                        "System.out.println(\"Action\");").done()
+                .endNode(3).name("End").done()
+                // connections
+                .connection(1,
+                            2)
+                .connection(2,
+                            3);
+        RuleFlowProcess process = factory.validate().getProcess();
+        Resource res = ResourceFactory.newByteArrayResource(XmlBPMNProcessDumper.INSTANCE.dump(process).getBytes());
+        res.setSourcePath("/tmp/processFactory.bpmn2"); // source path or target path must be set to be added into kbase
+        KieBase kbase = createKnowledgeBaseFromResources(res);
+        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
+        ksession.startProcess("org.jbpm.process");
+        ksession.dispose();
+    }
 
     @Test
     public void testCompositeNode() throws Exception {
         RuleFlowProcessFactory factory = RuleFlowProcessFactory.createProcess("org.jbpm.process");
         factory
-            // header
-            .name("My process").packageName("org.jbpm")
-            // nodes
-            .startNode(1).name("Start").done()
-            .compositeNode(2)
+                // header
+                .name("My process").packageName("org.jbpm")
+                // nodes
+                .startNode(1).name("Start").done()
+                .compositeNode(2)
                 .name("SubProcess")
                 .startNode(1).name("SubProcess Start").done()
-                .actionNode(2).name("SubProcess Action").action("java", "System.out.println(\"SubProcess Action\");").done()
+                .actionNode(2).name("SubProcess Action").action("java",
+                                                                "System.out.println(\"SubProcess Action\");").done()
                 .endNode(3).name("SubProcess End").terminate(true).done()
-                .connection(1, 2)
-                .connection(2, 3)
+                .connection(1,
+                            2)
+                .connection(2,
+                            3)
                 .done()
-            .endNode(3).name("End").done()
-            // connections
-            .connection(1, 2)
-            .connection(2, 3);
+                .endNode(3).name("End").done()
+                // connections
+                .connection(1,
+                            2)
+                .connection(2,
+                            3);
         RuleFlowProcess process = factory.validate().getProcess();
 
-        assertEquals("SubProcess", process.getNode(2).getName());
+        assertEquals("SubProcess",
+                     process.getNode(2).getName());
 
         Resource res = ResourceFactory.newByteArrayResource(XmlBPMNProcessDumper.INSTANCE.dump(process).getBytes());
         res.setSourcePath("/tmp/processFactory.bpmn2"); // source path or target path must be set to be added into kbase
@@ -89,28 +101,33 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
         StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
         ProcessInstance pi = ksession.startProcess("org.jbpm.process");
 
-        assertEquals(ProcessInstance.STATE_COMPLETED, pi.getState());
+        assertEquals(ProcessInstance.STATE_COMPLETED,
+                     pi.getState());
 
         ksession.dispose();
     }
 
-    @Test(timeout=10000)
+    @Test(timeout = 10000)
     public void testBoundaryTimerTimeCycle() throws Exception {
-        NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("BoundaryTimerEvent", 1);
+        NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("BoundaryTimerEvent",
+                                                                                                            1);
         RuleFlowProcessFactory factory = RuleFlowProcessFactory.createProcess("org.jbpm.process");
         factory
-            // header
-            .name("My process").packageName("org.jbpm")
-            // nodes
-            .startNode(1).name("Start").done()
-            .humanTaskNode(2).name("Task").actorId("john").taskName("MyTask").done()
-            .endNode(3).name("End1").terminate(false).done()
-            .boundaryEventNode(4).name("BoundaryTimerEvent").attachedTo(2).timeCycle("1s###5s").cancelActivity(false).done()
-            .endNode(5).name("End2").terminate(false).done()
-            // connections
-            .connection(1, 2)
-            .connection(2, 3)
-            .connection(4, 5);
+                // header
+                .name("My process").packageName("org.jbpm")
+                // nodes
+                .startNode(1).name("Start").done()
+                .humanTaskNode(2).name("Task").actorId("john").taskName("MyTask").done()
+                .endNode(3).name("End1").terminate(false).done()
+                .boundaryEventNode(4).name("BoundaryTimerEvent").attachedTo(2).timeCycle("1s###5s").cancelActivity(false).done()
+                .endNode(5).name("End2").terminate(false).done()
+                // connections
+                .connection(1,
+                            2)
+                .connection(2,
+                            3)
+                .connection(4,
+                            5);
         RuleFlowProcess process = factory.validate().getProcess();
 
         Resource res = ResourceFactory.newByteArrayResource(XmlBPMNProcessDumper.INSTANCE.dump(process).getBytes());
@@ -118,7 +135,8 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
         KieBase kbase = createKnowledgeBaseFromResources(res);
         StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
         TestWorkItemHandler testHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", testHandler);
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+                                                              testHandler);
         ksession.addEventListener(countDownListener);
 
         ProcessInstance pi = ksession.startProcess("org.jbpm.process");
@@ -126,32 +144,38 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
 
         countDownListener.waitTillCompleted(); // wait for boundary timer firing
 
-        assertNodeTriggered(pi.getId(), "End2");
+        assertNodeTriggered(pi.getId(),
+                            "End2");
         assertProcessInstanceActive(pi); // still active because CancelActivity = false
 
-        ksession.getWorkItemManager().completeWorkItem(testHandler.getWorkItem().getId(), null);
+        ksession.getWorkItemManager().completeWorkItem(testHandler.getWorkItem().getId(),
+                                                       null);
         assertProcessInstanceCompleted(pi);
 
         ksession.dispose();
     }
 
-    @Test(timeout=10000)
+    @Test(timeout = 10000)
     public void testBoundaryTimerTimeDuration() throws Exception {
-        NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("BoundaryTimerEvent", 1);
+        NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("BoundaryTimerEvent",
+                                                                                                            1);
         RuleFlowProcessFactory factory = RuleFlowProcessFactory.createProcess("org.jbpm.process");
         factory
-            // header
-            .name("My process").packageName("org.jbpm")
-            // nodes
-            .startNode(1).name("Start").done()
-            .humanTaskNode(2).name("Task").actorId("john").taskName("MyTask").done()
-            .endNode(3).name("End1").terminate(false).done()
-            .boundaryEventNode(4).name("BoundaryTimerEvent").attachedTo(2).timeDuration("1s").cancelActivity(false).done()
-            .endNode(5).name("End2").terminate(false).done()
-            // connections
-            .connection(1, 2)
-            .connection(2, 3)
-            .connection(4, 5);
+                // header
+                .name("My process").packageName("org.jbpm")
+                // nodes
+                .startNode(1).name("Start").done()
+                .humanTaskNode(2).name("Task").actorId("john").taskName("MyTask").done()
+                .endNode(3).name("End1").terminate(false).done()
+                .boundaryEventNode(4).name("BoundaryTimerEvent").attachedTo(2).timeDuration("1s").cancelActivity(false).done()
+                .endNode(5).name("End2").terminate(false).done()
+                // connections
+                .connection(1,
+                            2)
+                .connection(2,
+                            3)
+                .connection(4,
+                            5);
         RuleFlowProcess process = factory.validate().getProcess();
 
         Resource res = ResourceFactory.newByteArrayResource(XmlBPMNProcessDumper.INSTANCE.dump(process).getBytes());
@@ -159,7 +183,8 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
         KieBase kbase = createKnowledgeBaseFromResources(res);
         StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
         TestWorkItemHandler testHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", testHandler);
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+                                                              testHandler);
         ksession.addEventListener(countDownListener);
 
         ProcessInstance pi = ksession.startProcess("org.jbpm.process");
@@ -167,11 +192,70 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
 
         countDownListener.waitTillCompleted(); // wait for boundary timer firing
 
-        assertNodeTriggered(pi.getId(), "End2");
+        assertNodeTriggered(pi.getId(),
+                            "End2");
         assertProcessInstanceActive(pi); // still active because CancelActivity = false
 
-        ksession.getWorkItemManager().completeWorkItem(testHandler.getWorkItem().getId(), null);
+        ksession.getWorkItemManager().completeWorkItem(testHandler.getWorkItem().getId(),
+                                                       null);
         assertProcessInstanceCompleted(pi);
+
+        ksession.dispose();
+    }
+
+    @Test(timeout = 10000)
+    public void testAdHocSimple() throws Exception {
+        RuleFlowProcessFactory factory = RuleFlowProcessFactory.createProcess("org.jbpm.process");
+        factory
+                .dynamic(true)
+                .name("Event Process")
+                .version("1")
+                .packageName("org.jbpm");
+        RuleFlowProcess process = factory.validate().getProcess();
+        assertNotNull(process);
+        assertTrue(process.isDynamic());
+    }
+
+    @Test(timeout = 10000)
+    public void testSignalEvent() throws Exception {
+        RuleFlowProcessFactory factory = RuleFlowProcessFactory.createProcess("org.jbpm.process");
+        factory
+                .name("Event Process")
+                .version("1")
+                .packageName("org.jbpm")
+                .variable("eventData",
+                          new org.jbpm.process.core.datatype.impl.type.StringDataType())
+                .startNode(1).name("Start").done()
+                .eventNode(2).name("Event1").eventType("testEvent").variableName("eventData").done()
+                .actionNode(3).name("simpleActionNode").action("java",
+                                                               "System.out.println(\"test event action\");").done()
+                .endNode(4).name("End").done()
+                .connection(1,
+                            2)
+                .connection(2,
+                            3)
+                .connection(3,
+                            4);
+        RuleFlowProcess process = factory.validate().getProcess();
+
+        assertNotNull(process);
+
+        Resource res = ResourceFactory.newByteArrayResource(XmlBPMNProcessDumper.INSTANCE.dump(process).getBytes());
+        res.setSourcePath("/tmp/processFactory.bpmn2"); // source path or target path must be set to be added into kbase
+        KieBase kbase = createKnowledgeBaseFromResources(res);
+        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
+        ProcessInstance pi = ksession.startProcess("org.jbpm.process");
+
+        assertNotNull(pi);
+
+        assertEquals(ProcessInstance.STATE_ACTIVE,
+                     pi.getState());
+
+        pi.signalEvent("testEvent",
+                       null);
+
+        assertEquals(ProcessInstance.STATE_COMPLETED,
+                     pi.getState());
 
         ksession.dispose();
     }

--- a/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/RuleFlowProcessFactory.java
+++ b/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/RuleFlowProcessFactory.java
@@ -55,6 +55,11 @@ public class RuleFlowProcessFactory extends RuleFlowNodeContainerFactory {
         return this;
     }
 
+    public RuleFlowProcessFactory dynamic(boolean dynamic) {
+        getRuleFlowProcess().setDynamic(dynamic);
+        return this;
+    }
+
     public RuleFlowProcessFactory version(String version) {
     	getRuleFlowProcess().setVersion(version);
         return this;

--- a/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/ActionNodeFactory.java
+++ b/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/ActionNodeFactory.java
@@ -24,13 +24,14 @@ import org.jbpm.workflow.core.NodeContainer;
 import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
 import org.jbpm.workflow.core.node.ActionNode;
 
-/**
- *
- */
 public class ActionNodeFactory extends NodeFactory {
 
-    public ActionNodeFactory(RuleFlowNodeContainerFactory nodeContainerFactory, NodeContainer nodeContainer, long id) {
-        super(nodeContainerFactory, nodeContainer, id);
+    public ActionNodeFactory(RuleFlowNodeContainerFactory nodeContainerFactory,
+                             NodeContainer nodeContainer,
+                             long id) {
+        super(nodeContainerFactory,
+              nodeContainer,
+              id);
     }
 
     protected Node createNode() {
@@ -46,19 +47,18 @@ public class ActionNodeFactory extends NodeFactory {
         return this;
     }
 
-    public ActionNodeFactory action(String dialect, String action) {
-        getActionNode().setAction(new DroolsConsequenceAction(dialect, action));
+    public ActionNodeFactory action(String dialect,
+                                    String action) {
+        getActionNode().setAction(new DroolsConsequenceAction(dialect,
+                                                              action));
         return this;
     }
-    
-    //
-    // Allow the creation of programmatic actions that implement org.jbpm.process.instance.impl.Action interface.
-    // I just want to write simple classes to execute arbitrary logic without having to use a file.
-    //
+
     public ActionNodeFactory action(Action action) {
-      DroolsAction droolsAction = new DroolsAction();
-      droolsAction.setMetaData("Action",action);
-      getActionNode().setAction(droolsAction);
-      return this;
-  }    
+        DroolsAction droolsAction = new DroolsAction();
+        droolsAction.setMetaData("Action",
+                                 action);
+        getActionNode().setAction(droolsAction);
+        return this;
+    }
 }

--- a/jbpm-flow/src/test/java/org/jbpm/process/ProcessFactoryTest.java
+++ b/jbpm-flow/src/test/java/org/jbpm/process/ProcessFactoryTest.java
@@ -21,27 +21,29 @@ import org.jbpm.test.util.AbstractBaseTest;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
-public class ProcessFactoryTest extends AbstractBaseTest  {
+public class ProcessFactoryTest extends AbstractBaseTest {
 
-    public void addLogger() { 
+    public void addLogger() {
         logger = LoggerFactory.getLogger(this.getClass());
     }
-    
-	@Test
-	public void testProcessFactory() {
-		RuleFlowProcessFactory factory = RuleFlowProcessFactory.createProcess("org.drools.core.process");
-		factory
-			// header
-			.name("My process").packageName("org.drools")
-			// nodes
-			.startNode(1).name("Start").done()
-			.actionNode(2).name("Action")
-				.action("java", "System.out.println(\"Action\");").done()
-			.endNode(3).name("End").done()
-			// connections
-			.connection(1, 2)
-			.connection(2, 3);
-		factory.validate().getProcess();
-	}
 
+    @Test
+    public void testProcessFactory() throws Exception {
+        RuleFlowProcessFactory factory = RuleFlowProcessFactory.createProcess("org.drools.core.process");
+        factory
+                // header
+                .name("My process").packageName("org.drools")
+                // nodes
+                .startNode(1).name("Start").done()
+                .actionNode(2).name("Action")
+                .action("java",
+                        "System.out.println(\"Action\");").done()
+                .endNode(3).name("End").done()
+                // connections
+                .connection(1,
+                            2)
+                .connection(2,
+                            3);
+        factory.validate().getProcess();
+    }
 }


### PR DESCRIPTION
Adds test to show correct usage for JBPM-6713 and can set dynamic process via RuleFlowProcessFactory now (plus formatting)