### PR TITLE
JBPM-8155 - New preprocessor in custom queries

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/QueryServiceImpl.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/QueryServiceImpl.java
@@ -18,6 +18,7 @@ package org.jbpm.kie.services.impl.query;
 
 import static org.jbpm.services.api.query.QueryResultMapper.COLUMN_EXTERNALID;
 import static org.jbpm.services.api.query.QueryResultMapper.COLUMN_PROCESSINSTANCEID;
+import static org.jbpm.services.api.query.QueryResultMapper.COLUMN_POTOWNER;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,6 +55,7 @@ import org.jbpm.kie.services.impl.query.persistence.QueryDefinitionEntity;
 import org.jbpm.kie.services.impl.query.preprocessor.BusinessAdminTasksPreprocessor;
 import org.jbpm.kie.services.impl.query.preprocessor.DeploymentIdsPreprocessor;
 import org.jbpm.kie.services.impl.query.preprocessor.PotOwnerTasksPreprocessor;
+import org.jbpm.kie.services.impl.query.preprocessor.UserAndGroupsTasksPreprocessor;
 import org.jbpm.kie.services.impl.security.DeploymentRolesManager;
 import org.jbpm.runtime.manager.impl.identity.UserDataServiceProvider;
 import org.jbpm.services.api.DeploymentEvent;
@@ -206,6 +208,8 @@ public class QueryServiceImpl implements QueryService, DeploymentEventListener {
                     dataSetDefRegistry.registerPreprocessor(sqlDef.getUUID(), new BusinessAdminTasksPreprocessor(identityProvider, userGroupCallback, metadata));
                 } else if (queryDefinition.getTarget().equals(Target.FILTERED_PO_TASK)) {
                     dataSetDefRegistry.registerPreprocessor(sqlDef.getUUID(), new PotOwnerTasksPreprocessor(identityProvider, userGroupCallback, metadata));
+                } else if (queryDefinition.getTarget().equals(Target.USER_GROUPS_TASK)) {
+                    dataSetDefRegistry.registerPreprocessor(sqlDef.getUUID(), new UserAndGroupsTasksPreprocessor(identityProvider, userGroupCallback, COLUMN_POTOWNER, metadata));
                 }
                 
                 for (String columnId : metadata.getColumnIds()) {

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/preprocessor/UserAndGroupsTasksPreprocessor.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/preprocessor/UserAndGroupsTasksPreprocessor.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.kie.services.impl.query.preprocessor;
+
+import static org.dashbuilder.dataset.filter.FilterFactory.AND;
+import static org.dashbuilder.dataset.filter.FilterFactory.in;
+import static org.jbpm.services.api.query.QueryResultMapper.COLUMN_POTOWNER;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.DataSetMetadata;
+import org.dashbuilder.dataset.filter.ColumnFilter;
+import org.dashbuilder.dataset.filter.CoreFunctionFilter;
+import org.dashbuilder.dataset.filter.DataSetFilter;
+import org.kie.api.task.UserGroupCallback;
+import org.kie.internal.identity.IdentityProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UserAndGroupsTasksPreprocessor extends UserTasksPreprocessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserAndGroupsTasksPreprocessor.class);
+
+    private IdentityProvider identityProvider;
+
+    private UserGroupCallback userGroupCallback;
+
+    private String columnId;
+
+    public UserAndGroupsTasksPreprocessor(IdentityProvider identityProvider, UserGroupCallback userGroupCallback, 
+                                          String columnId, DataSetMetadata metadata) {
+        super(metadata);
+        this.identityProvider = identityProvider;
+        this.userGroupCallback = userGroupCallback;
+        this.columnId = columnId;
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public void preprocess(DataSetLookup lookup) {
+        if (identityProvider == null || userGroupCallback == null) {
+            return;
+        }
+
+        ColumnFilter columnFilter;
+        List<Comparable> orgEntities = new ArrayList<>();
+
+        if (lookup.getFirstFilterOp() != null) {
+            List<String> potOwners = new ArrayList<String>();
+            List<ColumnFilter> columnFilters = lookup.getFirstFilterOp().getColumnFilterList();
+            Iterator<ColumnFilter> it= columnFilters.iterator();
+            while (orgEntities.isEmpty() && it.hasNext()) {
+                CoreFunctionFilter column = (CoreFunctionFilter)it.next();
+
+                if (column.getColumnId().toUpperCase().equals(columnId)) {
+                    potOwners.addAll(column.getParameters());
+
+                    for (String potOwner : potOwners) {
+                        addUserAndGroupsFromIdentityProvider(orgEntities, potOwner);
+                    }
+
+                    it.remove();
+                }
+            }
+
+            if (orgEntities.isEmpty()) {
+                addUserAndGroupsFromIdentityProvider(orgEntities, identityProvider.getName());
+            }
+
+            columnFilter = AND(in(COLUMN_POTOWNER, orgEntities));
+            lookup.getFirstFilterOp().addFilterColumn(columnFilter);
+        } else {
+            DataSetFilter filter = new DataSetFilter();
+            addUserAndGroupsFromIdentityProvider(orgEntities, identityProvider.getName());
+
+            columnFilter = AND(in(COLUMN_POTOWNER, orgEntities));
+            filter.addFilterColumn(columnFilter);
+            lookup.addOperation(filter);
+        }
+
+        LOGGER.debug("Adding column filter: {}", columnFilter);
+
+        super.preprocess(lookup);
+    }
+
+    private void addUserAndGroupsFromIdentityProvider(List<Comparable> orgEntities, String userId) {
+        orgEntities.addAll(Optional.ofNullable(userGroupCallback.getGroupsForUser(userId)).orElse(new ArrayList<>()));
+        orgEntities.add(userId);
+    }
+}

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/query/preprocessor/UserAndGroupsTasksPreprocessorTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/query/preprocessor/UserAndGroupsTasksPreprocessorTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.kie.services.impl.query.preprocessor;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.DataSetMetadata;
+import org.dashbuilder.dataset.filter.CoreFunctionFilter;
+import org.dashbuilder.dataset.filter.DataSetFilter;
+import org.jbpm.kie.services.impl.query.CoreFunctionQueryParamBuilder;
+import org.jbpm.services.api.query.model.QueryParam;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.task.UserGroupCallback;
+import org.kie.internal.identity.IdentityProvider;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserAndGroupsTasksPreprocessorTest {
+
+    DataSetLookup dataSetLookup;
+    private static String COL_ID = "POTOWNER";
+
+    @Mock
+    IdentityProvider identityProvider;
+
+    @Mock
+    UserGroupCallback userGroupCallback;
+
+    @Mock
+    DataSetMetadata metaData;
+
+    @InjectMocks
+    UserAndGroupsTasksPreprocessor userAndGroupsTasksPreprocessor;
+
+    @Before
+    public void init() {
+        dataSetLookup = new DataSetLookup();
+        userAndGroupsTasksPreprocessor = new  UserAndGroupsTasksPreprocessor(identityProvider,
+                                                                             userGroupCallback,
+                                                                             COL_ID,
+                                                                             metaData);
+    }
+
+    @Test
+    public void testSetUser() {
+        String role1 = "role1";
+        String role2 = "role2";
+        String userId = "userId";
+
+        when(userGroupCallback.getGroupsForUser(userId)).thenReturn(Arrays.asList(role1,
+                                                                                  role2));
+        when(identityProvider.getName()).thenReturn(userId);
+
+        userAndGroupsTasksPreprocessor.preprocess(dataSetLookup);
+
+        assertEquals("(POTOWNER in " + role1 + ", " + role2 + ", " + userId + ")",
+                     dataSetLookup.getFirstFilterOp().getColumnFilterList().get(0).toString());
+    }
+
+    @Test
+    public void testSetUserWithoutRoles() {
+        String userId = "userId";
+
+        when(userGroupCallback.getGroupsForUser(userId)).thenReturn(Collections.emptyList());
+        when(identityProvider.getName()).thenReturn(userId);
+
+        userAndGroupsTasksPreprocessor.preprocess(dataSetLookup);
+
+        assertEquals("(POTOWNER in " + userId + ")",
+                     dataSetLookup.getFirstFilterOp().getColumnFilterList().get(0).toString());
+    }
+
+    @Test
+    public void testNullGroups() {
+        String userId = "userId";
+
+        when(userGroupCallback.getGroupsForUser(userId)).thenReturn(null);
+        when(identityProvider.getName()).thenReturn(userId);
+
+        userAndGroupsTasksPreprocessor.preprocess(dataSetLookup);
+
+        assertEquals("(POTOWNER in " + userId + ")",
+                     dataSetLookup.getFirstFilterOp().getColumnFilterList().get(0).toString());
+    }
+
+    @Test
+    public void testPotOwnerFilterNoIdentityProvider() {
+        String userId = "userId";
+
+        when(userGroupCallback.getGroupsForUser(userId)).thenReturn(null);
+        when(identityProvider.getName()).thenReturn(userId);
+
+        String potOwner = "potOwner";
+        when(userGroupCallback.getGroupsForUser(potOwner)).thenReturn(Arrays.asList("role1",
+                "role2"));
+
+        List<String> potOwners = new ArrayList<String>();
+        potOwners.add(potOwner);
+        QueryParam queryParam = new QueryParam(COL_ID, "IN", potOwners);
+
+        List<QueryParam> queryParams = new ArrayList<QueryParam>();
+        queryParams.add(queryParam);
+        CoreFunctionQueryParamBuilder coreFunctionQueryParamBuilder = new CoreFunctionQueryParamBuilder(queryParam);
+        CoreFunctionFilter columnFilter = (CoreFunctionFilter) coreFunctionQueryParamBuilder.build();
+
+        DataSetFilter filter = new DataSetFilter();
+        filter.addFilterColumn(columnFilter);
+        dataSetLookup.addOperation(filter);
+
+        userAndGroupsTasksPreprocessor.preprocess(dataSetLookup);
+
+        assertEquals("(POTOWNER in role1, role2, " + potOwner + ")",
+                     dataSetLookup.getFirstFilterOp().getColumnFilterList().get(0).toString());
+    }
+
+    @Test
+    public void testPotOwnerFilterWithEmptyPotOwnerList() {
+        String userId = "userId";
+
+        when(userGroupCallback.getGroupsForUser(userId)).thenReturn(null);
+        when(identityProvider.getName()).thenReturn(userId);
+
+        List<String> potOwners = new ArrayList<String>();
+        QueryParam queryParam = new QueryParam(COL_ID, "IN", potOwners);
+
+        List<QueryParam> queryParams = new ArrayList<QueryParam>();
+        queryParams.add(queryParam);
+        CoreFunctionQueryParamBuilder coreFunctionQueryParamBuilder = new CoreFunctionQueryParamBuilder(queryParam);
+        CoreFunctionFilter columnFilter = (CoreFunctionFilter) coreFunctionQueryParamBuilder.build();
+
+        DataSetFilter filter = new DataSetFilter();
+        filter.addFilterColumn(columnFilter);
+        dataSetLookup.addOperation(filter);
+
+        userAndGroupsTasksPreprocessor.preprocess(dataSetLookup);
+
+        assertEquals("(POTOWNER in " + userId + ")",
+                     dataSetLookup.getFirstFilterOp().getColumnFilterList().get(0).toString());
+    }
+
+    @Test
+    public void testPotOwnerFilterNoIdentityProviderAndNullGroups() {
+        String userId = "userId";
+
+        when(userGroupCallback.getGroupsForUser(userId)).thenReturn(null);
+        when(identityProvider.getName()).thenReturn(userId);
+
+        String potOwner = "potOwner";
+        when(userGroupCallback.getGroupsForUser(potOwner)).thenReturn(null);
+
+        List<String> potOwners = new ArrayList<String>();
+        potOwners.add(potOwner);
+        QueryParam queryParam = new QueryParam(COL_ID, "IN", potOwners);
+
+        List<QueryParam> queryParams = new ArrayList<QueryParam>();
+        queryParams.add(queryParam);
+        CoreFunctionQueryParamBuilder coreFunctionQueryParamBuilder = new CoreFunctionQueryParamBuilder(queryParam);
+        CoreFunctionFilter columnFilter = (CoreFunctionFilter) coreFunctionQueryParamBuilder.build();
+
+        DataSetFilter filter = new DataSetFilter();
+        filter.addFilterColumn(columnFilter);
+        dataSetLookup.addOperation(filter);
+
+        userAndGroupsTasksPreprocessor.preprocess(dataSetLookup);
+
+        assertEquals("(POTOWNER in " + potOwner + ")",
+                     dataSetLookup.getFirstFilterOp().getColumnFilterList().get(0).toString());
+    }
+}

--- a/jbpm-services/jbpm-services-api/src/build/revapi-config.json
+++ b/jbpm-services/jbpm-services-api/src/build/revapi-config.json
@@ -45,7 +45,31 @@
           "methodName": "getTimers",
           "elementKind": "method",
           "justification": "JBPM-7632 - Enhance process definition data including timers and nodes"
-        }
+        },
+        {
+  	  "code": "java.field.enumConstantOrderChanged",
+   	  "old": "field org.jbpm.services.api.query.model.QueryDefinition.Target.CUSTOM",
+   	  "new": "field org.jbpm.services.api.query.model.QueryDefinition.Target.CUSTOM",
+   	  "oldOrdinal": "8",
+   	  "newOrdinal": "9",
+   	  "package": "org.jbpm.services.api.query.model",
+   	  "classSimpleName": "Target",
+   	  "fieldName": "CUSTOM",
+   	  "elementKind": "enumConstant",
+   	  "justification": "JBPM-8155 -Adding new target for custom queries USER_GROUPS_TASK and moving CUSTOM"
+ 	},
+	{
+  	  "code": "java.field.enumConstantOrderChanged",
+          "old": "field org.jbpm.services.api.query.model.QueryDefinition.Target.USER_GROUPS_TASK",
+  	  "new": "field org.jbpm.services.api.query.model.QueryDefinition.Target.USER_GROUPS_TASK",
+  	  "oldOrdinal": "9",
+  	  "newOrdinal": "8",
+  	  "package": "org.jbpm.services.api.query.model",
+  	  "classSimpleName": "Target",
+  	  "fieldName": "USER_GROUPS_TASK",
+  	  "elementKind": "enumConstant",
+  	  "justification": "JBPM-8155 -Adding new target for custom queries USER_GROUPS_TASK"
+	}
       ]
     }
   }

--- a/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/query/model/QueryDefinition.java
+++ b/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/query/model/QueryDefinition.java
@@ -33,6 +33,7 @@ public interface QueryDefinition {
         FILTERED_PROCESS,
         FILTERED_BA_TASK,
         FILTERED_PO_TASK,
+        USER_GROUPS_TASK,
         CUSTOM;
     }
 


### PR DESCRIPTION
Adding a new preprocessor in order to filter by potential owners. The preprocessor creates 2 types of filter:

If the custom query hasn't got any query-params related to the potential owners, the preprocessor adds a new column filter by the logged user and his groups.
If the custom query has a query-params related to a list of potential owners, the logged user won't be take into account in the filter, but the new preprocessor will add a new column filter by the list of potOwners included in the query-params and their groups.