### PR TITLE
JDK11: Include javax.activation:activation to elastic search

### DIFF
--- a/jbpm-event-emitters/jbpm-event-emitters-elasticsearch/pom.xml
+++ b/jbpm-event-emitters/jbpm-event-emitters-elasticsearch/pom.xml
@@ -137,6 +137,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
This allows to run these tests on JDK11.