### PR TITLE
[JBPM-7988] EJB timer stops working in specific circumstances

### DIFF
--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/pom.xml
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/pom.xml
@@ -21,6 +21,10 @@
       <artifactId>drools-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-flow</artifactId>
     </dependency>

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
@@ -16,6 +16,11 @@
 
 package org.jbpm.services.ejb.timer;
 
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
 import org.drools.core.time.InternalSchedulerService;
 import org.drools.core.time.Job;
 import org.drools.core.time.JobContext;
@@ -31,10 +36,7 @@ import org.jbpm.process.core.timer.impl.GlobalTimerService;
 import org.jbpm.process.core.timer.impl.GlobalTimerService.GlobalJobHandle;
 import org.jbpm.process.instance.timer.TimerManager.ProcessJobContext;
 import org.jbpm.process.instance.timer.TimerManager.StartProcessJobContext;
-
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import java.util.concurrent.atomic.AtomicLong;
+import org.kie.api.runtime.EnvironmentName;
 
 
 public class EjbSchedulerService implements GlobalSchedulerService {
@@ -131,7 +133,7 @@ public class EjbSchedulerService implements GlobalSchedulerService {
         return true;	    
 	}
 	
-	private String getJobName(JobContext ctx, Long id) {
+    protected String getJobName(JobContext ctx, Long id) {
 
         String jobname = null;
         
@@ -139,7 +141,8 @@ public class EjbSchedulerService implements GlobalSchedulerService {
             ProcessJobContext processCtx = (ProcessJobContext) ctx;
             jobname = processCtx.getSessionId() + "-" + processCtx.getProcessInstanceId() + "-" + processCtx.getTimer().getId();
             if (processCtx instanceof StartProcessJobContext) {
-                jobname = "StartProcess-"+((StartProcessJobContext) processCtx).getProcessId()+ "-" + processCtx.getTimer().getId();
+                String deploymentId = (String) processCtx.getKnowledgeRuntime().getEnvironment().get(EnvironmentName.DEPLOYMENT_ID);
+                jobname = deploymentId + "-StartProcess-" + ((StartProcessJobContext) processCtx).getProcessId() + "-" + processCtx.getTimer().getId();
             }
         } else if (ctx instanceof NamedJobContext) {
             jobname = ((NamedJobContext) ctx).getJobName();

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/test/java/org/jbpm/services/ejb/timer/EJBTimerJobNameTest.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/test/java/org/jbpm/services/ejb/timer/EJBTimerJobNameTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.services.ejb.timer;
+
+import java.util.Collections;
+
+import org.drools.core.common.InternalKnowledgeRuntime;
+import org.drools.core.impl.InternalKnowledgeBase;
+import org.drools.core.impl.KnowledgeBaseFactory;
+import org.drools.core.impl.StatefulKnowledgeSessionImpl;
+import org.drools.core.time.impl.IntervalTrigger;
+import org.jbpm.process.instance.timer.TimerInstance;
+import org.jbpm.process.instance.timer.TimerManager.StartProcessJobContext;
+import org.junit.Assert;
+import org.junit.Test;
+import org.kie.api.runtime.EnvironmentName;
+
+public class EJBTimerJobNameTest {
+
+    @Test
+    public void testStartProcessJobContextUniqueJobNamesAmongSessions() {
+
+        // we set the same process ID 
+        StartProcessJobContext ctxA = new StartProcessJobContext(new TimerInstance(), new IntervalTrigger(), "processId", Collections.emptyMap(), createRuntime(1L, "container-1"));
+        StartProcessJobContext ctxB = new StartProcessJobContext(new TimerInstance(), new IntervalTrigger(), "processId", Collections.emptyMap(), createRuntime(2L, "container-2"));
+
+        EjbSchedulerService service = new EjbSchedulerService();
+        String jobNameA = service.getJobName(ctxA, 1L);
+        String jobNameB = service.getJobName(ctxB, 1L);
+        Assert.assertNotEquals(jobNameA, jobNameB);
+    }
+
+    private InternalKnowledgeRuntime createRuntime(Long id, String containerId) {
+        InternalKnowledgeBase kBase2 = KnowledgeBaseFactory.newKnowledgeBase();
+        StatefulKnowledgeSessionImpl knowledge = new StatefulKnowledgeSessionImpl(id, kBase2);
+        knowledge.getEnvironment().set(EnvironmentName.DEPLOYMENT_ID, containerId);
+        return knowledge;
+    }
+}


### PR DESCRIPTION
Creating unique names when it exists the same name of process across
containers