### PR TITLE
Stabilize Audit tests

### DIFF
--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/AbstractAuditLogServiceTest.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/AbstractAuditLogServiceTest.java
@@ -23,8 +23,6 @@ import org.assertj.core.api.Assertions;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseFactory;
 import org.drools.core.io.impl.ClassPathResource;
-import org.hamcrest.core.AnyOf;
-import org.hamcrest.core.Is;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.jbpm.test.util.AbstractBaseTest;
 import org.kie.api.KieBase;
@@ -42,8 +40,6 @@ import org.kie.internal.persistence.jpa.JPAKnowledgeService;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.assertThat;
 
 /**
  * This class tests the following classes: 
@@ -482,7 +478,7 @@ public abstract class AbstractAuditLogServiceTest extends AbstractBaseTest {
             variableValues.add(var.getValue());
             variableIds.add(var.getVariableId());
             // Various DBs return various empty values. (E.g. Oracle returns null.)
-            assertThat(var.getOldValue(), AnyOf.anyOf(Is.is(""), Is.is((String) null), Is.is(" ")));
+            Assertions.assertThat(var.getOldValue()).isIn("", " ", null);
             Assertions.assertThat(var.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
             Assertions.assertThat(var.getProcessId()).isEqualTo(processInstance.getProcessId());
             Assertions.assertThat(var.getVariableInstanceId()).isEqualTo("list");

--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/jms/AsyncAuditLogProducerTest.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/jms/AsyncAuditLogProducerTest.java
@@ -22,7 +22,6 @@ import static org.jbpm.persistence.util.PersistenceUtil.createEnvironment;
 import static org.jbpm.persistence.util.PersistenceUtil.setupWithPoolingDataSource;
 import static org.jbpm.process.audit.AbstractAuditLogServiceTest.createKieSession;
 import static org.jbpm.process.audit.AbstractAuditLogServiceTest.createKnowledgeBase;
-import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,8 +44,6 @@ import javax.persistence.EntityManagerFactory;
 import javax.transaction.UserTransaction;
 
 import org.assertj.core.api.Assertions;
-import org.hamcrest.core.AnyOf;
-import org.hamcrest.core.Is;
 import org.hornetq.jms.server.embedded.EmbeddedJMS;
 import org.jboss.narayana.jta.jms.ConnectionFactoryProxy;
 import org.jboss.narayana.jta.jms.TransactionHelperImpl;
@@ -324,12 +321,12 @@ public class AsyncAuditLogProducerTest extends AbstractBaseTest {
         //verify variables
         List<VariableInstanceLog> variables = logService.findVariableInstances(processInstance.getId());
         Assertions.assertThat(variables).isNotNull();
-        Assertions.assertThat(variables.size()).isEqualTo(2);
+        Assertions.assertThat(variables).hasSize(2);
         
         VariableInstanceLog var = variables.get(0);
         // initial value from rule flow definition
         Assertions.assertThat(var.getValue()).isEqualTo("InitialValue");
-        assertThat(var.getOldValue(), AnyOf.anyOf(Is.is(""), Is.is((String) null), Is.is(" ")));
+        Assertions.assertThat(var.getOldValue()).isIn("", " ", null);
         Assertions.assertThat(var.getProcessInstanceId().longValue()).isEqualTo(processInstance.getId());
         Assertions.assertThat(var.getProcessId()).isEqualTo(processInstance.getProcessId());
         Assertions.assertThat(var.getVariableId()).isEqualTo("s");
@@ -412,7 +409,7 @@ public class AsyncAuditLogProducerTest extends AbstractBaseTest {
         for (VariableInstanceLog var : listVariables) {
             variableValues.add(var.getValue());
             variableIds.add(var.getVariableId());
-            assertThat(var.getOldValue(), AnyOf.anyOf(Is.is(""), Is.is((String) null), Is.is(" ")));
+            Assertions.assertThat(var.getOldValue()).isIn("", " ", null);
             Assertions.assertThat(var.getProcessInstanceId().longValue()).isEqualTo(processInstance.getId());
             Assertions.assertThat(var.getProcessId()).isEqualTo(processInstance.getProcessId());
             Assertions.assertThat(var.getVariableInstanceId()).isEqualTo("list");

--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/query/AuditQueryCoverageTest.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/query/AuditQueryCoverageTest.java
@@ -17,6 +17,7 @@
 package org.jbpm.process.audit.query;
 
 import static org.jbpm.persistence.util.PersistenceUtil.JBPM_PERSISTENCE_UNIT_NAME;
+import static org.jbpm.process.audit.query.AuditQueryDataUtil.cleanDB;
 import static org.jbpm.process.audit.query.AuditQueryDataUtil.createTestNodeInstanceLogData;
 import static org.jbpm.process.audit.query.AuditQueryDataUtil.createTestProcessInstanceLogData;
 import static org.jbpm.process.audit.query.AuditQueryDataUtil.createTestVariableInstanceLogData;
@@ -62,6 +63,7 @@ public class AuditQueryCoverageTest extends JPAAuditLogService {
     
     @AfterClass
     public static void reset() { 
+        cleanDB(emf);
         afterClass();
     }
 

--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/query/AuditQueryDataUtil.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/query/AuditQueryDataUtil.java
@@ -19,8 +19,10 @@ package org.jbpm.process.audit.query;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
@@ -36,6 +38,8 @@ import org.jbpm.process.audit.strategy.StandaloneJtaStrategy;
 public class AuditQueryDataUtil {
     
     private static Random random = new Random();
+
+    private static List<Object> createdEntities = new LinkedList<>();
 
     static long randomLong() { 
         long result = (long) Math.abs(random.nextInt());
@@ -126,7 +130,8 @@ public class AuditQueryDataUtil {
             em.persist(testData[i]);
         }
         jtaHelper.leaveTransaction(em, tx);
-        
+
+        createdEntities.addAll(Arrays.asList(testData));
         return testData;
     }
 
@@ -184,7 +189,8 @@ public class AuditQueryDataUtil {
             em.persist(testData[i]);
         }
         jtaHelper.leaveTransaction(em, tx);
-        
+
+        createdEntities.addAll(Arrays.asList(testData));
         return testData;
     }
 
@@ -248,7 +254,8 @@ public class AuditQueryDataUtil {
             em.persist(testData[i]);
         }
         jtaHelper.leaveTransaction(em, tx);
-        
+
+        createdEntities.addAll(Arrays.asList(testData));
         return testData;
     }
 
@@ -269,6 +276,20 @@ public class AuditQueryDataUtil {
                assertTrue( "Duration " + dur + " is larger than max " + maxOrMin[1], dur <= maxOrMin[1] ); 
            }
        }
+    }
+
+    static void cleanDB(EntityManagerFactory emf) {
+        StandaloneJtaStrategy jtaHelper = new StandaloneJtaStrategy(emf);
+        EntityManager em = jtaHelper.getEntityManager();
+
+        Object tx = jtaHelper.joinTransaction(em);
+
+        for (Object entity : createdEntities) {
+            Object mergedEntity = em.merge(entity);
+            em.remove(mergedEntity);
+        }
+
+        jtaHelper.leaveTransaction(em, tx);
     }
     
 }

--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/query/AuditQueryTest.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/query/AuditQueryTest.java
@@ -22,6 +22,7 @@ import static org.jbpm.persistence.util.PersistenceUtil.setupWithPoolingDataSour
 import static org.jbpm.process.audit.query.AuditQueryDataUtil.BOTH;
 import static org.jbpm.process.audit.query.AuditQueryDataUtil.MAX;
 import static org.jbpm.process.audit.query.AuditQueryDataUtil.MIN;
+import static org.jbpm.process.audit.query.AuditQueryDataUtil.cleanDB;
 import static org.jbpm.process.audit.query.AuditQueryDataUtil.createTestNodeInstanceLogData;
 import static org.jbpm.process.audit.query.AuditQueryDataUtil.createTestProcessInstanceLogData;
 import static org.jbpm.process.audit.query.AuditQueryDataUtil.createTestVariableInstanceLogData;
@@ -92,6 +93,7 @@ public class AuditQueryTest extends JPAAuditLogService {
     @AfterClass
     public static void reset() { 
         LoggingPrintStream.resetInterceptSysOutSysErr();
+        cleanDB(emf);
         cleanUp(context);
     }
 
@@ -376,7 +378,7 @@ public class AuditQueryTest extends JPAAuditLogService {
     public void likeRegexQueryBuilderTest() { 
        ProcessInstanceLogQueryBuilder builder = this.processInstanceLogQuery();
       
-       builder.like();
+       builder.regex();
        boolean parameterFailed = false;
        try { 
            builder.duration(pilTestData[0].getDuration(), pilTestData[2].getDuration());
@@ -393,38 +395,38 @@ public class AuditQueryTest extends JPAAuditLogService {
        
        builder = this.processInstanceLogQuery();
        regex = regex.substring(0, regex.length()-1) + ".";
-       builder.like().identity(regex);
+       builder.regex().identity(regex);
        resultList = builder.build().getResultList(); 
        assertEquals( "literal regex identity result", 1, resultList.size());
        assertEquals( externalId, resultList.get(0).getExternalId() );
        
        builder = this.processInstanceLogQuery();
        regex = regex.substring(0, 10) + "*";
-       builder.like().identity(regex);
+       builder.regex().identity(regex);
        resultList = builder.build().getResultList(); 
        assertEquals( "literal regex identity result", 1, resultList.size());
        assertEquals( externalId, resultList.get(0).getExternalId() );
        
        builder = this.processInstanceLogQuery();
        String regex2 = "*" + pilTestData[0].getIdentity().substring(10);
-       builder.like().intersect().identity(regex, regex2);
+       builder.regex().intersect().identity(regex, regex2);
        resultList = builder.build().getResultList(); 
        assertEquals( "literal regex identity result", 1, resultList.size());
        assertEquals( externalId, resultList.get(0).getExternalId() );
       
        builder = this.processInstanceLogQuery();
        regex2 = "*" + pilTestData[5].getIdentity().substring(10);
-       builder.like().intersect().identity(regex, regex2);
+       builder.regex().intersect().identity(regex, regex2);
        resultList = builder.build().getResultList(); 
        assertEquals( "literal regex identity result", 0, resultList.size());
       
        builder = this.processInstanceLogQuery();
-       builder.like().union().identity(regex, regex2);
+       builder.regex().union().identity(regex, regex2);
        resultList = builder.build().getResultList(); 
        assertEquals( "literal regex identity result", 2, resultList.size());
        
        builder = this.processInstanceLogQuery();
-       builder.like().union().identity("*");
+       builder.regex().union().identity("*");
        resultList = builder.build().getResultList(); 
        assertEquals( "literal regex identity result", this.processInstanceLogQuery().build().getResultList().size(), resultList.size());
     }       
@@ -462,7 +464,6 @@ public class AuditQueryTest extends JPAAuditLogService {
        long min = durationOrderedProcInstLogList.get(lastElemIndex).getDuration();
        builder.durationMin(min);
        resultList = builder.build().getResultList();
-       duration = resultList.get(0).getDuration();
        verifyMaxMinDuration(resultList, MIN, min);
            
        // union max and min
@@ -539,34 +540,27 @@ public class AuditQueryTest extends JPAAuditLogService {
     }
    
     @Test
-    public void lastVariableTest() throws Exception { 
-        StandaloneJtaStrategy jtaHelper = new StandaloneJtaStrategy(emf);
-        EntityManager em = jtaHelper.getEntityManager();
-
+    public void lastVariableTest() throws Exception {
         int numLogs = 10;
         VariableInstanceLog [] testData = new VariableInstanceLog[numLogs];
         Calendar cal = GregorianCalendar.getInstance(); 
 
         for( int i = 0; i < 5; ++i ) {
             cal.roll(Calendar.SECOND, 1);
-            testData[i] = new VariableInstanceLog(23l, "org.lots.of.vars", "inst", "first-var", "val-a", "oldVal-" + i);
-            testData[i+5] = new VariableInstanceLog(23l, "org.lots.of.vars", "inst", "second-var", "val-b", "oldVal-" + i);
+            testData[i] = new VariableInstanceLog(23L, "org.lots.of.vars", "inst", "first-var", "val-a", "oldVal-" + i);
+            testData[i+5] = new VariableInstanceLog(23L, "org.lots.of.vars", "inst", "second-var", "val-b", "oldVal-" + i);
             testData[i].setDate(cal.getTime());
             testData[i+5].setDate(cal.getTime());
         }
-        
-        Object tx = jtaHelper.joinTransaction(em);
-        for( int i = 0; i < numLogs; ++i ) {
-            em.persist(testData[i]);
-        }
-        jtaHelper.leaveTransaction(em, tx);
+
+        persistEntities(testData);
        
         VariableInstanceLogQueryBuilder queryBuilder;
         ParametrizedQuery<org.kie.api.runtime.manager.audit.VariableInstanceLog> query ;
         List<org.kie.api.runtime.manager.audit.VariableInstanceLog> logs;
        
         queryBuilder = this.variableInstanceLogQuery();
-        query = queryBuilder.last().intersect().processInstanceId(23l).build();
+        query = queryBuilder.last().intersect().processInstanceId(23L).build();
         logs = query.getResultList();
         assertEquals("2 logs", 2, logs.size());
         
@@ -576,13 +570,12 @@ public class AuditQueryTest extends JPAAuditLogService {
         assertEquals("Only 1 log expected", 1, logs.size());
         assertEquals("Incorrect variable val", "val-a", logs.get(0).getValue());
         assertEquals("Incorrect variable old val", "oldVal-4", logs.get(0).getOldValue());
-    } 
+
+        removeEntities(testData);
+    }
 
     @Test
-    public void variableValueTest() throws Exception { 
-        StandaloneJtaStrategy jtaHelper = new StandaloneJtaStrategy(emf);
-        EntityManager em = jtaHelper.getEntityManager();
-
+    public void variableValueTest() throws Exception {
         int numLogs = 9;
         VariableInstanceLog [] testData = new VariableInstanceLog[numLogs];
         Calendar cal = GregorianCalendar.getInstance(); 
@@ -592,12 +585,8 @@ public class AuditQueryTest extends JPAAuditLogService {
             cal.roll(Calendar.SECOND, 1);
             testData[i] = new VariableInstanceLog(randomLong(), processId, "varInstId", "var-" +i, "val-"+i, "oldVal-" + i);
         }
-        
-        Object tx = jtaHelper.joinTransaction(em);
-        for( int i = 0; i < numLogs; ++i ) {
-            em.persist(testData[i]);
-        }
-        jtaHelper.leaveTransaction(em, tx);
+
+        persistEntities(testData);
        
         VariableInstanceLogQueryBuilder queryBuilder;
         ParametrizedQuery<org.kie.api.runtime.manager.audit.VariableInstanceLog> query ;
@@ -669,7 +658,7 @@ public class AuditQueryTest extends JPAAuditLogService {
         // regex: find 2
         queryBuilder = this.variableInstanceLogQuery();
         query = queryBuilder
-                .like().union()
+                .regex().union()
                 .variableValue("var-2", "val-*")
                 .variableValue("var-3", "val-*")
                 .build();
@@ -684,7 +673,7 @@ public class AuditQueryTest extends JPAAuditLogService {
         queryBuilder = this.variableInstanceLogQuery();
         query = queryBuilder
                 .newGroup()
-                .like().union()
+                .regex().union()
                 .variableValue("var-2", "val-*")
                 .variableValue("var-3", "val-*")
                 .endGroup()
@@ -697,5 +686,33 @@ public class AuditQueryTest extends JPAAuditLogService {
            String id = varLog.getVariableId().substring("var-".length());
            assertEquals( "variable value", "val-" + id, varLog.getValue());
         }
-    } 
+
+        removeEntities(testData);
+    }
+
+    private void persistEntities(VariableInstanceLog[] testData) {
+        StandaloneJtaStrategy jtaHelper = new StandaloneJtaStrategy(emf);
+        EntityManager em = jtaHelper.getEntityManager();
+
+        int numLogs = testData.length;
+        Object tx = jtaHelper.joinTransaction(em);
+        for( int i = 0; i < numLogs; ++i ) {
+            em.persist(testData[i]);
+        }
+        jtaHelper.leaveTransaction(em, tx);
+    }
+
+    private void removeEntities(VariableInstanceLog[] testData) {
+        StandaloneJtaStrategy jtaHelper = new StandaloneJtaStrategy(emf);
+        EntityManager em = jtaHelper.getEntityManager();
+
+        int numLogs = testData.length;
+        Object tx = jtaHelper.joinTransaction(em);
+        for( int i = 0; i < numLogs; ++i ) {
+            VariableInstanceLog mergedEntity = em.merge(testData[i]);
+            em.remove(mergedEntity);
+        }
+        jtaHelper.leaveTransaction(em, tx);
+    }
+
 }


### PR DESCRIPTION
Hi, @mswiderski,

here is the PR we discussed. I basically eliminated jUnit Assert in two classes and added removal of entities in the tests which created them so it won't cause issues to other tests.