### PR TITLE
JBPM-7951 Remove patched tomcat-dbcp

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
@@ -765,12 +765,6 @@
                       <groupId>org.jboss.logging</groupId>
                       <artifactId>jboss-logging</artifactId>
                     </dependency>
-
-                    <!-- TODO: A temporary workaround until tomcat 9.0.13 is released -->
-                    <dependency>
-                      <groupId>org.apache.tomcat</groupId>
-                      <artifactId>tomcat-dbcp</artifactId>
-                    </dependency>
                   </dependencies>
                 </container>
                 <configuration>
@@ -858,13 +852,6 @@
         <dependency>
           <groupId>org.jboss.logging</groupId>
           <artifactId>jboss-logging</artifactId>
-          <scope>test</scope>
-        </dependency>
-
-        <!-- TODO: A temporary workaround until tomcat 9.0.13 is released -->
-        <dependency>
-          <groupId>org.apache.tomcat</groupId>
-          <artifactId>tomcat-dbcp</artifactId>
           <scope>test</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
Depends on https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/885