### PR TITLE
JBPM-7667 - no index created for AuditTaskImpl table - fix long index…

### DIFF
--- a/jbpm-human-task/jbpm-human-task-audit/src/main/java/org/jbpm/services/task/audit/impl/model/AuditTaskImpl.java
+++ b/jbpm-human-task/jbpm-human-task-audit/src/main/java/org/jbpm/services/task/audit/impl/model/AuditTaskImpl.java
@@ -31,7 +31,7 @@ import org.kie.internal.task.api.AuditTask;
 @Entity
 @Table(name = "AuditTaskImpl", indexes = {
         @Index(name = "IDX_AuditTaskImpl_taskId", columnList = "taskId"),
-        @Index(name = "IDX_AuditTaskImpl_processInstanceId", columnList = "processInstanceId"),
+        @Index(name = "IDX_AuditTaskImpl_pInstId", columnList = "processInstanceId"),
         @Index(name = "IDX_AuditTaskImpl_workItemId", columnList = "workItemId"),
         @Index(name = "IDX_AuditTaskImpl_name", columnList = "name"),
         @Index(name = "IDX_AuditTaskImpl_processId", columnList = "processId"),

--- a/jbpm-installer/src/main/resources/db/ddl-scripts/db2/db2-jbpm-schema.sql
+++ b/jbpm-installer/src/main/resources/db/ddl-scripts/db2/db2-jbpm-schema.sql
@@ -804,7 +804,7 @@
     create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo(ERROR_ACK);
 
     create index IDX_AuditTaskImpl_taskId on AuditTaskImpl(taskId);
-    create index IDX_AuditTaskImpl_processInstanceId on AuditTaskImpl(processInstanceId);
+    create index IDX_AuditTaskImpl_pInstId on AuditTaskImpl(processInstanceId);
     create index IDX_AuditTaskImpl_workItemId on AuditTaskImpl(workItemId);
     create index IDX_AuditTaskImpl_name on AuditTaskImpl(name);
     create index IDX_AuditTaskImpl_processId on AuditTaskImpl(processId);

--- a/jbpm-installer/src/main/resources/db/ddl-scripts/derby/derby-jbpm-schema.sql
+++ b/jbpm-installer/src/main/resources/db/ddl-scripts/derby/derby-jbpm-schema.sql
@@ -805,7 +805,7 @@
     create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo(ERROR_ACK);
 
     create index IDX_AuditTaskImpl_taskId on AuditTaskImpl(taskId);
-    create index IDX_AuditTaskImpl_processInstanceId on AuditTaskImpl(processInstanceId);
+    create index IDX_AuditTaskImpl_pInstId on AuditTaskImpl(processInstanceId);
     create index IDX_AuditTaskImpl_workItemId on AuditTaskImpl(workItemId);
     create index IDX_AuditTaskImpl_name on AuditTaskImpl(name);
     create index IDX_AuditTaskImpl_processId on AuditTaskImpl(processId);

--- a/jbpm-installer/src/main/resources/db/ddl-scripts/h2/h2-jbpm-schema.sql
+++ b/jbpm-installer/src/main/resources/db/ddl-scripts/h2/h2-jbpm-schema.sql
@@ -807,7 +807,7 @@
     create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo(ERROR_ACK);
 
     create index IDX_AuditTaskImpl_taskId on AuditTaskImpl(taskId);
-    create index IDX_AuditTaskImpl_processInstanceId on AuditTaskImpl(processInstanceId);
+    create index IDX_AuditTaskImpl_pInstId on AuditTaskImpl(processInstanceId);
     create index IDX_AuditTaskImpl_workItemId on AuditTaskImpl(workItemId);
     create index IDX_AuditTaskImpl_name on AuditTaskImpl(name);
     create index IDX_AuditTaskImpl_processId on AuditTaskImpl(processId);

--- a/jbpm-installer/src/main/resources/db/ddl-scripts/hsqldb/hsqldb-jbpm-schema.sql
+++ b/jbpm-installer/src/main/resources/db/ddl-scripts/hsqldb/hsqldb-jbpm-schema.sql
@@ -808,7 +808,7 @@
     create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo(ERROR_ACK);
 
     create index IDX_AuditTaskImpl_taskId on AuditTaskImpl(taskId);
-    create index IDX_AuditTaskImpl_processInstanceId on AuditTaskImpl(processInstanceId);
+    create index IDX_AuditTaskImpl_pInstId on AuditTaskImpl(processInstanceId);
     create index IDX_AuditTaskImpl_workItemId on AuditTaskImpl(workItemId);
     create index IDX_AuditTaskImpl_name on AuditTaskImpl(name);
     create index IDX_AuditTaskImpl_processId on AuditTaskImpl(processId);

--- a/jbpm-installer/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
+++ b/jbpm-installer/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
@@ -882,7 +882,7 @@
     create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo(ERROR_ACK);
 
     create index IDX_AuditTaskImpl_taskId on AuditTaskImpl(taskId);
-    create index IDX_AuditTaskImpl_processInstanceId on AuditTaskImpl(processInstanceId);
+    create index IDX_AuditTaskImpl_pInstId on AuditTaskImpl(processInstanceId);
     create index IDX_AuditTaskImpl_workItemId on AuditTaskImpl(workItemId);
     create index IDX_AuditTaskImpl_name on AuditTaskImpl(name);
     create index IDX_AuditTaskImpl_processId on AuditTaskImpl(processId);

--- a/jbpm-installer/src/main/resources/db/ddl-scripts/mysqlinnodb/mysql-innodb-jbpm-schema.sql
+++ b/jbpm-installer/src/main/resources/db/ddl-scripts/mysqlinnodb/mysql-innodb-jbpm-schema.sql
@@ -885,7 +885,7 @@
     create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo(ERROR_ACK);
 
     create index IDX_AuditTaskImpl_taskId on AuditTaskImpl(taskId);
-    create index IDX_AuditTaskImpl_processInstanceId on AuditTaskImpl(processInstanceId);
+    create index IDX_AuditTaskImpl_pInstId on AuditTaskImpl(processInstanceId);
     create index IDX_AuditTaskImpl_workItemId on AuditTaskImpl(workItemId);
     create index IDX_AuditTaskImpl_name on AuditTaskImpl(name);
     create index IDX_AuditTaskImpl_processId on AuditTaskImpl(processId);

--- a/jbpm-installer/src/main/resources/db/ddl-scripts/oracle/oracle-jbpm-schema.sql
+++ b/jbpm-installer/src/main/resources/db/ddl-scripts/oracle/oracle-jbpm-schema.sql
@@ -873,7 +873,7 @@
     create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo(ERROR_ACK);
 
     create index IDX_AuditTaskImpl_taskId on AuditTaskImpl(taskId);
-    create index IDX_AuditTaskImpl_processInstanceId on AuditTaskImpl(processInstanceId);
+    create index IDX_AuditTaskImpl_pInstId on AuditTaskImpl(processInstanceId);
     create index IDX_AuditTaskImpl_workItemId on AuditTaskImpl(workItemId);
     create index IDX_AuditTaskImpl_name on AuditTaskImpl(name);
     create index IDX_AuditTaskImpl_processId on AuditTaskImpl(processId);

--- a/jbpm-installer/src/main/resources/db/ddl-scripts/postgresql/postgresql-jbpm-schema.sql
+++ b/jbpm-installer/src/main/resources/db/ddl-scripts/postgresql/postgresql-jbpm-schema.sql
@@ -874,7 +874,7 @@
     create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo(ERROR_ACK);
 
     create index IDX_AuditTaskImpl_taskId on AuditTaskImpl(taskId);
-    create index IDX_AuditTaskImpl_processInstanceId on AuditTaskImpl(processInstanceId);
+    create index IDX_AuditTaskImpl_pInstId on AuditTaskImpl(processInstanceId);
     create index IDX_AuditTaskImpl_workItemId on AuditTaskImpl(workItemId);
     create index IDX_AuditTaskImpl_name on AuditTaskImpl(name);
     create index IDX_AuditTaskImpl_processId on AuditTaskImpl(processId);

--- a/jbpm-installer/src/main/resources/db/ddl-scripts/sqlserver/sqlserver-jbpm-schema.sql
+++ b/jbpm-installer/src/main/resources/db/ddl-scripts/sqlserver/sqlserver-jbpm-schema.sql
@@ -808,7 +808,7 @@
     create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo(ERROR_ACK);
 
     create index IDX_AuditTaskImpl_taskId on AuditTaskImpl(taskId);
-    create index IDX_AuditTaskImpl_processInstanceId on AuditTaskImpl(processInstanceId);
+    create index IDX_AuditTaskImpl_pInstId on AuditTaskImpl(processInstanceId);
     create index IDX_AuditTaskImpl_workItemId on AuditTaskImpl(workItemId);
     create index IDX_AuditTaskImpl_name on AuditTaskImpl(name);
     create index IDX_AuditTaskImpl_processId on AuditTaskImpl(processId);

--- a/jbpm-installer/src/main/resources/db/ddl-scripts/sqlserver2008/sqlserver2008-jbpm-schema.sql
+++ b/jbpm-installer/src/main/resources/db/ddl-scripts/sqlserver2008/sqlserver2008-jbpm-schema.sql
@@ -808,7 +808,7 @@
     create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo(ERROR_ACK);
 
     create index IDX_AuditTaskImpl_taskId on AuditTaskImpl(taskId);
-    create index IDX_AuditTaskImpl_processInstanceId on AuditTaskImpl(processInstanceId);
+    create index IDX_AuditTaskImpl_pInstId on AuditTaskImpl(processInstanceId);
     create index IDX_AuditTaskImpl_workItemId on AuditTaskImpl(workItemId);
     create index IDX_AuditTaskImpl_name on AuditTaskImpl(name);
     create index IDX_AuditTaskImpl_processId on AuditTaskImpl(processId);

--- a/jbpm-installer/src/main/resources/db/ddl-scripts/sybase/sybase-jbpm-schema.sql
+++ b/jbpm-installer/src/main/resources/db/ddl-scripts/sybase/sybase-jbpm-schema.sql
@@ -900,7 +900,7 @@
     create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo(ERROR_ACK);
 
     create index IDX_AuditTaskImpl_taskId on AuditTaskImpl(taskId);
-    create index IDX_AuditTaskImpl_processInstanceId on AuditTaskImpl(processInstanceId);
+    create index IDX_AuditTaskImpl_pInstId on AuditTaskImpl(processInstanceId);
     create index IDX_AuditTaskImpl_workItemId on AuditTaskImpl(workItemId);
     create index IDX_AuditTaskImpl_name on AuditTaskImpl(name);
     create index IDX_AuditTaskImpl_processId on AuditTaskImpl(processId);


### PR DESCRIPTION
… identifier

@mswiderski this is the fix for ORA-00972: identifier is too long we spoke about. I chose the name we already use in other tables.