### PR TITLE
RHBA-592 - KieSession already used when starting process with PER_PRO…

### DIFF
--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/PerProcessInstanceRuntimeManager.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/PerProcessInstanceRuntimeManager.java
@@ -205,8 +205,8 @@ public class PerProcessInstanceRuntimeManager extends AbstractRuntimeManager {
         if (ksessionId == null) {
             // make sure ksession is not use by any other context
             Object contextId = mapper.findContextId(ksession.getIdentifier(), this.identifier);
-            if (contextId != null) {
-                throw new IllegalStateException("KieSession with id " + ksession.getIdentifier() + " is already used by another context");
+            if (contextId != null && !contextId.equals(context.getContextId().toString())) {
+                throw new IllegalStateException("KieSession with id " + ksession.getIdentifier() + " is already used by another context " + contextId + " expected is "+ context.getContextId());
             }
             return;
         }


### PR DESCRIPTION
…CESS_INSTANCE strategy

it turned out the issues is with not checking the results of found context which is actually the right one. So that seems to be related in dealing with persistence context on tomcat to some extend. Though the validation logic was truly not complete.

@sutaakar could you please have a look and try if possible as we don't run PR jobs on tomcat. I tried it myself but would be good to have another pair of eyes (and hands) on it