### PR TITLE
JBPM-8034 - Add runtime type for wid parameters and results

### DIFF
--- a/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WidInfo.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WidInfo.java
@@ -81,6 +81,7 @@ public class WidInfo {
                     this.parameters.put(widParam.name(),
                                         new InternalWidParamsAndResults(widParam.name(),
                                                                         widParam.type(),
+                                                                        widParam.runtimeType(),
                                                                         widParam.required()));
                 }
             }
@@ -98,6 +99,7 @@ public class WidInfo {
                     this.results.put(widResult.name(),
                                      new InternalWidParamsAndResults(widResult.name(),
                                                                      widResult.type(),
+                                                                     widResult.runtimeType(),
                                                                      false));
                 }
             }
@@ -142,13 +144,16 @@ public class WidInfo {
 
         private String name;
         private String type;
+        private String runtimeType;
         private boolean required;
 
         public InternalWidParamsAndResults(String name,
                                            String type,
+                                           String runtimeType,
                                            boolean required) {
             this.name = name;
             this.type = type;
+            this.runtimeType = runtimeType;
             this.required = required;
         }
 
@@ -166,6 +171,14 @@ public class WidInfo {
 
         public void setType(String type) {
             this.type = type;
+        }
+
+        public String getRuntimeType() {
+            return runtimeType;
+        }
+
+        public void setRuntimeType(String runtimeType) {
+            this.runtimeType = runtimeType;
         }
 
         public boolean isRequired() {

--- a/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WidParameter.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WidParameter.java
@@ -29,5 +29,7 @@ public @interface WidParameter {
 
     String type() default "new StringDataType()";
 
+    String runtimeType() default "String";
+
     boolean required() default false;
 }

--- a/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WidResult.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WidResult.java
@@ -28,4 +28,6 @@ public @interface WidResult {
     String name() default "";
 
     String type() default "new StringDataType()";
+
+    String runtimeType() default "String";
 }

--- a/jbpm-workitems/jbpm-workitems-core/src/test/java/org/jbpm/process/workitem/core/util/WidProcessorTest.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/test/java/org/jbpm/process/workitem/core/util/WidProcessorTest.java
@@ -337,11 +337,15 @@ public class WidProcessorTest {
         assertTrue(widParameters[0].required());
         assertEquals("new StringDataType()",
                      widParameters[0].type());
+        assertEquals("String",
+                     widParameters[0].runtimeType());
         assertEquals("sampleParamTwo",
                      widParameters[1].name());
         assertTrue(widParameters[1].required());
         assertEquals("new StringDataType()",
                      widParameters[1].type());
+        assertEquals("String",
+                     widParameters[1].runtimeType());
 
         WidResult[] widResults = widInfo.results();
         assertEquals(1,
@@ -350,6 +354,8 @@ public class WidProcessorTest {
                      widResults[0].name());
         assertEquals("new StringDataType()",
                      widResults[0].type());
+        assertEquals("String",
+                     widParameters[0].runtimeType());
 
         WidParameterValues[] widParameterValues = widInfo.parameterValues();
         assertEquals(2,
@@ -426,11 +432,15 @@ public class WidProcessorTest {
         assertTrue(widParameters[0].required());
         assertEquals("new StringDataType()",
                      widParameters[0].type());
+        assertEquals("String",
+                     widParameters[0].runtimeType());
         assertEquals("sampleParamTwo",
                      widParameters[1].name());
         assertTrue(widParameters[1].required());
         assertEquals("new StringDataType()",
                      widParameters[1].type());
+        assertEquals("String",
+                     widParameters[1].runtimeType());
 
         WidResult[] widResults = widInfo.results();
         assertEquals(1,
@@ -439,6 +449,8 @@ public class WidProcessorTest {
                      widResults[0].name());
         assertEquals("new StringDataType()",
                      widResults[0].type());
+        assertEquals("String",
+                     widParameters[0].runtimeType());
 
         WidParameterValues[] widParameterValues = widInfo.parameterValues();
         assertEquals(2,
@@ -642,11 +654,15 @@ public class WidProcessorTest {
         assertTrue(widParameters[0].required());
         assertEquals("new StringDataType()",
                      widParameters[0].type());
+        assertEquals("String",
+                     widParameters[0].runtimeType());
         assertEquals("sampleParamTwo",
                      widParameters[1].name());
         assertTrue(widParameters[1].required());
         assertEquals("new StringDataType()",
                      widParameters[1].type());
+        assertEquals("String",
+                     widParameters[1].runtimeType());
 
         WidResult[] widResults = widInfo.results();
         assertEquals(1,
@@ -655,6 +671,8 @@ public class WidProcessorTest {
                      widResults[0].name());
         assertEquals("new StringDataType()",
                      widResults[0].type());
+        assertEquals("String",
+                     widParameters[0].runtimeType());
 
         WidParameterValues[] widParameterValues = widInfo.parameterValues();
         assertEquals(2,
@@ -740,11 +758,15 @@ public class WidProcessorTest {
         assertTrue(widParameters[0].required());
         assertEquals("new StringDataType()",
                      widParameters[0].type());
+        assertEquals("String",
+                     widParameters[0].runtimeType());
         assertEquals("sampleParamTwo",
                      widParameters[1].name());
         assertTrue(widParameters[1].required());
         assertEquals("new StringDataType()",
                      widParameters[1].type());
+        assertEquals("String",
+                     widParameters[1].runtimeType());
 
         WidResult[] widResults = widInfo.results();
         assertEquals(1,
@@ -753,6 +775,8 @@ public class WidProcessorTest {
                      widResults[0].name());
         assertEquals("new StringDataType()",
                      widResults[0].type());
+        assertEquals("String",
+                     widParameters[0].runtimeType());
 
         WidParameterValues[] widParameterValues = widInfo.parameterValues();
         assertEquals(2,
@@ -839,11 +863,15 @@ public class WidProcessorTest {
         assertTrue(widParameters[0].required());
         assertEquals("new StringDataType()",
                      widParameters[0].type());
+        assertEquals("String",
+                     widParameters[0].runtimeType());
         assertEquals("sampleParamTwo",
                      widParameters[1].name());
         assertTrue(widParameters[1].required());
         assertEquals("new StringDataType()",
                      widParameters[1].type());
+        assertEquals("String",
+                     widParameters[1].runtimeType());
 
         WidResult[] widResults = widInfo.results();
         assertEquals(1,
@@ -852,6 +880,8 @@ public class WidProcessorTest {
                      widResults[0].name());
         assertEquals("new StringDataType()",
                      widResults[0].type());
+        assertEquals("String",
+                     widParameters[0].runtimeType());
 
         WidParameterValues[] widParameterValues = widInfo.parameterValues();
         assertEquals(2,
@@ -914,10 +944,14 @@ public class WidProcessorTest {
 
         WidInfo widInfoObj = new WidInfo(widInfoList);
         assertNotNull(widInfoObj);
-        assertEquals("mvel: new com.sample.MyWorkItemHandler(\\\"testAccessToken\\\")", widInfoObj.getDefaultHandler());
-        assertEquals("mvel: new com.sample.MyWorkItemHandler(\"testAccessToken\")", widInfoObj.getDefaultHandlerUnEscaped());
-        assertEquals("new com.sample.MyWorkItemHandler(\\\"testAccessToken\\\")", widInfoObj.getDefaultHandlerNoType());
-        assertEquals("new com.sample.MyWorkItemHandler(\"testAccessToken\")", widInfoObj.getDefaultHandlerNoTypeUnEscaped());
+        assertEquals("mvel: new com.sample.MyWorkItemHandler(\\\"testAccessToken\\\")",
+                     widInfoObj.getDefaultHandler());
+        assertEquals("mvel: new com.sample.MyWorkItemHandler(\"testAccessToken\")",
+                     widInfoObj.getDefaultHandlerUnEscaped());
+        assertEquals("new com.sample.MyWorkItemHandler(\\\"testAccessToken\\\")",
+                     widInfoObj.getDefaultHandlerNoType());
+        assertEquals("new com.sample.MyWorkItemHandler(\"testAccessToken\")",
+                     widInfoObj.getDefaultHandlerNoTypeUnEscaped());
     }
 
     private Compiler compileWithGenerator() {


### PR DESCRIPTION
adds runtime type of parameters and results so this way users can specify for example

```java
 @WidParameter(name = "Files", runtimeType = "java.util.List")
```
this helps users know what type each parameter and resuts are (can specify exactly when creating business processes) as well as helps with auto generation of fully executable bpmn2 for each handler.