### PR TITLE
Downgrade Resteasy to fix jbpm-container tests on WebLogic

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/pom.xml
@@ -18,6 +18,9 @@
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
+    <!-- Use older version because of Resteasy bug in WebLogic
+           https://issues.jboss.org/browse/RESTEASY-1748 -->
+    <version.org.jboss.resteasy>3.0.19.Final</version.org.jboss.resteasy>
   </properties>
 
   <modules>


### PR DESCRIPTION
There is an issue https://issues.jboss.org/browse/RESTEASY-1748 with Resteasy on weblogic. The issue prevents using REST services so REST WIH tests will fail on WebLogic. I will be notified when the bug is fixed, so it should be only a temporary fix. 