### PR TITLE
[RHPAM-1600] REST Endpoint for getting errors in a kie-container doesn't filter the result by container id

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/admin/ProcessInstanceAdminServiceImpl.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/admin/ProcessInstanceAdminServiceImpl.java
@@ -235,6 +235,16 @@ public class ProcessInstanceAdminServiceImpl implements ProcessInstanceAdminServ
         return execErrors;
     }
     
+    @Override
+    public List<ExecutionError> getErrorsByDeploymentId(String containerId, boolean includeAcknowledged, QueryContext queryContext) {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("deploymentId", containerId);
+        params.put("ack", getAckMode(includeAcknowledged));
+        applyQueryContext(params, queryContext);
+
+        List<ExecutionError> execErrors = commandService.execute(new QueryNameCommand<List<ExecutionError>>("getErrorsByDeploymentId", params));
+        return execErrors;
+    }
     /*
      * Helper methods
      */

--- a/jbpm-services/jbpm-kie-services/src/main/resources/META-INF/Servicesorm.xml
+++ b/jbpm-services/jbpm-kie-services/src/main/resources/META-INF/Servicesorm.xml
@@ -1126,6 +1126,35 @@
     </query>
     <!-- hint name="org.hibernate.timeout" value="200"/ -->
   </named-query> 
+
+  <named-query name="getErrorsByDeploymentId">
+    <query>
+     select
+      new org.kie.internal.runtime.error.ExecutionError(
+      error.errorId,
+      error.type,
+      error.deploymentId,
+      error.processInstanceId,
+      error.processId,
+      error.activityId,
+      error.activityName,
+      error.jobId,
+      error.errorMessage,
+      error.acknowledged,
+      error.acknowledgedBy,
+      error.acknowledgedAt,
+      error.errorDate
+      )
+      from
+        ExecutionErrorInfo error
+      where
+        error.acknowledged in (:ack) and
+        error.deploymentId = :deploymentId
+      order by 
+        error.errorDate DESC
+    </query>
+    <!-- hint name="org.hibernate.timeout" value="200"/ -->
+  </named-query> 
   
   <named-query name="getTaskErrors">
     <query>

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/admin/ProcessInstanceAdminServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/admin/ProcessInstanceAdminServiceImplTest.java
@@ -415,6 +415,33 @@ public class ProcessInstanceAdminServiceImplTest extends AbstractKieServicesBase
         assertTrue(error.isAcknowledged());
     }
 
+    @Test
+    public void testErrorByDeploymentId() {
+
+        try {
+            processService.startProcess(deploymentUnit.getIdentifier(), "BrokenScriptTask");
+        } catch (Exception e) {
+            // expected as this is broken script process
+        }
+
+        List<ExecutionError> errors = processAdminService.getErrors(true, new QueryContext());
+        assertNotNull(errors);
+        assertEquals(1, errors.size());
+
+        ExecutionError error = errors.get(0);
+        assertNotNull(error);
+
+        // try non empty deploymentId
+        String deploymentId = error.getDeploymentId();
+        errors = processAdminService.getErrorsByDeploymentId(deploymentId, true, new QueryContext());
+        assertNotNull(errors);
+        assertEquals(1, errors.size());
+
+        // try empty deploymentId
+        errors = processAdminService.getErrorsByDeploymentId("empty-deployment-id", true, new QueryContext());
+        assertNotNull(errors);
+        assertEquals(0, errors.size());
+    }
     /*
      * Helper methods 
      */

--- a/jbpm-services/jbpm-services-api/src/build/revapi-config.json
+++ b/jbpm-services/jbpm-services-api/src/build/revapi-config.json
@@ -558,7 +558,16 @@
 		  "methodName": "getProcessInstanceDescription",
 		  "elementKind": "method",
 		  "justification": "JBPM-6890: Adding the customTaskID as a unique identifier for an active"
-		 }
+		 },
+         {
+         "code": "java.method.addedToInterface",
+         "new": "method java.util.List<org.kie.internal.runtime.error.ExecutionError> org.jbpm.services.api.admin.ProcessInstanceAdminService::getErrorsByDeploymentId(java.lang.String, boolean, org.kie.api.runtime.query.QueryContext)",
+         "package": "org.jbpm.services.api.admin",
+         "classSimpleName": "ProcessInstanceAdminService",
+         "methodName": "getErrorsByDeploymentId",
+         "elementKind": "method",
+         "justification": "Added support for filtering errors by deployment id"
+         }
       ]
     }
   }

--- a/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/admin/ProcessInstanceAdminService.java
+++ b/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/admin/ProcessInstanceAdminService.java
@@ -165,4 +165,12 @@ public interface ProcessInstanceAdminService {
      */
     List<ExecutionError> getErrors(boolean includeAcknowledged, QueryContext queryContext);
     
+    /**
+     * Returns all execution errors for a given deployment regardless of their type
+     * @param deploymentId deployment id that contains the errors
+     * @param includeAcknowledged indicates whether to include acknowledged errors or not
+     * @param queryContext control parameters for pagination
+     * @return list of found errors
+     */
+    List<ExecutionError> getErrorsByDeploymentId(String deploymentId, boolean includeAcknowledged, QueryContext queryContext);
 }


### PR DESCRIPTION

Added new api function to get errors by deployment id