### PR TITLE
Update XSD Schema locations in BPMN2 definitions

### DIFF
--- a/jbpm-bpmn2/src/test/resources/BPMN2-EventSubprocessSignal-Nested.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-EventSubprocessSignal-Nested.bpmn2
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://www.jboss.org/drools" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.omg.org/spec/BPMN/20100524/DI http://www.omg.org/spec/BPMN/20100524/DI-XMI http://www.omg.org/spec/DD/20100524/DC http://www.omg.org/spec/DD/20100524/DC-XMI http://www.omg.org/spec/DD/20100524/DI http://www.omg.org/spec/DD/20100524/DI-XMI" id="Definitions_1" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.jboss.org/drools" typeLanguage="http://www.java.com/javaTypes">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                   xmlns:tns="http://www.jboss.org/drools"
+                   xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+                   id="Definitions_1"
+                   expressionLanguage="http://www.mvel.org/2.0"
+                   targetNamespace="http://www.jboss.org/drools"
+                   typeLanguage="http://www.java.com/javaTypes">
   <bpmn2:process id="BPMN2-EventSubprocessSignal" tns:version="1" tns:packageName="defaultPackage" name="Default Process">
 
     <bpmn2:startEvent id="_1" name="Start" />

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/log/TaskLogClean-inputAssociation.bpmn2
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/log/TaskLogClean-inputAssociation.bpmn2
@@ -7,7 +7,7 @@
 	xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
 	xmlns:drools="http://www.jboss.org/drools"
 	xmlns="http://www.jboss.org/drools"
-	xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/20100501/BPMN20.xsd
+	xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL https://www.omg.org/spec/BPMN/20100501/BPMN20.xsd
                     http://www.jboss.org/drools drools.xsd 
                     http://www.bpsim.org/schemas/1.0 bpsim.xsd" 
 	id="Definition"

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/regression/task/HumanTask-inputTransformation.bpmn2
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/regression/task/HumanTask-inputTransformation.bpmn2
@@ -7,7 +7,7 @@
 	xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
 	xmlns:drools="http://www.jboss.org/drools"
 	xmlns="http://www.jboss.org/drools"
-	xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/20100501/BPMN20.xsd
+	xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL https://www.omg.org/spec/BPMN/20100501/BPMN20.xsd
                     http://www.jboss.org/drools drools.xsd 
                     http://www.bpsim.org/schemas/1.0 bpsim.xsd" 
 	id="Definition"


### PR DESCRIPTION
Update to BPMN definitions which were failing the tests. OMG has decided to move schemas under HTTPS protocol.