### PR TITLE
DROOLS-1393 - Investigate why JpaOptLockPersistentStatefulSessionTest…

### DIFF
--- a/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/error/ExecutionErrorHandlingRuntimeManagerTest.java
+++ b/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/error/ExecutionErrorHandlingRuntimeManagerTest.java
@@ -284,7 +284,7 @@ public class ExecutionErrorHandlingRuntimeManagerTest extends AbstractBaseTest {
         
         List<ExecutionError> errors = storage.list(0, 10);
         assertNotNull(errors);
-        assertEquals(expectedErrors, errors.size());
+        assertTrue(errors.size() >= expectedErrors);
         assertExecutionError(errors.get(0), "DB", "UserTaskWithRollback", "Hello");      
 
     }


### PR DESCRIPTION
… is failing with Hibernate 5

depends on https://github.com/kiegroup/drools/pull/2019

this change is needed as on per request strategy the session is destroyed and thus causes now additional error from narayana about failure in delisting connection from transaction. 