### PR TITLE
JBPM-7740 - UserGroupCallbackTaskCommand.doCallbackGroupsOperation() …

### DIFF
--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/OrganizationalEntityImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/OrganizationalEntityImpl.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
+import javax.persistence.Cacheable;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
@@ -28,6 +29,7 @@ import org.kie.internal.task.api.model.InternalOrganizationalEntity;
 
 @Entity
 @Table(name="OrganizationalEntity")
+@Cacheable
 public abstract class OrganizationalEntityImpl implements InternalOrganizationalEntity {
     
     @Id


### PR DESCRIPTION
…bottle-neck by large number of groupId

@tkobayas here is a one liner that enables cache for user and groups which seems to increase performance. See jira for details on how to configure it. Would you be able to give it a try with other than H2 database?

Here are results with cache enabled
```
A process instance started : pid = 1
2018-09-11 09:18:22,493 INFO  [main] [com.sample.ProcessJPATest] getTasksAssignedAsPotentialOwner 
2018-09-11 09:18:30,459 INFO  [main] [com.sample.ProcessJPATest] john starts a task : taskId = 1
2018-09-11 09:18:30,671 INFO  [main] [com.sample.ProcessJPATest] john completes a task : taskId = 1
Task1 Exit
Task2 Entry
2018-09-11 09:18:30,917 INFO  [main] [com.sample.ProcessJPATest] completed
2018-09-11 09:18:30,917 INFO  [main] [com.sample.ProcessJPATest] getTasksAssignedAsPotentialOwner 
2018-09-11 09:18:30,952 INFO  [main] [com.sample.ProcessJPATest] mary starts a task : taskId = 2
2018-09-11 09:18:30,971 INFO  [main] [com.sample.ProcessJPATest] mary completes a task : taskId = 2
Task2 Exit
2018-09-11 09:18:31,031 INFO  [main] [com.sample.ProcessJPATest] completed
2018-09-11 09:18:31,036 INFO  [main] [com.sample.ProcessJPATest] Process completed in 967
```

so as you can see the first operations around tasks are bit slower as the cache needs to be populated but then completion of the task is way faster.

Then subsequent execution of the same process are fast

```
Task1 Entry
A process instance started : pid = 2
2018-09-11 09:18:31,091 INFO  [main] [com.sample.ProcessJPATest] getTasksAssignedAsPotentialOwner 
2018-09-11 09:18:32,163 INFO  [main] [com.sample.ProcessJPATest] john starts a task : taskId = 3
2018-09-11 09:18:32,292 INFO  [main] [com.sample.ProcessJPATest] john completes a task : taskId = 3
Task1 Exit
Task2 Entry
2018-09-11 09:18:32,449 INFO  [main] [com.sample.ProcessJPATest] completed
2018-09-11 09:18:32,449 INFO  [main] [com.sample.ProcessJPATest] getTasksAssignedAsPotentialOwner 
2018-09-11 09:18:32,456 INFO  [main] [com.sample.ProcessJPATest] mary starts a task : taskId = 4
2018-09-11 09:18:32,476 INFO  [main] [com.sample.ProcessJPATest] mary completes a task : taskId = 4
Task2 Exit
2018-09-11 09:18:32,522 INFO  [main] [com.sample.ProcessJPATest] completed
2018-09-11 09:18:32,523 INFO  [main] [com.sample.ProcessJPATest] Process completed in 1487
```