### PR TITLE
RHBA-248 - LogCleanupCommand follow-up

### DIFF
--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/LogCleanupCommandTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/LogCleanupCommandTest.java
@@ -28,13 +28,11 @@ import org.jbpm.runtime.manager.impl.jpa.EntityManagerFactoryManager;
 import org.jbpm.services.task.audit.service.TaskJPAAuditService;
 import org.jbpm.test.JbpmAsyncJobTestCase;
 import org.jbpm.test.listener.CountDownAsyncJobListener;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.task.TaskService;
 import org.kie.internal.executor.api.CommandContext;
-
 import qa.tools.ikeeper.annotation.BZ;
 
 /**
@@ -111,7 +109,6 @@ public class LogCleanupCommandTest extends JbpmAsyncJobTestCase {
         Assertions.assertThat(getNodeInstanceLogSize(HELLO_WORLD_ID)).isPositive();
     }
 
-    @Ignore
     @Test(timeout=10000)
     public void skipTaskLog() throws Exception {
         KieSession kieSession = null;
@@ -166,7 +163,6 @@ public class LogCleanupCommandTest extends JbpmAsyncJobTestCase {
         // Verify presence of data
         Assertions.assertThat(getProcessLogSize(runProcess)).isPositive();
         Assertions.assertThat(getNodeInstanceLogSize(runProcess)).isPositive();
-//        Assertions.assertThat(getExecutorLogSize()).isZero(); // TBD: Should be zero but is > zero
 
         // Set to NOW if date was not provided
         if (date == null) {
@@ -188,7 +184,6 @@ public class LogCleanupCommandTest extends JbpmAsyncJobTestCase {
         Assertions.assertThat(getNodeInstanceLogSize(HELLO_WORLD_ID)).isPositive();
     }
 
-    @Ignore
     @Test(timeout=10000)
     @BZ("1190881")
     public void deleteAllLogsOlderThanNow() throws Exception {
@@ -200,7 +195,6 @@ public class LogCleanupCommandTest extends JbpmAsyncJobTestCase {
         Assertions.assertThat(getNodeInstanceLogSize(HELLO_WORLD_ID)).isZero();
     }
 
-    @Ignore
     @Test(timeout=10000)
     public void deleteAllLogsOlderThanTomorrow() throws Exception {
         CountDownAsyncJobListener countDownListener = new CountDownAsyncJobListener(1);
@@ -221,7 +215,6 @@ public class LogCleanupCommandTest extends JbpmAsyncJobTestCase {
         Assertions.assertThat(getNodeInstanceLogSize(HELLO_WORLD_ID)).isPositive();
     }
 
-    @Ignore
     @Test(timeout=10000)
     @BZ("1190881")
     public void deleteAllLogsOlderThanPeriod() throws Exception {
@@ -231,20 +224,20 @@ public class LogCleanupCommandTest extends JbpmAsyncJobTestCase {
         KieSession kieSession = createKSession(HELLO_WORLD);
         startProcess(kieSession, HELLO_WORLD_ID, 3);
 
-        countDownListener.waitTillCompleted();
-
-        startProcess(kieSession, HELLO_WORLD_ID, 2);
+        // Advance time 1+ second forward
+        Thread.sleep(1010);
 
         // Verify presence of data
-        Assertions.assertThat(getProcessLogSize(HELLO_WORLD_ID)).isEqualTo(5);
+        Assertions.assertThat(getProcessLogSize(HELLO_WORLD_ID)).isEqualTo(3);
         Assertions.assertThat(getNodeInstanceLogSize(HELLO_WORLD_ID)).isPositive();
 
         // Schedule cleanup job
-        scheduleLogCleanup(false, false, false, null, "8s", HELLO_WORLD_ID);
+        scheduleLogCleanup(false, false, false, null, "1s", HELLO_WORLD_ID);
         countDownListener.waitTillCompleted();
 
         // Verify absence of data
-        Assertions.assertThat(getProcessLogSize(HELLO_WORLD_ID)).isEqualTo(2);
+        Assertions.assertThat(getProcessLogSize(HELLO_WORLD_ID)).isZero();
+        Assertions.assertThat(getNodeInstanceLogSize(HELLO_WORLD_ID)).isZero();
     }
 
     // ------------------------ Helper Methods ------------------------


### PR DESCRIPTION
@mswiderski when playing a little bit with LogCleanupCommand I found that if you skip task logs and delete only process logs, it behaves correctly, but when you then try to delete everything including task logs, task logs are not deleted because they don't have active process instances in ProcessInstanceLog table. So my proposal is to delete them too since they are orphans now.

Quick summary of changes:
* Delete everything which either belongs to non-active process instance or doesn't belong to any - it now applies to NodeInstanceLog, VariableInstanceLog, TaskEventImpl and AuditTaskImpl (it worked with Node/VariableInstanceLog before since it is deleted together with ProcessInstanceLog, so there are no orphans left, only task-related things can have orphans)
* Unignored remaining LogCleanupCommand tests - they were ignored for nearly 3 years since they were brought to community from QE internal repo, but they seem to be running well
