### PR TITLE
[7.7.x] RHBA-611 - The system property org.jbpm.rm.init.timer should be set a…

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/test/ejbservices/EDeploymentTest.java
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/test/ejbservices/EDeploymentTest.java
@@ -71,5 +71,10 @@ public class EDeploymentTest extends AbstractEJBServicesTest {
         DeployedUnit undeployed = deploymentService.getDeployedUnit(basicKieJar.getIdentifier());
         Assertions.assertThat(undeployed).isNull();
     }
+    
+    @Test
+    public void testEJBTimerServiceInitTimersDeactivated() {
+        Assertions.assertThat(System.getProperty("org.jbpm.rm.init.timer")).isEqualTo("false");
+    }
 
 }

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EJBTimerScheduler.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EJBTimerScheduler.java
@@ -18,11 +18,11 @@ package org.jbpm.services.ejb.timer;
 
 import java.io.Serializable;
 import java.util.Date;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
 import javax.ejb.ConcurrencyManagement;
 import javax.ejb.ConcurrencyManagementType;
@@ -55,6 +55,12 @@ public class EJBTimerScheduler {
 	
 	@Resource
 	private javax.ejb.TimerService timerService;
+	
+	@PostConstruct
+	public void setup() {
+	    // disable auto init of timers since ejb timer service supports persistence of timers
+	    System.setProperty("org.jbpm.rm.init.timer", "false");
+	}
 	
 	@SuppressWarnings("unchecked")
 	@Timeout


### PR DESCRIPTION
…s false by default in jbpm ejb timer service

Backport of one commit from #1165 for 7.7.x.

@mswiderski AFAIK from JIRA, the second commit (JBPM-7071) is supposed to be fixed only on 7.8.x, so I think it is not needed on 7.7.x, right?