### PR TITLE
Reuse version.org.wildfly from kie-parent

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
@@ -548,7 +548,7 @@
                   <artifactInstaller>
                     <groupId>org.wildfly</groupId>
                     <artifactId>wildfly-dist</artifactId>
-                    <version>${version.wildfly14}</version>
+                    <version>${version.org.wildfly}</version>
                   </artifactInstaller>
                   <dependencies>
                     <dependency>

--- a/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
@@ -482,7 +482,7 @@
                   <artifactInstaller>
                     <groupId>org.wildfly</groupId>
                     <artifactId>wildfly-dist</artifactId>
-                    <version>${version.wildfly14}</version>
+                    <version>${version.org.wildfly}</version>
                   </artifactInstaller>
                 </container>
               </configuration>

--- a/jbpm-container-test/pom.xml
+++ b/jbpm-container-test/pom.xml
@@ -40,7 +40,6 @@
      referencing the zip from local filesystem). -->
     <eap7.download.url>file:///valid-url-for-eap-7-needs-to-be-specified-here-or-via-cmd-line</eap7.download.url>
 
-    <version.wildfly14>14.0.1.Final</version.wildfly14>
     <version.tomcat9>9.0.12</version.tomcat9>
     <!-- jboss-remoting version compatible with jboss-remote-naming -->
     <version.org.jboss.remoting.naming>4.0.18.Final</version.org.jboss.remoting.naming>


### PR DESCRIPTION
@MarianMacik @mswiderski please check

Reuse `version.org.wildfly` from kie-parent to make future updates easier and less error prone.
Also it's not a good idea to include (part of) version number in the property name.