### PR TITLE
JBPM-6821: Information not available in NodeInstance event listener

### DIFF
--- a/jbpm-audit/src/main/java/org/jbpm/process/audit/event/DefaultAuditEventBuilderImpl.java
+++ b/jbpm-audit/src/main/java/org/jbpm/process/audit/event/DefaultAuditEventBuilderImpl.java
@@ -107,6 +107,7 @@ public class DefaultAuditEventBuilderImpl implements AuditEventBuilder {
         log.setExternalId(""+((KieSession) pnte.getKieRuntime()).getIdentifier());
         log.setNodeType(nodeType);
         log.setNodeContainerId(nodeContainerId);
+        log.setDate(pnte.getEventDate());
         return log;
     }
         
@@ -167,6 +168,7 @@ public class DefaultAuditEventBuilderImpl implements AuditEventBuilder {
         logEvent.setExternalId(""+((KieSession) pnle.getKieRuntime()).getIdentifier());
         logEvent.setNodeType(nodeType);
         logEvent.setNodeContainerId(nodeContainerId);
+        logEvent.setDate(pnle.getEventDate());
         return logEvent;
     }
 


### PR DESCRIPTION
@mswiderski This PR stores the eventDate in NODEINSTANCELOG the same way you did in processes and tasks. 