### PR TITLE
jbpm-container: Make Arquillian functional on WebLogic 12.2.1.3.0

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
@@ -882,6 +882,27 @@
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-wls-remote-12.1.x</artifactId>
             <version>1.0.1.Final</version>
+            <exclusions>
+              <!--
+                   Following artifacts are from wls-common module which is a parent of the arquillian-wls-remote-12.1.x
+                   adapter. However, these dependencies are only needed by REST-based wls adapters. Therefore, they
+                   are excluded so they don't cause issues with certain artifacts on a wls side like org.glassfish.hk2
+                   which would be loaded twice - once from wlclient.jar and once as transitive dependencies of these
+                   artifacts
+              -->
+              <exclusion>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-client</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-json-processing</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-multipart</artifactId>
+              </exclusion>
+            </exclusions>
           </dependency>
         </dependencies>
       </dependencyManagement>


### PR DESCRIPTION
This change makes Arquillian work with WebLogic 12.2.1.3.0. Change is complete from the Arquillian side, if somebody wants to run tests, they would need the newest Cargo, but as of now it is OK to merge it like this since really nobody in community will run it on WebLogic I think.