### PR TITLE
RHPAM-1271 KIE database creation does not include indexes

### DIFF
--- a/jbpm-audit/src/main/java/org/jbpm/process/audit/NodeInstanceLog.java
+++ b/jbpm-audit/src/main/java/org/jbpm/process/audit/NodeInstanceLog.java
@@ -24,13 +24,18 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
 import org.jbpm.process.audit.event.AuditEvent;
 
 @Entity
+@Table(name = "NodeInstanceLog", indexes = {@Index(name = "IDX_NInstLog_pInstId", columnList = "processInstanceId"),
+                                        @Index(name = "IDX_NInstLog_nodeType", columnList = "nodeType"),
+                                        @Index(name = "IDX_NInstLog_pId", columnList = "processId")})
 @SequenceGenerator(name="nodeInstanceLogIdSeq", sequenceName="NODE_INST_LOG_ID_SEQ", allocationSize=1)
 public class NodeInstanceLog implements Serializable, AuditEvent, org.kie.api.runtime.manager.audit.NodeInstanceLog {
    

--- a/jbpm-audit/src/main/java/org/jbpm/process/audit/ProcessInstanceLog.java
+++ b/jbpm-audit/src/main/java/org/jbpm/process/audit/ProcessInstanceLog.java
@@ -24,7 +24,9 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
@@ -33,6 +35,20 @@ import org.jbpm.process.audit.event.AuditEventBuilder;
 import org.kie.api.runtime.KieRuntime;
 
 @Entity
+@Table(name = "ProcessInstanceLog", indexes = {@Index(name = "IDX_PInstLog_duration", columnList = "duration"),
+                                        @Index(name = "IDX_PInstLog_end_date", columnList = "end_date"),
+                                        @Index(name = "IDX_PInstLog_extId", columnList = "externalId"),
+                                        @Index(name = "IDX_PInstLog_user_identity", columnList = "user_identity"),
+                                        @Index(name = "IDX_PInstLog_outcome", columnList = "outcome"),
+                                        @Index(name = "IDX_PInstLog_parentPInstId", columnList = "parentProcessInstanceId"),
+                                        @Index(name = "IDX_PInstLog_pId", columnList = "processId"),
+                                        @Index(name = "IDX_PInstLog_pInsteDescr", columnList = "processInstanceDescription"),
+                                        @Index(name = "IDX_PInstLog_pInstId", columnList = "processInstanceId"),
+                                        @Index(name = "IDX_PInstLog_pName", columnList = "processName"),
+                                        @Index(name = "IDX_PInstLog_pVersion", columnList = "processVersion"),
+                                        @Index(name = "IDX_PInstLog_start_date", columnList = "start_date"),
+                                        @Index(name = "IDX_PInstLog_status", columnList = "status"),
+                                        @Index(name = "IDX_PInstLog_correlation", columnList = "correlationKey")})
 @SequenceGenerator(name="processInstanceLogIdSeq", sequenceName="PROC_INST_LOG_ID_SEQ", allocationSize=1)
 public class ProcessInstanceLog implements Serializable, AuditEvent, org.kie.api.runtime.manager.audit.ProcessInstanceLog {
     

--- a/jbpm-audit/src/main/java/org/jbpm/process/audit/VariableInstanceLog.java
+++ b/jbpm-audit/src/main/java/org/jbpm/process/audit/VariableInstanceLog.java
@@ -24,7 +24,9 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.Transient;
@@ -34,6 +36,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Entity
+@Table(name = "VariableInstanceLog", indexes = {@Index(name = "IDX_VInstLog_pInstId", columnList = "processInstanceId"),
+                                               @Index(name = "IDX_VInstLog_varId", columnList = "variableId"),
+                                               @Index(name = "IDX_VInstLog_pId", columnList = "processId")})
 @SequenceGenerator(name="variableInstanceLogIdSeq", sequenceName="VAR_INST_LOG_ID_SEQ", allocationSize=1)
 public class VariableInstanceLog implements Serializable, AuditEvent, org.kie.api.runtime.manager.audit.VariableInstanceLog {
     

--- a/jbpm-human-task/jbpm-human-task-audit/src/main/java/org/jbpm/services/task/audit/impl/model/BAMTaskSummaryImpl.java
+++ b/jbpm-human-task/jbpm-human-task-audit/src/main/java/org/jbpm/services/task/audit/impl/model/BAMTaskSummaryImpl.java
@@ -23,6 +23,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
@@ -30,7 +31,17 @@ import javax.persistence.TemporalType;
 import javax.persistence.Version;
 
 @Entity
-@Table(name="BAMTaskSummary")
+@Table(name="BAMTaskSummary",
+       indexes = {@Index(name = "IDX_BAMTaskSumm_createdDate",  columnList="createdDate"),
+                  @Index(name = "IDX_BAMTaskSumm_duration",  columnList="duration"),
+                  @Index(name = "IDX_BAMTaskSumm_endDate",  columnList="endDate"),
+                  @Index(name = "IDX_BAMTaskSumm_pInstId",  columnList="processInstanceId"),
+                  @Index(name = "IDX_BAMTaskSumm_startDate",  columnList="startDate"),
+                  @Index(name = "IDX_BAMTaskSumm_status",  columnList="status"),
+                  @Index(name = "IDX_BAMTaskSumm_taskId",  columnList="taskId"),
+                  @Index(name = "IDX_BAMTaskSumm_taskName",  columnList="taskName"),
+                  @Index(name = "IDX_BAMTaskSumm_userId", columnList="userId")})
+
 @SequenceGenerator(name="bamTaskIdSeq", sequenceName="BAM_TASK_ID_SEQ")
 public class BAMTaskSummaryImpl implements Serializable {
 

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/AttachmentImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/AttachmentImpl.java
@@ -27,6 +27,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
@@ -37,7 +38,10 @@ import org.kie.internal.task.api.model.AccessType;
 import org.kie.internal.task.api.model.InternalAttachment;
 
 @Entity
-@Table(name="Attachment")
+@Table(name="Attachment",
+       indexes = {@Index(name = "IDX_Attachment_Id",  columnList="attachedBy_id"),
+                  @Index(name = "IDX_Attachment_DataId", columnList="TaskData_Attachments_Id")})
+
 @SequenceGenerator(name="attachmentIdSeq", sequenceName="ATTACHMENT_ID_SEQ", allocationSize=1)
 public class AttachmentImpl implements InternalAttachment {
     

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/BooleanExpressionImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/BooleanExpressionImpl.java
@@ -25,12 +25,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Lob;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 @Entity
-@Table(name="BooleanExpression")
+@Table(name="BooleanExpression",
+       indexes = {@Index(name = "IDX_BoolExpr_Id",  columnList="Escalation_Constraints_Id")})
 @SequenceGenerator(name="booleanExprIdSeq", sequenceName="BOOLEANEXPR_ID_SEQ", allocationSize=1)
 public class BooleanExpressionImpl implements org.kie.internal.task.api.model.BooleanExpression {
     

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/CommentImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/CommentImpl.java
@@ -27,6 +27,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
@@ -36,7 +37,9 @@ import org.kie.api.task.model.User;
 import org.kie.internal.task.api.model.InternalComment;
 
 @Entity
-@Table(name = "task_comment")
+@Table(name = "task_comment",
+       indexes = {@Index(name = "IDX_TaskComments_CreatedBy",  columnList="addedBy_id"),
+                  @Index(name = "IDX_TaskComments_Id", columnList="TaskData_Comments_Id")})
 @SequenceGenerator(name="commentIdSeq", sequenceName="COMMENT_ID_SEQ", allocationSize=1)
 public class CommentImpl implements InternalComment  {
     

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/DeadlineImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/DeadlineImpl.java
@@ -29,6 +29,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
@@ -39,7 +40,9 @@ import org.kie.api.task.model.I18NText;
 import org.kie.internal.task.api.model.Escalation;
 
 @Entity
-@Table(name="Deadline")
+@Table(name="Deadline",
+       indexes = {@Index(name = "IDX_Deadline_StartId",  columnList="Deadlines_StartDeadLine_Id"),
+                  @Index(name = "IDX_Deadline_EndId", columnList="Deadlines_EndDeadLine_Id")})
 @SequenceGenerator(name="deadlineIdSeq", sequenceName="DEADLINE_ID_SEQ", allocationSize=1)
 public class DeadlineImpl implements org.kie.internal.task.api.model.Deadline {
 

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/DelegationImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/DelegationImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -39,7 +40,9 @@ public class DelegationImpl  implements org.kie.internal.task.api.model.Delegati
     private AllowedToDelegate                    allowedToDelegate;
     
     @ManyToMany(targetEntity=OrganizationalEntityImpl.class)
-    @JoinTable(name = "Delegation_delegates", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"))    
+    @JoinTable(name = "Delegation_delegates", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"),
+       indexes = {@Index(name = "IDX_Delegation_EntityId",  columnList="entity_id"),
+                  @Index(name = "IDX_Delegation_TaskId", columnList="task_id")})
     private List<OrganizationalEntity> delegates = Collections.emptyList();
     
     public void writeExternal(ObjectOutput out) throws IOException {

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/EscalationImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/EscalationImpl.java
@@ -27,6 +27,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
@@ -38,7 +39,8 @@ import org.kie.internal.task.api.model.Notification;
 import org.kie.internal.task.api.model.Reassignment;
 
 @Entity
-@Table(name="Escalation")
+@Table(name="Escalation",
+       indexes = {@Index(name = "IDX_Escalation_Id",  columnList="Deadline_Escalation_Id")})
 @SequenceGenerator(name="escalationIdSeq", sequenceName="ESCALATION_ID_SEQ", allocationSize=1)
 public class EscalationImpl implements org.kie.internal.task.api.model.Escalation {
 

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/I18NTextImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/I18NTextImpl.java
@@ -26,6 +26,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Lob;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
@@ -33,7 +34,16 @@ import javax.persistence.Table;
 import org.kie.internal.task.api.model.InternalI18NText;
 
 @Entity
-@Table(name="I18NText")
+@Table(name="I18NText",
+       indexes = {@Index(name = "IDX_I18NText_SubjId",  columnList="Task_Subjects_Id"),
+                  @Index(name = "IDX_I18NText_NameId",  columnList="Task_Names_Id"),
+                  @Index(name = "IDX_I18NText_DescrId",  columnList="Task_Descriptions_Id"),
+                  @Index(name = "IDX_I18NText_ReassignId",  columnList="Reassignment_Documentation_Id"),
+                  @Index(name = "IDX_I18NText_NotSubjId",  columnList="Notification_Subjects_Id"),
+                  @Index(name = "IDX_I18NText_NotNamId",  columnList="Notification_Names_Id"),
+                  @Index(name = "IDX_I18NText_NotDocId",  columnList="Notification_Documentation_Id"),
+                  @Index(name = "IDX_I18NText_NotDescrId",  columnList="Notification_Descriptions_Id"),
+                  @Index(name = "IDX_I18NText_DeadDocId", columnList="Deadline_Documentation_Id")})
 @SequenceGenerator(name="i18nTextIdSeq", sequenceName="I18NTEXT_ID_SEQ", allocationSize=1)
 public class I18NTextImpl implements InternalI18NText {
     

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/NotificationImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/NotificationImpl.java
@@ -28,6 +28,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -41,7 +42,8 @@ import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.internal.task.api.model.NotificationType;
 
 @Entity
-@Table(name="Notification")
+@Table(name="Notification",
+       indexes = {@Index(name = "IDX_Not_EscId",  columnList="Escalation_Notifications_Id")})
 @SequenceGenerator(name="notificationIdSeq", sequenceName="NOTIFICATION_ID_SEQ", allocationSize=1)
 public class NotificationImpl implements org.kie.internal.task.api.model.Notification  {
     
@@ -57,11 +59,15 @@ public class NotificationImpl implements org.kie.internal.task.api.model.Notific
     private int                              priority;
     
     @ManyToMany(targetEntity=OrganizationalEntityImpl.class)
-    @JoinTable(name = "Notification_Recipients", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"))    
+    @JoinTable(name = "Notification_Recipients", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"),
+       indexes = {@Index(name = "IDX_NotRec_Entity",  columnList="entity_id"),
+                  @Index(name = "IDX_NotRec_Task", columnList="task_id")})
     private List<OrganizationalEntity>       recipients = Collections.emptyList();
 
     @ManyToMany(targetEntity=OrganizationalEntityImpl.class)
-    @JoinTable(name = "Notification_BAs", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"))
+    @JoinTable(name = "Notification_BAs", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"),
+       indexes = {@Index(name = "IDX_NotBAs_Entity",  columnList="entity_id"),
+                  @Index(name = "IDX_NotBAs_Task", columnList="task_id")})
     private List<OrganizationalEntity>       businessAdministrators = Collections.emptyList();
 
     @OneToMany(cascade = CascadeType.ALL, targetEntity=I18NTextImpl.class)

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/PeopleAssignmentsImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/PeopleAssignmentsImpl.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.persistence.Embeddable;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -45,23 +46,33 @@ public class PeopleAssignmentsImpl implements InternalPeopleAssignments {
     private UserImpl                       taskInitiator;
 
     @ManyToMany(targetEntity=OrganizationalEntityImpl.class)
-    @JoinTable(name = "PeopleAssignments_PotOwners", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"))
+    @JoinTable(name = "PeopleAssignments_PotOwners", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"),
+       indexes = {@Index(name = "IDX_PAsPot_Entity",  columnList="entity_id"),
+                  @Index(name = "IDX_PAsPot_Task", columnList="task_id")})
     private List<OrganizationalEntity> potentialOwners        = Collections.emptyList();
 
     @ManyToMany(targetEntity=OrganizationalEntityImpl.class)
-    @JoinTable(name = "PeopleAssignments_ExclOwners", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"))
+    @JoinTable(name = "PeopleAssignments_ExclOwners", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"),
+       indexes = {@Index(name = "IDX_PAsExcl_Entity",  columnList="entity_id"),
+                  @Index(name = "IDX_PAsExcl_Task", columnList="task_id")})
     private List<OrganizationalEntity> excludedOwners         = Collections.emptyList();
 
     @ManyToMany(targetEntity=OrganizationalEntityImpl.class)
-    @JoinTable(name = "PeopleAssignments_Stakeholders", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"))
+    @JoinTable(name = "PeopleAssignments_Stakeholders", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"),
+       indexes = {@Index(name = "IDX_PAsStake_Entity",  columnList="entity_id"),
+                  @Index(name = "IDX_PAsStake_Task", columnList="task_id")})
     private List<OrganizationalEntity> taskStakeholders       = Collections.emptyList();
 
     @ManyToMany(targetEntity=OrganizationalEntityImpl.class)
-    @JoinTable(name = "PeopleAssignments_BAs", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"))
+    @JoinTable(name = "PeopleAssignments_BAs", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"),
+       indexes = {@Index(name = "IDX_PAsBAs_Entity",  columnList="entity_id"),
+                  @Index(name = "IDX_PAsBAs_Task", columnList="task_id")})
     private List<OrganizationalEntity> businessAdministrators = Collections.emptyList();
 
     @ManyToMany(targetEntity=OrganizationalEntityImpl.class)
-    @JoinTable(name = "PeopleAssignments_Recipients", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"))
+    @JoinTable(name = "PeopleAssignments_Recipients", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"),
+       indexes = {@Index(name = "IDX_PAsRecip_Entity",  columnList="entity_id"),
+                  @Index(name = "IDX_PAsRecip_Task", columnList="task_id")})
     private List<OrganizationalEntity> recipients             = Collections.emptyList();
 
     public PeopleAssignmentsImpl() {

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/ReassignmentImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/ReassignmentImpl.java
@@ -27,6 +27,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -39,7 +40,8 @@ import org.kie.api.task.model.I18NText;
 import org.kie.api.task.model.OrganizationalEntity;
 
 @Entity
-@Table(name="Reassignment")
+@Table(name="Reassignment",
+       indexes = {@Index(name = "IDX_Reassign_Esc",  columnList="Escalation_Reassignments_Id")})
 @SequenceGenerator(name="reassignmentIdSeq", sequenceName="REASSIGNMENT_ID_SEQ", allocationSize=1)
 public class ReassignmentImpl implements org.kie.internal.task.api.model.Reassignment {
     
@@ -52,7 +54,9 @@ public class ReassignmentImpl implements org.kie.internal.task.api.model.Reassig
     private List<I18NText>             documentation = Collections.emptyList();
     
     @ManyToMany(targetEntity=OrganizationalEntityImpl.class)
-    @JoinTable(name = "Reassignment_potentialOwners", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"))    
+    @JoinTable(name = "Reassignment_potentialOwners", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "entity_id"),
+       indexes = {@Index(name = "IDX_ReassignPO_Entity",  columnList="entity_id"),
+                  @Index(name = "IDX_ReassignPO_Task", columnList="task_id")})
     private List<OrganizationalEntity> potentialOwners = Collections.emptyList();
 
     public void writeExternal(ObjectOutput out) throws IOException {

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/TaskImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/TaskImpl.java
@@ -33,6 +33,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
@@ -49,7 +50,15 @@ import org.kie.internal.task.api.model.InternalTask;
 import org.kie.internal.task.api.model.SubTasksStrategy;
 
 @Entity
-@Table(name="Task")
+@Table(name="Task",
+       indexes = {@Index(name = "IDX_Task_Initiator",  columnList="taskInitiator_id"),
+                  @Index(name = "IDX_Task_ActualOwner",  columnList="actualOwner_id"),
+                  @Index(name = "IDX_Task_CreatedBy",  columnList="createdBy_id"),
+                  @Index(name = "IDX_Task_processInstanceId",  columnList="processInstanceId"),
+                  @Index(name = "IDX_Task_processId",  columnList="processId"),
+                  @Index(name = "IDX_Task_status",  columnList="status"),
+                  @Index(name = "IDX_Task_archived",  columnList="archived"),
+                  @Index(name = "IDX_Task_workItemId", columnList="workItemId")})
 @SequenceGenerator(name="taskIdSeq", sequenceName="TASK_ID_SEQ", allocationSize=1)
 public class TaskImpl implements InternalTask {
     /**

--- a/jbpm-persistence/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/correlation/CorrelationPropertyInfo.java
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/correlation/CorrelationPropertyInfo.java
@@ -22,13 +22,16 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import javax.persistence.Version;
 
 import org.kie.internal.process.CorrelationProperty;
 
 @Entity
+@Table(name = "CorrelationPropertyInfo", indexes = {@Index(name = "IDX_CorrPropInfo_Id", columnList = "correlationKey_keyId")})
 @SequenceGenerator(name="correlationPropertyInfoIdSeq", sequenceName="CORRELATION_PROP_ID_SEQ")
 public class CorrelationPropertyInfo implements CorrelationProperty<String>, Serializable {
 

--- a/jbpm-persistence/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/processinstance/ProcessInstanceInfo.java
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/processinstance/ProcessInstanceInfo.java
@@ -33,6 +33,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.SequenceGenerator;
@@ -82,7 +83,10 @@ public class ProcessInstanceInfo implements PersistentProcessInstance {
     byte[]                                    processInstanceByteArray;
 
     @ElementCollection
-    @CollectionTable(name="EventTypes", joinColumns=@JoinColumn(name="InstanceId"))
+    @CollectionTable(name="EventTypes", joinColumns=@JoinColumn(name="InstanceId"),
+       indexes = {@Index(name = "IDX_EventTypes_Id",  columnList="InstanceId"),
+                  @Index(name = "IDX_EventTypes_element", columnList="element")})
+
     @Column(name="element")
     private Set<String>                       eventTypes         = new HashSet<String>();
     

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/jpa/ContextMappingInfo.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/jpa/ContextMappingInfo.java
@@ -22,9 +22,11 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import javax.persistence.Version;
 
 /**
@@ -37,6 +39,9 @@ import javax.persistence.Version;
  * This entity must be included in the persistence.xml when the "Per Process Instance" strategy is used.
  */
 @Entity
+@Table(name = "ContextMappingInfo", indexes = {@Index(name = "IDX_CMI_Context", columnList = "CONTEXT_ID"),
+                                        @Index(name = "IDX_CMI_KSession", columnList = "KSESSION_ID"),
+                                        @Index(name = "IDX_CMI_Owner", columnList = "OWNER_ID")})
 @SequenceGenerator(name="contextMappingInfoIdSeq", sequenceName="CONTEXT_MAPPING_INFO_ID_SEQ")
 @NamedQueries(value=
     {@NamedQuery(name="FindContextMapingByContextId", 

--- a/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/entities/ErrorInfo.java
+++ b/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/entities/ErrorInfo.java
@@ -24,9 +24,11 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.Transient;
@@ -35,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Entity
+@Table(name = "ErrorInfo", indexes = {@Index(name = "IDX_ErrorInfo_Id", columnList = "REQUEST_ID")})
 @SequenceGenerator(name="errorInfoIdSeq", sequenceName="ERROR_INFO_ID_SEQ")
 public class ErrorInfo implements org.kie.internal.executor.api.ErrorInfo, Serializable {
 	

--- a/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/entities/RequestInfo.java
+++ b/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/entities/RequestInfo.java
@@ -31,9 +31,11 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Lob;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
@@ -41,6 +43,9 @@ import org.kie.api.executor.STATUS;
 
 
 @Entity
+@Table(name = "RequestInfo", indexes = {@Index(name = "IDX_RequestInfo_status", columnList = "status"),
+                                        @Index(name = "IDX_RequestInfo_timestamp", columnList = "timestamp"),
+                                        @Index(name = "IDX_RequestInfo_owner", columnList = "owner")})
 @SequenceGenerator(name="requestInfoIdSeq", sequenceName="REQUEST_INFO_ID_SEQ")
 public class RequestInfo implements org.kie.internal.executor.api.RequestInfo, Serializable {
 


### PR DESCRIPTION
Signed-off-by: calvin zhu <calvinzhu@hotmail.com>

This PR is for 
https://issues.jboss.org/browse/RHPAM-1271

It use JPA 2.1 annotation to create the indexes (index list is from jbpm-installer/src/main/resources/db/ddl-scripts)