### PR TITLE
JBPM-6894 - SLA follow-up

### DIFF
--- a/jbpm-case-mgmt/jbpm-case-mgmt-api/src/main/java/org/jbpm/casemgmt/api/auth/AuthorizationManager.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-api/src/main/java/org/jbpm/casemgmt/api/auth/AuthorizationManager.java
@@ -33,6 +33,8 @@ public interface AuthorizationManager {
     
     public static final String OWNER_ROLE = "owner";
     public static final String ADMIN_ROLE = "admin";
+
+    public static final String UNKNOWN_USER = "unknown";
     
     public enum ProtectedOperation {
         CLOSE_CASE,

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/AuthorizationManagerImpl.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/AuthorizationManagerImpl.java
@@ -69,6 +69,12 @@ public class AuthorizationManagerImpl implements AuthorizationManager {
         if (!isEnabled()) {
             return;
         }
+
+        if (loggedInAsSystemUser()) {
+            logger.debug("Logged in as system user 'unknown'. Skipping authorization check.");
+            return;
+        }
+
         logger.debug("Checking authorization to case {} for user {}", caseId, identityProvider.getName());
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("caseId", caseId);
@@ -79,6 +85,11 @@ public class AuthorizationManagerImpl implements AuthorizationManager {
     
     @Override
     public void checkOperationAuthorization(String caseId, ProtectedOperation operation) throws SecurityException {
+        if (loggedInAsSystemUser()) {
+            logger.debug("Logged in as system user 'unknown'. Skipping operation authorization check.");
+            return;
+        }
+
         List<String> rolesForOperation = operationAuthorization.get(operation);
         
         if (rolesForOperation == null || rolesForOperation.isEmpty()) {
@@ -160,6 +171,11 @@ public class AuthorizationManagerImpl implements AuthorizationManager {
 
     @Override
     public Map<String, Object> filterByDataAuthorization(String caseId, CaseFileInstance caseFileInstance, Map<String, Object> data) {
+        if (loggedInAsSystemUser()) {
+            logger.debug("Logged in as system user 'unknown'. Returning all data.");
+            return data;
+        }
+
         if (data == null || data.isEmpty()) {
             logger.debug("No data to be filtered");
             return data;
@@ -194,6 +210,11 @@ public class AuthorizationManagerImpl implements AuthorizationManager {
 
     @Override
     public void checkDataAuthorization(String caseId, CaseFileInstance caseFileInstance, Collection<String> dataNames) {
+        if (loggedInAsSystemUser()) {
+            logger.debug("Logged in as system user 'unknown'. Skipping data authorization check.");
+            return;
+        }
+
         if (dataNames == null || dataNames.isEmpty()) {
             logger.debug("No data to be checked");
             return;
@@ -228,6 +249,11 @@ public class AuthorizationManagerImpl implements AuthorizationManager {
     
     @Override
     public List<CommentInstance> filterByCommentAuthorization(String caseId, CaseFileInstance caseFileInstance, List<CommentInstance> comments) {
+        if (loggedInAsSystemUser()) {
+            logger.debug("Logged in as system user 'unknown'. Returning all comments.");
+            return comments;
+        }
+
         if (comments == null || comments.isEmpty()) {
             logger.debug("No comments to be filtered");
             return comments;
@@ -261,6 +287,11 @@ public class AuthorizationManagerImpl implements AuthorizationManager {
     
     @Override
     public void checkCommentAuthorization(String caseId, CaseFileInstance caseFileInstance, CommentInstance commentInstance) {
+        if (loggedInAsSystemUser()) {
+            logger.debug("Logged in as system user 'unknown'. Skipping comment authorization check.");
+            return;
+        }
+
         CommentInstanceImpl comment = ((CommentInstanceImpl) commentInstance);
         if (comment.getRestrictedTo() == null || comment.getRestrictedTo().isEmpty()) {
             return;
@@ -288,5 +319,9 @@ public class AuthorizationManagerImpl implements AuthorizationManager {
         callerRoles.add(PUBLIC_GROUP);
         
         return callerRoles;
+    }
+
+    protected boolean loggedInAsSystemUser() {
+        return UNKNOWN_USER.equals(identityProvider.getName());
     }
 }


### PR DESCRIPTION
Hi, @mswiderski,

just quick summary for public:

PR consists of 2 commits:

* SLA violation is now propagated to entry type of NodeInstanceLog. SLAComplianceTest were altered to reflect and test this fact.
* Introduced a System User `unknown` who is authorized to all operations with cases. This was needed to allow engine to call SLA Violation listeners which might be triggered when nobody is logged in. Tests were added which cover all six places where a check loggedInAsSystemUser() is used: checkAuthorization, checkOperationAuthorization, filterByDataAuthorization, checkDataAuthorization, filterByCommentAuthorization, checkCommentAuthorization. Each test covers two of them.
