### PR TITLE
RHPAM-1192: Error in the tasks search by potential owners

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/RuntimeDataServiceImpl.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/RuntimeDataServiceImpl.java
@@ -836,7 +836,7 @@ public class RuntimeDataServiceImpl implements RuntimeDataService, DeploymentEve
 	public List<TaskSummary> getTasksAssignedAsPotentialOwner(String userId, List<String> groupIds, QueryFilter filter) {
 	    Map<String, Object> params = new HashMap<String, Object>();
         params.put("userId", userId);        
-        params.put("groupIds", getCallbackUserRoles(userGroupCallback, userId));
+        params.put("groupIds", mergeLists(groupIds, getCallbackUserRoles(userGroupCallback, userId)));
         
         applyQueryContext(params, filter);
         applyQueryFilter(params, filter);
@@ -847,7 +847,7 @@ public class RuntimeDataServiceImpl implements RuntimeDataService, DeploymentEve
 	public List<TaskSummary> getTasksAssignedAsPotentialOwner(String userId, List<String> groupIds, List<Status> status, QueryFilter filter) {
 	    Map<String, Object> params = new HashMap<String, Object>();
         params.put("userId", userId);        
-        params.put("groupIds", adoptList(groupIds, getCallbackUserRoles(userGroupCallback, userId)));
+        params.put("groupIds", mergeLists(groupIds, getCallbackUserRoles(userGroupCallback, userId)));
         params.put("status", adoptList(status, allActiveStatus));  
         
         applyQueryContext(params, filter);
@@ -1337,12 +1337,22 @@ public class RuntimeDataServiceImpl implements RuntimeDataService, DeploymentEve
              for (Object value : values) {
                  data.add(value);
              }
-             
              return data;
          }
+         
          return source;
      }
      
+     protected List<?> mergeLists(List<?> source, List<?> values) {
+         List<Object> data = new ArrayList<Object>();  
+         data.addAll(values);
+        
+         if (source != null) {
+             data.addAll(source);
+         }
+         
+         return data;
+     }
      
 
 }

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/RuntimeDataServiceImplTaskLookupTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/RuntimeDataServiceImplTaskLookupTest.java
@@ -172,6 +172,30 @@ public class RuntimeDataServiceImplTaskLookupTest extends AbstractKieServicesBas
         processService.abortProcessInstance(processInstanceId);
         processInstanceId = null;
     }
+    
+    @Test
+    public void testGetTasksAssignedAsPotentialOwnerWithGroupsAndWrongUserId() {
+        asssertProcessInstance();
+        
+        List<String> managerList = Arrays.asList("managers");
+        
+        List<TaskSummary> taskSummaries = runtimeDataService.getTasksAssignedAsPotentialOwner("mcivantos", fakeGroupIds, new QueryFilter());
+        assertNotNull(taskSummaries);
+        assertEquals(0, taskSummaries.size());
+
+        taskSummaries = runtimeDataService.getTasksAssignedAsPotentialOwner("mcivantos", managerList, new QueryFilter());
+        assertNotNull(taskSummaries);
+        assertEquals(1, taskSummaries.size());
+
+        List<String> groupsList = Arrays.asList("managers", "admins");
+        
+        taskSummaries = runtimeDataService.getTasksAssignedAsPotentialOwner("mcivantos", groupsList, new QueryFilter());
+        assertNotNull(taskSummaries);
+        assertEquals(2, taskSummaries.size());
+
+        processService.abortProcessInstance(processInstanceId);
+        processInstanceId = null;
+    }
 
     @Test
     public void testGetTasksAssignedAsPotentialOwnerWithGroupsAndStatus() {
@@ -191,7 +215,7 @@ public class RuntimeDataServiceImplTaskLookupTest extends AbstractKieServicesBas
 
         taskSummaries = runtimeDataService.getTasksAssignedAsPotentialOwner("maciej", fakeGroupIds, readyStatusOnly, new QueryFilter());
         assertNotNull(taskSummaries);
-        assertEquals(0, taskSummaries.size());
+        assertEquals(1, taskSummaries.size());
 
         taskSummaries = runtimeDataService.getTasksAssignedAsPotentialOwner("maciej", null, suspendedStatusOnly, new QueryFilter());
         assertNotNull(taskSummaries);


### PR DESCRIPTION
@mswiderski  We've detected some incoherence in the tasks search by pot-owner. When the group is set:
- With status=null: the groupIds set in the input parameters isn't taken into account.
- With status not null: the groupIds set in the input parameters is taken into account.

And in all the queries used in this method (for example: https://github.com/kiegroup/jbpm/blob/4b5895028198c2ba6d3abf06ce2bd8c1a05d3c33/jbpm-human-task/jbpm-human-task-jpa/src/main/resources/META-INF/Taskorm.xml#L225) the where clause takes into account as pot-owner the userId OR the groups, but when the group is set in the input parameters the userId's groups aren't taken into account. 
