### PR TITLE
JBPM-5223 - Improve WorkItemHandler parameter definition

### DIFF
--- a/jbpm-workitems/jbpm-workitems-archetype/src/main/resources/archetype-resources/jbpm-workitems-__rootArtifactId__/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-archetype/src/main/resources/archetype-resources/jbpm-workitems-__rootArtifactId__/pom.xml
@@ -68,7 +68,7 @@
           <compilerArgs>
             <arg>-AwidName=${classPrefix}</arg>
             <arg>-AgenerateTemplates=true</arg>
-            <arg>-AtemplateResources=${classPrefix}.wid:widtemplate.st,${classPrefix}.json:jsontemplate.st,index.html:indextemplate.st</arg>
+            <arg>-AtemplateResources=${classPrefix}.wid:widtemplate.st,${classPrefix}.json:jsontemplate.st,index.html:indextemplate.st,kie-deployment-descriptor.xml:kie-ddtemplate.st</arg>
           </compilerArgs>
         </configuration>
       </plugin>

--- a/jbpm-workitems/jbpm-workitems-archetype/src/main/resources/archetype-resources/jbpm-workitems-__rootArtifactId__/src/assembly/widrepo-assembly.xml
+++ b/jbpm-workitems/jbpm-workitems-archetype/src/main/resources/archetype-resources/jbpm-workitems-__rootArtifactId__/src/assembly/widrepo-assembly.xml
@@ -35,6 +35,7 @@
         <include>*.wid</include>
         <include>*.html</include>
         <include>*.json</include>
+        <include>*.xml</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/jbpm-workitems/jbpm-workitems-archetype/src/main/resources/archetype-resources/jbpm-workitems-__rootArtifactId__/src/main/resources/kie-ddtemplate.st
+++ b/jbpm-workitems/jbpm-workitems-archetype/src/main/resources/archetype-resources/jbpm-workitems-__rootArtifactId__/src/main/resources/kie-ddtemplate.st
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<deployment-descriptor xsi:schemaLocation="http://www.jboss.org/jbpm deployment-descriptor.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <persistence-unit>org.jbpm.domain</persistence-unit>
+    <audit-persistence-unit>org.jbpm.domain</audit-persistence-unit>
+    <audit-mode>JPA</audit-mode>
+    <persistence-mode>JPA</persistence-mode>
+    <runtime-strategy>SINGLETON</runtime-strategy>
+    <marshalling-strategies/>
+    <event-listeners/>
+    <task-event-listeners/>
+    <globals/>
+    <work-item-handlers>
+    $widInfo:{k|
+      <work-item-handler>
+        <resolver>mvel</resolver>
+        <identifier>$widInfo.(k).defaultHandlerNoType$</identifier>
+        <parameters/>
+        <name>$widInfo.(k).name$</name>
+      </work-item-handler>
+    }; separator=""$
+    </work-item-handlers>
+    <environment-entries/>
+    <configurations/>
+    <required-roles/>
+    <remoteable-classes/>
+    <limit-serialization-classes>true</limit-serialization-classes>
+</deployment-descriptor>

--- a/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/RequiredParameterValidator.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/RequiredParameterValidator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.core.util;
+
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemHandler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RequiredParameterValidator {
+
+    private static final Logger logger = LoggerFactory.getLogger(RequiredParameterValidator.class);
+
+    public static void validate(Class<? extends WorkItemHandler> handlerClass,
+                                WorkItem workItem) throws Exception {
+
+        Wid handlerWidAnnotation = handlerClass.getDeclaredAnnotation(Wid.class);
+        if (workItem == null || handlerWidAnnotation == null || handlerWidAnnotation.parameters() == null || handlerWidAnnotation.parameters().length < 1) {
+            // nothing to validate
+            return;
+        }
+
+        for (WidParameter handlerWidParameter : handlerWidAnnotation.parameters()) {
+            if (handlerWidParameter.name() != null && handlerWidParameter.required()) {
+                if (workItem.getParameter(handlerWidParameter.name()) == null) {
+                    logger.error("Workitem declares following required parameter which does not exist: " + handlerWidParameter.name());
+                    throw new IllegalArgumentException("Workitem declares following required parameter which does not exist: " + handlerWidParameter.name());
+                }
+            }
+        }
+    }
+}

--- a/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/Wid.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/Wid.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Documented;
  * values for the handlers workitem configuration.
  * Can be used to auto-generate the handlers workitem configuration (.wid) file.
  */
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Documented
 public @interface Wid {

--- a/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WidInfo.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WidInfo.java
@@ -64,7 +64,8 @@ public class WidInfo {
                 for (WidParameter widParam : wid.parameters()) {
                     this.parameters.put(widParam.name(),
                                         new InternalWidParamsAndResults(widParam.name(),
-                                                                        widParam.type()));
+                                                                        widParam.type(),
+                                                                        widParam.required()));
                 }
             }
 
@@ -80,7 +81,8 @@ public class WidInfo {
                 for (WidResult widResult : wid.results()) {
                     this.results.put(widResult.name(),
                                      new InternalWidParamsAndResults(widResult.name(),
-                                                                     widResult.type()));
+                                                                     widResult.type(),
+                                                                     false));
                 }
             }
 
@@ -105,10 +107,10 @@ public class WidInfo {
     }
 
     private String removeType(String value) {
-        if(value != null) {
-            if(value.startsWith("mvel: ")) {
+        if (value != null) {
+            if (value.startsWith("mvel: ")) {
                 return value.substring(6);
-            } else if(value.startsWith("reflection: ")) {
+            } else if (value.startsWith("reflection: ")) {
                 return value.substring(12);
             } else {
                 return value;
@@ -122,11 +124,14 @@ public class WidInfo {
 
         private String name;
         private String type;
+        private boolean required;
 
         public InternalWidParamsAndResults(String name,
-                                           String type) {
+                                           String type,
+                                           boolean required) {
             this.name = name;
             this.type = type;
+            this.required = required;
         }
 
         public String getName() {
@@ -143,6 +148,14 @@ public class WidInfo {
 
         public void setType(String type) {
             this.type = type;
+        }
+
+        public boolean isRequired() {
+            return required;
+        }
+
+        public void setRequired(boolean required) {
+            this.required = required;
         }
     }
 

--- a/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WidParameter.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WidParameter.java
@@ -26,5 +26,5 @@ import java.lang.annotation.Documented;
 public @interface WidParameter {
     String name() default "";
     String type() default "StringDataType";
-
+    boolean required() default false;
 }

--- a/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WidProcessor.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WidProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.element.Element;
@@ -33,7 +34,6 @@ import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
-import javax.annotation.processing.ProcessingEnvironment;
 
 import org.stringtemplate.v4.ST;
 

--- a/jbpm-workitems/jbpm-workitems-core/src/test/java/org/jbpm/process/workitem/core/util/RequiredParameterValidatorTest.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/test/java/org/jbpm/process/workitem/core/util/RequiredParameterValidatorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.core.util;
+
+import org.drools.core.process.instance.impl.WorkItemImpl;
+import org.jbpm.process.workitem.core.TestWorkItemManager;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RequiredParameterValidatorTest {
+
+    private RequiredParametersTestHandler testHandler = new RequiredParametersTestHandler();
+    private TestWorkItemManager testManager = new TestWorkItemManager();
+
+    @Test
+    public void testValidaRequiredParameters() throws Exception {
+        try {
+            WorkItemImpl workItem = new WorkItemImpl();
+            workItem.setParameter("firstParam",
+                                  "testValue");
+            workItem.setParameter("thirdParam",
+                                  "testValue");
+
+            testHandler.executeWorkItem(workItem,
+                                        testManager);
+        } catch (Exception e) {
+            fail("Required parameters have been set. No exception should be thrown: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testInvalidaRequiredParameters() throws Exception {
+        try {
+            WorkItemImpl workItem = new WorkItemImpl();
+            workItem.setParameter("secondParam",
+                                  "testValue");
+
+            testHandler.executeWorkItem(workItem,
+                                        testManager);
+            fail("Exception on required parameters was not thrown by handler");
+        } catch (Exception e) {
+
+        }
+    }
+}

--- a/jbpm-workitems/jbpm-workitems-core/src/test/java/org/jbpm/process/workitem/core/util/RequiredParametersTestHandler.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/test/java/org/jbpm/process/workitem/core/util/RequiredParametersTestHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.core.util;
+
+import org.jbpm.process.workitem.core.AbstractLogOrThrowWorkItemHandler;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemManager;
+
+@Wid(widfile = "TestHandler.wid", name = "TestHandler",
+        displayName = "TestHandler",
+        defaultHandler = "mvel: org.jbpm.process.workitem.core.util.RequiredParametersTestHandler()",
+        parameters = {
+                @WidParameter(name = "firstParam", required = true),
+                @WidParameter(name = "secondParam"),
+                @WidParameter(name = "thirdParam", required = true),
+        })
+public class RequiredParametersTestHandler extends AbstractLogOrThrowWorkItemHandler {
+
+    public void executeWorkItem(WorkItem workItem,
+                                WorkItemManager workItemManager) {
+        try {
+            RequiredParameterValidator.validate(this.getClass(),
+                                                workItem);
+        } catch (Exception e) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    public void abortWorkItem(WorkItem wi,
+                              WorkItemManager wim) {
+    }
+}

--- a/jbpm-workitems/jbpm-workitems-core/src/test/java/org/jbpm/process/workitem/core/util/WidProcessorTest.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/test/java/org/jbpm/process/workitem/core/util/WidProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,8 @@ public class WidProcessorTest {
                     "        displayName=\"My Test Class\", icon=\"/my/icons/myicon.png\",\n" +
                     "        defaultHandler=\"mvel: new com.sample.MyWorkItemHandler()\",\n" +
                     "        parameters={\n" +
-                    "                @WidParameter(name=\"sampleParam\"),\n" +
-                    "                @WidParameter(name=\"sampleParamTwo\")\n" +
+                    "                @WidParameter(name=\"sampleParam\", required = true),\n" +
+                    "                @WidParameter(name=\"sampleParamTwo\", required = true)\n" +
                     "        },\n" +
                     "        parameterValues={\n" +
                     "                @WidParameterValues(parameterName=\"sampleParam\", values=\"a,b,c,d,e\"),\n" +
@@ -71,8 +71,8 @@ public class WidProcessorTest {
                     "        displayName=\"My Test Class Refl\", category=\"testcategory\", icon=\"/my/icons/myicon.png\",\n" +
                     "        defaultHandler=\"reflection: new com.sample.MyWorkItemHandler()\",\n" +
                     "        parameters={\n" +
-                    "                @WidParameter(name=\"sampleParam\"),\n" +
-                    "                @WidParameter(name=\"sampleParamTwo\")\n" +
+                    "                @WidParameter(name=\"sampleParam\", required = true),\n" +
+                    "                @WidParameter(name=\"sampleParamTwo\", required = true)\n" +
                     "        },\n" +
                     "        parameterValues={\n" +
                     "                @WidParameterValues(parameterName=\"sampleParam\", values=\"a,b,c,d,e\"),\n" +
@@ -96,8 +96,8 @@ public class WidProcessorTest {
                     "\n" +
                     "@Wid(widfile = \"mywidfiletwo.wid\",\n" +
                     "        parameters = {\n" +
-                    "                @WidParameter(name = \"sampleParamThree\"),\n" +
-                    "                @WidParameter(name = \"sampleParamFour\")\n" +
+                    "                @WidParameter(name = \"sampleParamThree\", required = true),\n" +
+                    "                @WidParameter(name = \"sampleParamFour\", required = true)\n" +
                     "        },\n" +
                     "        parameterValues={\n" +
                     "                @WidParameterValues(parameterName=\"sampleParamThree\", values=\"a,b,c,d,e\"),\n" +
@@ -122,8 +122,8 @@ public class WidProcessorTest {
                     "        displayName = \"My Test Class\", category=\"testcategory\", icon = \"/my/icons/myicon.png\",\n" +
                     "        defaultHandler = \"mvel: new com.sample.MyWorkItemHandler()\",\n" +
                     "        parameters = {\n" +
-                    "                @WidParameter(name = \"sampleParam\"),\n" +
-                    "                @WidParameter(name = \"sampleParamTwo\")\n" +
+                    "                @WidParameter(name = \"sampleParam\", required = true),\n" +
+                    "                @WidParameter(name = \"sampleParamTwo\", required = true)\n" +
                     "        },\n" +
                     "        parameterValues={\n" +
                     "                @WidParameterValues(parameterName=\"sampleParam\", values=\"a,b,c,d,e\"),\n" +
@@ -173,10 +173,12 @@ public class WidProcessorTest {
                      widParameters.length);
         assertEquals("sampleParam",
                      widParameters[0].name());
+        assertTrue(widParameters[0].required());
         assertEquals("StringDataType",
                      widParameters[0].type());
         assertEquals("sampleParamTwo",
                      widParameters[1].name());
+        assertTrue(widParameters[1].required());
         assertEquals("StringDataType",
                      widParameters[1].type());
 
@@ -304,8 +306,6 @@ public class WidProcessorTest {
         // make sure version of org.jboss.myworkitem is 2.0 (overwritten)
         assertEquals("1.0",
                      widInfo.getMavenDepends().get("org.jboss.myworkitem").getVersion());
-
-
     }
 
     @Test


### PR DESCRIPTION
Added "required" attribute to the WidParameter allowing users to set certain handler input params to be set as required (handler will not execute if required params cannot be found) 

Updated WidProcessor to generate a parameter validation class for each of the handlers. This class checks existence of the required parameters and will throw exception if they cannot be found.

Added ValidatingAbstractLogOrThrowWorkitemHandler which workitem handlers can extend. It provides a validate method that will call the handlers validation class

Small changes to workitem archetype to add generation of the deployment descriptor