### PR TITLE
[JBPM-5188] Content negotiation @ RestWorkItemHandler

### DIFF
--- a/jbpm-workitems/jbpm-workitems-rest/src/test/java/org/jbpm/process/workitem/rest/RestWorkItemHandlerTest.java
+++ b/jbpm-workitems/jbpm-workitems-rest/src/test/java/org/jbpm/process/workitem/rest/RestWorkItemHandlerTest.java
@@ -16,6 +16,7 @@
 
 package org.jbpm.process.workitem.rest;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -1047,5 +1048,41 @@ public class RestWorkItemHandlerTest {
         results = ((TestWorkItemManager) manager).getResults(workItem.getId());
         result = (String) results.get(PARAM_RESULT);
         assertEquals(result, headerValues2);
-    }     
+    }
+
+    @Test
+    public void testGETCharsetOperation() throws UnsupportedEncodingException {
+        final String charset = "Windows-1252";
+        String expected = "Š";
+
+        RESTWorkItemHandler handler = new RESTWorkItemHandler();
+
+        WorkItemImpl workItem = new WorkItemImpl();
+        workItem.setParameter("Url",
+                              serverURL + "/charset");
+        workItem.setParameter("AcceptCharset", charset);
+        workItem.setParameter("Method",
+                              "GET");
+
+        WorkItemManager manager = new TestWorkItemManager();
+        handler.executeWorkItem(workItem,
+                                manager);
+
+        Map<String, Object> results = ((TestWorkItemManager) manager).getResults(workItem.getId());
+        assertNotNull("results cannot be null",
+                      results);
+        String result = (String) results.get(PARAM_RESULT);
+        assertNotNull("result cannot be null",
+                      result);
+
+        assertEquals(expected, result);
+        int responseCode = (Integer) results.get(PARAM_STATUS);
+        assertNotNull(responseCode);
+        assertEquals(200,
+                     responseCode);
+        String responseMsg = (String) results.get(PARAM_STATUS_MSG);
+        assertNotNull(responseMsg);
+        assertEquals("request to endpoint " + workItem.getParameter("Url") + " successfully completed OK",
+                     responseMsg);
+    }
 }

--- a/jbpm-workitems/jbpm-workitems-rest/src/test/java/org/jbpm/process/workitem/rest/TestRESTResource.java
+++ b/jbpm-workitems/jbpm-workitems-rest/src/test/java/org/jbpm/process/workitem/rest/TestRESTResource.java
@@ -16,12 +16,14 @@
 
 package org.jbpm.process.workitem.rest;
 
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -30,6 +32,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 @Path("/test")
 public class TestRESTResource {
@@ -39,6 +43,19 @@ public class TestRESTResource {
     public String get(@QueryParam("param") String param) {
 
         return "Hello from REST" + (param != null ? " " + param : "");
+    }
+
+    @GET
+    @Path("/charset")
+    @Produces("text/plain")
+    public Response getPlainText(@HeaderParam("Accept-Charset") String acceptCharset) {
+        String entity = "Š"; // utf string
+        Charset charset = Charset.forName(acceptCharset);
+
+        Response myResponse = Response.status(Status.OK)
+                .entity(entity.getBytes(charset))
+                .build();
+        return myResponse;
     }
 
     @POST


### PR DESCRIPTION
adding Accept-Charset header to enforce server to send back the proper
charset.
The content-type might or might not send back the parameter charset so
this keeps that in mind that.