### PR TITLE
JBPM-7277 - Node SLA is not updated for the right node

### DIFF
--- a/jbpm-audit/src/main/java/org/jbpm/process/audit/JPAWorkingMemoryDbLogger.java
+++ b/jbpm-audit/src/main/java/org/jbpm/process/audit/JPAWorkingMemoryDbLogger.java
@@ -180,11 +180,13 @@ public class JPAWorkingMemoryDbLogger extends AbstractAuditLogger {
         if (event.getNodeInstance() != null) {
             // since node instance is set this is SLA violation for node instance
             long nodeInstanceId = event.getNodeInstance().getId();
+            long processInstanceId = event.getProcessInstance().getId();
             NodeInstanceLog log = (NodeInstanceLog) ((NodeInstanceImpl) event.getNodeInstance()).getMetaData().get("NodeInstanceLog");
             if (log == null) {
                 List<NodeInstanceLog> result = em.createQuery(
-                        "from NodeInstanceLog as log where log.nodeInstanceId = :niId and log.type = 0")
-                        .setParameter("niId", Long.toString(nodeInstanceId)).getResultList();
+                        "from NodeInstanceLog as log where log.nodeInstanceId = :niId and log.processInstanceId = :piId and log.type = 0")
+                        .setParameter("niId", Long.toString(nodeInstanceId))
+                        .setParameter("piId", processInstanceId).getResultList();
                 if (result != null && !result.isEmpty()) {
                     log = result.get(result.size() - 1);
                 }


### PR DESCRIPTION
@mswiderski As discussed, here is the fix. I have tested it on our Jenkins with all databases and it passed 3 times in a row. The reason why I don't include a test is that this test which was able to reproduce it in plain jBPM engine took more than minute for some databases (generating a big amount of data so query can clash wrong data), so I think it is not worth including it. We will still be able to verify it in KIE Server tests though. Thanks!

Marian