### PR TITLE
mutable groups

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/identity/JBossUserGroupCallbackImpl.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/identity/JBossUserGroupCallbackImpl.java
@@ -71,7 +71,9 @@ public class JBossUserGroupCallbackImpl extends AbstractUserGroupInfo implements
 		while (it.hasNext()) {
 			String userId = (String) it.next();
 			
-			groups = Arrays.asList(userGroups.getProperty(userId, "").split(separator));
+			String[] groupsArray = userGroups.getProperty(userId, "").split(separator);
+			groups = new ArrayList();
+			Collections.addAll(groups, groupsArray);
 			groupStore.put(userId, groups);
 			allgroups.addAll(groups);
 			


### PR DESCRIPTION
previously I got an error in `GetUserTaskCommand` at 68 because of immutable behaviour of groups:

```
        List<String> usersGroup = context.getUserGroupCallback().getGroupsForUser(userId);
        usersGroup.add(userId);
```
