### PR TITLE
Fix CDI Tests by adding AssertJ as a test dependency

### DIFF
--- a/jbpm-services/jbpm-services-cdi/pom.xml
+++ b/jbpm-services/jbpm-services-cdi/pom.xml
@@ -201,6 +201,13 @@
       <artifactId>arquillian-core-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- test: assertj -->
+    <!-- CDI tests extend tests in jbpm-kie-services -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
@mswiderski 
Fixes issues described in https://github.com/kiegroup/jbpm/pull/1123#issuecomment-360393508.

Thanks,

Marian
