### PR TITLE
Stabilize ElasticSearch test

### DIFF
--- a/jbpm-event-emitters/jbpm-event-emitters-elasticsearch/src/test/java/org/jbpm/event/emitters/elasticsearch/ElasticsearchEventEmitterProcessTest.java
+++ b/jbpm-event-emitters/jbpm-event-emitters-elasticsearch/src/test/java/org/jbpm/event/emitters/elasticsearch/ElasticsearchEventEmitterProcessTest.java
@@ -95,7 +95,7 @@ public class ElasticsearchEventEmitterProcessTest {
         cleanUp(context);
     }
 
-    @Test(timeout=5000)
+    @Test(timeout=10000)
     public void testIntegrationWithEventManager() throws Exception {
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
         kbuilder.add(new ClassPathResource("WorkItemsProcess.rf"), ResourceType.DRF);


### PR DESCRIPTION
Timeout increase is needed because of w2k16 machines.