### PR TITLE
Stabilize EventEmitter tests

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/CompensationTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/CompensationTest.java
@@ -16,17 +16,22 @@
 
 package org.jbpm.bpmn2;
 
+import static org.junit.Assert.assertThat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
 import org.hamcrest.core.AnyOf;
 import org.hamcrest.core.Is;
+import org.hamcrest.core.IsCollectionContaining;
 import org.jbpm.bpmn2.objects.TestWorkItemHandler;
+import org.jbpm.process.audit.VariableInstanceLog;
 import org.jbpm.process.core.context.exception.CompensationScope;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.junit.After;
@@ -46,8 +51,6 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class CompensationTest extends JbpmBpmn2TestCase {
@@ -261,9 +264,11 @@ public class CompensationTest extends JbpmBpmn2TestCase {
         assertProcessInstanceCompleted(processInstance.getId(), ksession);
         if( ! isPersistence() ) { 
             assertProcessVarValue(processInstance, "x", null);
-        } else { 
-            String actualValue = getProcessVarValue(processInstance, "x");
-            assertThat(actualValue, AnyOf.anyOf(Is.is(""), Is.is(" "), Is.is((String) null)));
+        } else {
+            // We need to check it this way because of some databases like Oracle RAC etc.
+            List<VariableInstanceLog> logs = logService.findVariableInstances(processInstance.getId(), "x");
+            List<String> values = logs.stream().map(VariableInstanceLog::getValue).collect(Collectors.toList());
+            assertThat(values, IsCollectionContaining.hasItem(AnyOf.anyOf(Is.is(" "), Is.is(""), Is.is((String) null))));
         }
     }
     

--- a/jbpm-persistence/jbpm-persistence-api/src/main/java/org/jbpm/persistence/api/integration/base/TransactionalPersistenceEventManager.java
+++ b/jbpm-persistence/jbpm-persistence-api/src/main/java/org/jbpm/persistence/api/integration/base/TransactionalPersistenceEventManager.java
@@ -40,7 +40,7 @@ public class TransactionalPersistenceEventManager implements PersistenceEventMan
     private static final Logger logger = LoggerFactory.getLogger(TransactionalPersistenceEventManager.class);
     private static final String EVENT_COLLECTION = "org.jbpm.integration.events";
     
-    private TransactionManager tm;
+    protected TransactionManager tm;
     private EventEmitter emitter;
     
     

--- a/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/processinstance/objects/TestTransactionalPersistenceEventManager.java
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/processinstance/objects/TestTransactionalPersistenceEventManager.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.persistence.processinstance.objects;
+
+import org.drools.persistence.api.TransactionManagerFactory;
+import org.jbpm.persistence.api.integration.base.TransactionalPersistenceEventManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test extension of <code>TransactionalPersistenceEventManager</code>.
+ */
+public class TestTransactionalPersistenceEventManager extends TransactionalPersistenceEventManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestTransactionalPersistenceEventManager.class);
+
+    public void resetTransactionManager() {
+        logger.debug("Reseting Transaction Manager");
+        this.tm = TransactionManagerFactory.get().newTransactionManager();
+    }
+}

--- a/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/session/PersistentStatefulSessionTest.java
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/session/PersistentStatefulSessionTest.java
@@ -32,8 +32,10 @@ import javax.transaction.UserTransaction;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseFactory;
 import org.drools.core.io.impl.ClassPathResource;
+import org.jbpm.persistence.api.integration.EventManagerProvider;
 import org.jbpm.persistence.api.integration.InstanceView;
 import org.jbpm.persistence.processinstance.objects.TestEventEmitter;
+import org.jbpm.persistence.processinstance.objects.TestTransactionalPersistenceEventManager;
 import org.jbpm.persistence.session.objects.TestWorkItemHandler;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.jbpm.test.util.AbstractBaseTest;
@@ -656,6 +658,8 @@ public class PersistentStatefulSessionTest extends AbstractBaseTest {
 
     @Test
     public void testIntegrationWithEventManager3() {
+        // Because of MapBasedPersistenceTest we have to be sure that we register TX sync on the right transaction manager
+        ((TestTransactionalPersistenceEventManager) EventManagerProvider.getInstance().get()).resetTransactionManager();
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add( new ClassPathResource( "WorkItemsProcess.rf" ),
                       ResourceType.DRF );

--- a/jbpm-persistence/jbpm-persistence-jpa/src/test/resources/META-INF/services/org.jbpm.persistence.api.integration.PersistenceEventManager
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/test/resources/META-INF/services/org.jbpm.persistence.api.integration.PersistenceEventManager
@@ -1,0 +1,1 @@
+org.jbpm.persistence.processinstance.objects.TestTransactionalPersistenceEventManager


### PR DESCRIPTION
@mswiderski I have found the testIntegrationWithEventManager3 test failing in case MapBasedPersistenceTest is run before it. I think the issue was that these tests introduce their own Transaction Manager [here](https://github.com/kiegroup/jbpm/blob/master/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/map/impl/MapBasedPersistenceTest.java#L53) which is actually ManualProcessTransactionManager. In such a case, MapBased tests registered their own TX manager and when TransactionalPersistenceEventManager creates its tx manager [here](https://github.com/kiegroup/jbpm/blob/master/jbpm-persistence/jbpm-persistence-api/src/main/java/org/jbpm/persistence/api/integration/base/TransactionalPersistenceEventManager.java#L48) it does not find all thing it needs via JNDI, so then tx sync is not synchronized since everything is null [there](https://github.com/kiegroup/drools/blob/master/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java#L303). Therefore, no events are persisted. Now when it is the other way around, during MapBased tests we get no tx active to register sync, since it registers sync on different tx manager than the manual one used by tests, but that's not an issue since we don't need it there.

So I have created a TestTransactionalPersistenceEventManager which is an extension of an ordinary one which we can reset to recreate the right jta tx manager.


Moreover, I slightly altered one compensation test method since on some DBs it returns wrong values if they are within the same timestamp. 

I hope it is understandable and my findings are correct. But I can say that it works on our Jenkins after this change.