### PR TITLE
[JBPM-7837] ExecutorServiceImpl.requeue(Long olderThan) doesn't calcu…

### DIFF
--- a/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/RequeueAware.java
+++ b/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/RequeueAware.java
@@ -20,8 +20,8 @@ public interface RequeueAware {
 
 	/**
 	 * Moves <code>RequestInfo</code> instances that are in running state longer than
-	 * given amount of time (in milliseconds)
-	 * @param olderThan amount of time in milliseconds from current time stamp
+	 * given amount of time (time unit depends on the <code>org.kie.executor.timeunit</code> system property)
+	 * @param olderThan amount of time from current time stamp
 	 */
 	void requeue(Long olderThan);
 	

--- a/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/impl/ExecutorServiceImpl.java
+++ b/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/impl/ExecutorServiceImpl.java
@@ -45,7 +45,6 @@ import org.kie.internal.executor.api.ExecutorService;
  */
 public class ExecutorServiceImpl implements ExecutorService, RequeueAware {
 	
-    private TimeUnit timeunit = TimeUnit.valueOf(System.getProperty("org.kie.executor.timeunit", "SECONDS"));
     private long maxRunningTime = Long.parseLong(System.getProperty("org.kie.executor.running.max", "600"));
     
     private Executor executor;
@@ -246,7 +245,7 @@ public class ExecutorServiceImpl implements ExecutorService, RequeueAware {
         	if (olderThan == null) {
         		olderThan = maxRunningTime;
         	}
-        	((RequeueAware) adminService).requeue(timeunit.convert(olderThan, TimeUnit.MILLISECONDS));
+        	((RequeueAware) adminService).requeue(TimeUnit.MILLISECONDS.convert(olderThan, executor.getTimeunit()));
         }
 	}
 


### PR DESCRIPTION
…late a correct value

- Unit test

It contains non-preferred Thread.sleep(). Hmm, if it's really better to avoid, I would write one more test with requestInfo.setTime(new Date() - 2000ms). Please let me know.