### PR TITLE
Exclude jboss-jaxb-api_2.2_spec from WebSphere

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/shrinkwrap-war-profiles/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/shrinkwrap-war-profiles/pom.xml
@@ -149,6 +149,11 @@
               <groupId>xml-apis</groupId>
               <artifactId>xml-apis</artifactId>
             </exclusion>
+            <!-- conflicts on WAS -->
+            <exclusion>
+              <groupId>org.jboss.spec.javax.xml.bind</groupId>
+              <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+            </exclusion>
           </exclusions>
         </dependency>
       </dependencies>


### PR DESCRIPTION
There are conflicts on WAS when creating an XML from deployment descriptor. This fixes it.