### PR TITLE
AF-1685: Development Lifecycle Streamline

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/AbstractDeploymentService.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/AbstractDeploymentService.java
@@ -202,21 +202,19 @@ public abstract class AbstractDeploymentService implements DeploymentService, Li
 
                 RuntimeManager manager = deployed.getRuntimeManager();
 
-                if(abortInstances && !activeProcesses.isEmpty()) {
+                if (abortInstances && !activeProcesses.isEmpty()) {
                     activeProcesses = runtimeDataService.getProcessInstancesByDeploymentId(unit.getIdentifier(), states, new QueryContext(0, -1));
-                    if (!activeProcesses.isEmpty()) {
-                        activeProcesses.forEach(processInstanceDesc -> {
-                            RuntimeEngine engine = manager.getRuntimeEngine(ProcessInstanceIdContext.get(processInstanceDesc.getId()));
-                            try {
-                                KieSession ksession = engine.getKieSession();
-                                ksession.abortProcessInstance(processInstanceDesc.getId());
-                            } catch (Exception ex) {
-                                logger.error("Error aborting process instance {} due to: {}", processInstanceDesc.getId(), ex.getMessage());
-                            } finally {
-                                manager.disposeRuntimeEngine(engine);
-                            }
-                        });
-                    }
+                    activeProcesses.forEach(processInstanceDesc -> {
+                        RuntimeEngine engine = manager.getRuntimeEngine(ProcessInstanceIdContext.get(processInstanceDesc.getId()));
+                        try {
+                            KieSession ksession = engine.getKieSession();
+                            ksession.abortProcessInstance(processInstanceDesc.getId());
+                        } catch (Exception ex) {
+                            logger.error("Error aborting process instance {} due to: {}", processInstanceDesc.getId(), ex.getMessage());
+                        } finally {
+                            manager.disposeRuntimeEngine(engine);
+                        }
+                    });
                 }
 
                 ((AbstractRuntimeManager)manager).close(true);

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/KModuleDeploymentService.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/KModuleDeploymentService.java
@@ -222,12 +222,12 @@ public class KModuleDeploymentService extends AbstractDeploymentService {
     }
 
     @Override
-	public void undeploy(DeploymentUnit unit) {
+	public void undeploy(DeploymentUnit unit, boolean abortInstances) {
     	if (!(unit instanceof KModuleDeploymentUnit)) {
             throw new IllegalArgumentException("Invalid deployment unit provided - " + unit.getClass().getName());
         }
         KModuleDeploymentUnit kmoduleUnit = (KModuleDeploymentUnit) unit;
-		super.undeploy(unit);
+		super.undeploy(unit, abortInstances);
 
         formManagerService.unRegisterForms( unit.getIdentifier() );
 

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/KModuleDeploymentService.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/KModuleDeploymentService.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import javax.persistence.EntityManagerFactory;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -222,12 +223,12 @@ public class KModuleDeploymentService extends AbstractDeploymentService {
     }
 
     @Override
-	public void undeploy(DeploymentUnit unit, boolean abortInstances) {
+	public void undeploy(DeploymentUnit unit, Function<DeploymentUnit, Boolean> beforeUndeploy) {
     	if (!(unit instanceof KModuleDeploymentUnit)) {
             throw new IllegalArgumentException("Invalid deployment unit provided - " + unit.getClass().getName());
         }
         KModuleDeploymentUnit kmoduleUnit = (KModuleDeploymentUnit) unit;
-		super.undeploy(unit, abortInstances);
+		super.undeploy(unit, beforeUndeploy);
 
         formManagerService.unRegisterForms( unit.getIdentifier() );
 

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/utils/PreUndeployOperations.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/utils/PreUndeployOperations.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.kie.services.impl.utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+import org.jbpm.services.api.DeploymentService;
+import org.jbpm.services.api.RuntimeDataService;
+import org.jbpm.services.api.model.DeployedUnit;
+import org.jbpm.services.api.model.DeploymentUnit;
+import org.jbpm.services.api.model.ProcessInstanceDesc;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.manager.RuntimeEngine;
+import org.kie.api.runtime.manager.RuntimeManager;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.api.runtime.query.QueryContext;
+import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class to provide default functions to use on {@link DeploymentService#undeploy(DeploymentUnit, Function<DeploymentUnit, Boolean>)}
+ */
+public class PreUndeployOperations {
+
+    private static Logger logger = LoggerFactory.getLogger(PreUndeployOperations.class);
+
+    private static List<Integer> activeProcessInstancessStates = new ArrayList<>();
+
+    static {
+        activeProcessInstancessStates.add(ProcessInstance.STATE_ACTIVE);
+        activeProcessInstancessStates.add(ProcessInstance.STATE_PENDING);
+        activeProcessInstancessStates.add(ProcessInstance.STATE_SUSPENDED);
+    }
+
+    /**
+     * Returns a function that checks if a given {@link DeploymentUnit} has active process instances and prevents its undeployment.
+     * That's the default operation when no other is supplied.
+     * @param runtimeDataService a {@link RuntimeDataService} to query the process instances
+     */
+    public static Function<DeploymentUnit, Boolean> checkActiveProcessInstances(final RuntimeDataService runtimeDataService) {
+        return unit -> {
+            Collection<ProcessInstanceDesc> activeProcesses = runtimeDataService.getProcessInstancesByDeploymentId(unit.getIdentifier(), activeProcessInstancessStates, new QueryContext());
+            if (!activeProcesses.isEmpty()) {
+                throw new IllegalStateException("Undeploy forbidden - there are active processes instances for deployment " + unit.getIdentifier());
+            }
+            return true;
+        };
+    }
+
+    /**
+     * Returns a function that checks if a given {@link DeploymentUnit} has active process instances instances, aborts them and,
+     * if nothing wrong happened, lets the undeployment operation continue.
+     * @param runtimeDataService a {@link RuntimeDataService} to query the process instances
+     * @param deploymentService a {@link DeploymentService} to provide access to the deployed unit.
+     */
+    public static Function<DeploymentUnit, Boolean> abortUnitActiveProcessInstances(final RuntimeDataService runtimeDataService, final DeploymentService deploymentService) {
+        return unit -> {
+            Collection<ProcessInstanceDesc> activeProcesses = runtimeDataService.getProcessInstancesByDeploymentId(unit.getIdentifier(), activeProcessInstancessStates, new QueryContext(0, -1));
+
+            DeployedUnit deployedUnit = deploymentService.getDeployedUnit(unit.getIdentifier());
+
+            if (deployedUnit == null) {
+                throw new IllegalStateException("Undeploy forbidden - No deployments available for " + unit.getIdentifier());
+            }
+
+            for (ProcessInstanceDesc instanceDesc : activeProcesses) {
+                RuntimeManager manager = deployedUnit.getRuntimeManager();
+                RuntimeEngine engine = manager.getRuntimeEngine(ProcessInstanceIdContext.get(instanceDesc.getId()));
+                try {
+                    KieSession ksession = engine.getKieSession();
+                    ksession.abortProcessInstance(instanceDesc.getId());
+                } catch (Exception e) {
+                    logger.error("Undeploy forbidden - Error aborting process instances for deployment unit {} due to: {}", unit.getIdentifier(), e.getMessage());
+                    return false;
+                } finally {
+                    manager.disposeRuntimeEngine(engine);
+                }
+            }
+
+            return true;
+        };
+    }
+
+    /**
+     * Returns a function that bypasses the check and always allows to undeploy.
+     */
+    public static Function<DeploymentUnit, Boolean> doNothing() {
+        return unit -> true;
+    }
+}

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/KModuleDeploymentServiceTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/KModuleDeploymentServiceTest.java
@@ -120,8 +120,8 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
         assertNotNull(deployed.getDeploymentUnit());
         assertNotNull(deployed.getRuntimeManager());
         assertNull(deployed.getDeployedAssetLocation("customtask"));
-        assertEquals(GROUP_ID+":"+ARTIFACT_ID+":"+VERSION+":"+"KBase-test"+":"+"ksession-test",
-                deployed.getDeploymentUnit().getIdentifier());
+        assertEquals(GROUP_ID + ":" + ARTIFACT_ID + ":" + VERSION + ":" + "KBase-test" + ":" + "ksession-test",
+                     deployed.getDeploymentUnit().getIdentifier());
 
         assertNotNull(runtimeDataService);
         Collection<ProcessDefinition> processes = runtimeDataService.getProcesses(new QueryContext());
@@ -151,8 +151,7 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
 
         assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
 
-        checkFormsDeployment( deploymentUnit.getIdentifier() );
-
+        checkFormsDeployment(deploymentUnit.getIdentifier());
     }
 
     @Test
@@ -170,8 +169,8 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
         assertNotNull(deployed.getDeploymentUnit());
         assertNotNull(deployed.getRuntimeManager());
         assertNull(deployed.getDeployedAssetLocation("customtask"));
-        assertEquals(GROUP_ID+":"+ARTIFACT_ID+":"+VERSION,
-                deployed.getDeploymentUnit().getIdentifier());
+        assertEquals(GROUP_ID + ":" + ARTIFACT_ID + ":" + VERSION,
+                     deployed.getDeploymentUnit().getIdentifier());
 
         assertNotNull(runtimeDataService);
         Collection<ProcessDefinition> processes = runtimeDataService.getProcesses(new QueryContext());
@@ -201,11 +200,10 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
 
         assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
 
-        checkFormsDeployment( deploymentUnit.getIdentifier() );
-
+        checkFormsDeployment(deploymentUnit.getIdentifier());
     }
 
-    @Test(expected=RuntimeException.class)
+    @Test(expected = RuntimeException.class)
     public void testDuplicatedDeployment() {
 
         assertNotNull(deploymentService);
@@ -223,17 +221,6 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
 
     @Test
     public void testUnDeploymentWithActiveProcesses() {
-
-        testUndeploymentWithActiveInstances(false);
-    }
-
-    @Test
-    public void testUnDeploymentWithActiveProcessesAborting() {
-
-        testUndeploymentWithActiveInstances(true);
-    }
-
-    private void testUndeploymentWithActiveInstances(boolean abortInstances) {
 
         assertNotNull(deploymentService);
 
@@ -256,14 +243,71 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
         ProcessInstance processInstance = engine.getKieSession().startProcess("org.jbpm.writedocument", params);
 
         assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
+        try {
+            // undeploy should fail due to active process instances
+            deploymentService.undeploy(deploymentUnit);
+            fail("Should fail due to active process instance");
+        } catch (IllegalStateException e) {
 
-        deploymentService.undeploy(deploymentUnit, abortInstances);
+        }
+
+        engine.getKieSession().abortProcessInstance(processInstance.getId());
+
+        checkFormsDeployment(deploymentUnit.getIdentifier());
+    }
+
+    @Test
+    public void testUnDeploymentWithoutActiveProcesses() {
+
+        assertNotNull(deploymentService);
+
+        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+        DeployedUnit deployedGeneral = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
+
+        assertNotNull(deployedGeneral);
+        assertNotNull(deployedGeneral.getDeploymentUnit());
+        assertNotNull(deployedGeneral.getRuntimeManager());
+
+        RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
+        assertNotNull(manager);
+
+        RuntimeEngine engine = manager.getRuntimeEngine(EmptyContext.get());
+        assertNotNull(engine);
+
+        deploymentService.undeploy(deploymentUnit);
+    }
+
+    @Test
+    public void testUnDeploymentWithActiveProcessesAborting() {
+        assertNotNull(deploymentService);
+
+        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+        DeployedUnit deployedGeneral = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
+        assertNotNull(deployedGeneral);
+        assertNotNull(deployedGeneral.getDeploymentUnit());
+        assertNotNull(deployedGeneral.getRuntimeManager());
+
+        RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
+        assertNotNull(manager);
+
+        RuntimeEngine engine = manager.getRuntimeEngine(EmptyContext.get());
+        assertNotNull(engine);
+
+        Map<String, Object> params = new HashMap<String, Object>();
+
+        ProcessInstance processInstance = engine.getKieSession().startProcess("org.jbpm.writedocument", params);
+
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
+
+        deploymentService.undeploy(deploymentUnit, true);
 
         ProcessInstanceDesc processInstanceDesc = runtimeDataService.getProcessInstanceById(processInstance.getId());
 
-        int expectedState = abortInstances ? ProcessInstance.STATE_ABORTED : ProcessInstance.STATE_ACTIVE;
-
-        assertEquals(expectedState, processInstanceDesc.getState().intValue());
+        assertEquals(ProcessInstance.STATE_ABORTED, processInstanceDesc.getState().intValue());
     }
 
     @Test
@@ -291,8 +335,7 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
 
         assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
 
-        checkFormsDeployment( deploymentUnit.getIdentifier() );
-
+        checkFormsDeployment(deploymentUnit.getIdentifier());
     }
 
     @Test
@@ -308,260 +351,9 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
         processes.add("repo/processes/general/import.bpmn");
 
         DeploymentDescriptor customDescriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
-		customDescriptor.getBuilder()
-		.runtimeStrategy(RuntimeStrategy.PER_REQUEST)
-		.addWorkItemHandler(new NamedObjectModel("Log", "org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler"));
-
-        Map<String, String> resources = new HashMap<String, String>();
-		resources.put("src/main/resources/" + DeploymentDescriptor.META_INF_LOCATION, customDescriptor.toXml());
-
-        InternalKieModule kJar1 = createKieJar(ks, releaseId, processes, resources);
-        File pom = new File("target/kmodule", "pom.xml");
-        pom.getParentFile().mkdir();
-        try {
-            FileOutputStream fs = new FileOutputStream(pom);
-            fs.write(getPom(releaseId).getBytes());
-            fs.close();
-        } catch (Exception e) {
-
-        }
-        KieMavenRepository repository = getKieMavenRepository();
-        repository.deployArtifact(releaseId, kJar1, pom);
-
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, "kjar-with-dd", VERSION, "KBase-test", "ksession-test2");
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
-        DeployedUnit deployedGeneral = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
-        assertNotNull(deployedGeneral);
-        assertNotNull(deployedGeneral.getDeploymentUnit());
-        assertNotNull(deployedGeneral.getRuntimeManager());
-
-        DeploymentDescriptor descriptor = ((InternalRuntimeManager)deployedGeneral.getRuntimeManager()).getDeploymentDescriptor();
-        assertNotNull(descriptor);
-		assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
-		assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
-		assertEquals(AuditMode.JPA, descriptor.getAuditMode());
-		assertEquals(PersistenceMode.JPA, descriptor.getPersistenceMode());
-		assertEquals(RuntimeStrategy.PER_REQUEST, descriptor.getRuntimeStrategy());
-		assertEquals(0, descriptor.getMarshallingStrategies().size());
-		assertEquals(0, descriptor.getConfiguration().size());
-		assertEquals(0, descriptor.getEnvironmentEntries().size());
-		assertEquals(0, descriptor.getEventListeners().size());
-		assertEquals(0, descriptor.getGlobals().size());
-		assertEquals(0, descriptor.getTaskEventListeners().size());
-		assertEquals(1, descriptor.getWorkItemHandlers().size());
-		assertEquals(0, descriptor.getRequiredRoles().size());
-
-        RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
-        assertNotNull(manager);
-
-        RuntimeEngine engine = manager.getRuntimeEngine(EmptyContext.get());
-        assertNotNull(engine);
-
-        Map<String, Object> params = new HashMap<String, Object>();
-
-        ProcessInstance processInstance = engine.getKieSession().startProcess("customtask", params);
-
-        assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
-
-        manager.disposeRuntimeEngine(engine);
-
-        checkFormsDeployment( deploymentUnit.getIdentifier() );
-    }
-
-    @Test(expected=SecurityException.class)
-    public void testDeploymentOfProcessWithDescriptorWitSecurityManager() {
-
-        assertNotNull(deploymentService);
-
-        KieServices ks = KieServices.Factory.get();
-        ReleaseId releaseId = ks.newReleaseId(GROUP_ID, "kjar-with-dd", VERSION);
-        List<String> processes = new ArrayList<String>();
-        processes.add("repo/processes/general/customtask.bpmn");
-        processes.add("repo/processes/general/humanTask.bpmn");
-        processes.add("repo/processes/general/import.bpmn");
-
-        DeploymentDescriptor customDescriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
-		customDescriptor.getBuilder()
-		.runtimeStrategy(RuntimeStrategy.PER_PROCESS_INSTANCE)
-		.addWorkItemHandler(new NamedObjectModel("Log", "org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler"))
-		.addRequiredRole("experts");
-
-        Map<String, String> resources = new HashMap<String, String>();
-		resources.put("src/main/resources/" + DeploymentDescriptor.META_INF_LOCATION, customDescriptor.toXml());
-
-        InternalKieModule kJar1 = createKieJar(ks, releaseId, processes, resources);
-        File pom = new File("target/kmodule", "pom.xml");
-        pom.getParentFile().mkdir();
-        try {
-            FileOutputStream fs = new FileOutputStream(pom);
-            fs.write(getPom(releaseId).getBytes());
-            fs.close();
-        } catch (Exception e) {
-
-        }
-        KieMavenRepository repository = getKieMavenRepository();
-        repository.deployArtifact(releaseId, kJar1, pom);
-
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, "kjar-with-dd", VERSION, "KBase-test", "ksession-test2");
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
-        DeployedUnit deployedGeneral = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
-        assertNotNull(deployedGeneral);
-        assertNotNull(deployedGeneral.getDeploymentUnit());
-        assertNotNull(deployedGeneral.getRuntimeManager());
-
-        DeploymentDescriptor descriptor = ((InternalRuntimeManager)deployedGeneral.getRuntimeManager()).getDeploymentDescriptor();
-        assertNotNull(descriptor);
-		assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
-		assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
-		assertEquals(AuditMode.JPA, descriptor.getAuditMode());
-		assertEquals(PersistenceMode.JPA, descriptor.getPersistenceMode());
-		assertEquals(RuntimeStrategy.PER_PROCESS_INSTANCE, descriptor.getRuntimeStrategy());
-		assertEquals(0, descriptor.getMarshallingStrategies().size());
-		assertEquals(0, descriptor.getConfiguration().size());
-		assertEquals(0, descriptor.getEnvironmentEntries().size());
-		assertEquals(0, descriptor.getEventListeners().size());
-		assertEquals(0, descriptor.getGlobals().size());
-		assertEquals(0, descriptor.getTaskEventListeners().size());
-		assertEquals(1, descriptor.getWorkItemHandlers().size());
-		assertEquals(1, descriptor.getRequiredRoles().size());
-
-        RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
-        assertNotNull(manager);
-
-        manager.getRuntimeEngine(EmptyContext.get());
-
-        checkFormsDeployment( deploymentUnit.getIdentifier() );
-    }
-
-
-    @Test
-    public void testDeploymentOfProcessWithDescriptorKieConteinerInjection() {
-
-        assertNotNull(deploymentService);
-
-        KieServices ks = KieServices.Factory.get();
-        ReleaseId releaseId = ks.newReleaseId(GROUP_ID, "kjar-with-dd", VERSION);
-        List<String> processes = new ArrayList<String>();
-        processes.add("repo/processes/general/customtask.bpmn");
-        processes.add("repo/processes/general/humanTask.bpmn");
-        processes.add("repo/processes/general/import.bpmn");
-
-        DeploymentDescriptor customDescriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
-		customDescriptor.getBuilder()
-		.runtimeStrategy(RuntimeStrategy.PER_REQUEST)
-		.addWorkItemHandler(new NamedObjectModel("mvel", "Log", "new org.jbpm.kie.services.test.objects.KieConteinerSystemOutWorkItemHandler(kieContainer)"));
-
-        Map<String, String> resources = new HashMap<String, String>();
-		resources.put("src/main/resources/" + DeploymentDescriptor.META_INF_LOCATION, customDescriptor.toXml());
-
-        InternalKieModule kJar1 = createKieJar(ks, releaseId, processes, resources);
-        File pom = new File("target/kmodule", "pom.xml");
-        pom.getParentFile().mkdir();
-        try {
-            FileOutputStream fs = new FileOutputStream(pom);
-            fs.write(getPom(releaseId).getBytes());
-            fs.close();
-        } catch (Exception e) {
-
-        }
-        KieMavenRepository repository = getKieMavenRepository();
-        repository.deployArtifact(releaseId, kJar1, pom);
-
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, "kjar-with-dd", VERSION, "KBase-test", "ksession-test2");
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
-        DeployedUnit deployedGeneral = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
-        assertNotNull(deployedGeneral);
-        assertNotNull(deployedGeneral.getDeploymentUnit());
-        assertNotNull(deployedGeneral.getRuntimeManager());
-
-        DeploymentDescriptor descriptor = ((InternalRuntimeManager)deployedGeneral.getRuntimeManager()).getDeploymentDescriptor();
-        assertNotNull(descriptor);
-		assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
-		assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
-		assertEquals(AuditMode.JPA, descriptor.getAuditMode());
-		assertEquals(PersistenceMode.JPA, descriptor.getPersistenceMode());
-		assertEquals(RuntimeStrategy.PER_REQUEST, descriptor.getRuntimeStrategy());
-		assertEquals(0, descriptor.getMarshallingStrategies().size());
-		assertEquals(0, descriptor.getConfiguration().size());
-		assertEquals(0, descriptor.getEnvironmentEntries().size());
-		assertEquals(0, descriptor.getEventListeners().size());
-		assertEquals(0, descriptor.getGlobals().size());
-		assertEquals(0, descriptor.getTaskEventListeners().size());
-		assertEquals(1, descriptor.getWorkItemHandlers().size());
-		assertEquals(0, descriptor.getRequiredRoles().size());
-
-        RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
-        assertNotNull(manager);
-
-        RuntimeEngine engine = manager.getRuntimeEngine(EmptyContext.get());
-        assertNotNull(engine);
-
-        Map<String, Object> params = new HashMap<String, Object>();
-
-        ProcessInstance processInstance = engine.getKieSession().startProcess("customtask", params);
-
-        assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
-        manager.disposeRuntimeEngine(engine);
-
-        checkFormsDeployment( deploymentUnit.getIdentifier() );
-    }
-
-    @Test
-    public void testDeploymentOfProcessesKieConteinerInjection() {
-
-        assertNotNull(deploymentService);
-
-        KModuleDeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION, "KBase-test", "ksession-test-2");
-
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
-
-        assertNotNull(deploymentUnit.getDeploymentDescriptor());
-
-        DeployedUnit deployed = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
-        assertNotNull(deployed);
-        assertNotNull(deployed.getDeploymentUnit());
-        assertNotNull(deployed.getRuntimeManager());
-        assertNull(deployed.getDeployedAssetLocation("customtask"));
-        assertEquals(GROUP_ID+":"+ARTIFACT_ID+":"+VERSION+":"+"KBase-test"+":"+"ksession-test-2",
-                deployed.getDeploymentUnit().getIdentifier());
-
-
-        RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
-        assertNotNull(manager);
-
-        RuntimeEngine engine = manager.getRuntimeEngine(EmptyContext.get());
-        assertNotNull(engine);
-
-        Map<String, Object> params = new HashMap<String, Object>();
-        params.put("id", "test");
-        ProcessInstance processInstance = engine.getKieSession().startProcess("customtask", params);
-
-        assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
-        manager.disposeRuntimeEngine(engine);
-
-        checkFormsDeployment( deploymentUnit.getIdentifier() );
-    }
-
-    @Test
-    public void testDeploymentAvoidEmptyDescriptorOverride() {
-
-        assertNotNull(deploymentService);
-
-        KieServices ks = KieServices.Factory.get();
-        ReleaseId releaseId = ks.newReleaseId(GROUP_ID, "kjar-with-dd", VERSION);
-        List<String> processes = new ArrayList<String>();
-        processes.add("repo/processes/general/customtask.bpmn");
-        processes.add("repo/processes/general/humanTask.bpmn");
-        processes.add("repo/processes/general/import.bpmn");
-
-        DeploymentDescriptor customDescriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
         customDescriptor.getBuilder()
-        .runtimeStrategy(RuntimeStrategy.PER_REQUEST)
-        .addWorkItemHandler(new NamedObjectModel("Log", "org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler"));
+                .runtimeStrategy(RuntimeStrategy.PER_REQUEST)
+                .addWorkItemHandler(new NamedObjectModel("Log", "org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler"));
 
         Map<String, String> resources = new HashMap<String, String>();
         resources.put("src/main/resources/" + DeploymentDescriptor.META_INF_LOCATION, customDescriptor.toXml());
@@ -579,11 +371,7 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
         KieMavenRepository repository = getKieMavenRepository();
         repository.deployArtifact(releaseId, kJar1, pom);
 
-        KModuleDeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, "kjar-with-dd", VERSION, "KBase-test", "ksession-test2");
-
-        // let's simulate change of deployment descriptor on deploy time
-        deploymentUnit.setDeploymentDescriptor(new DeploymentDescriptorImpl()); // set empty one...
-
+        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, "kjar-with-dd", VERSION, "KBase-test", "ksession-test2");
         deploymentService.deploy(deploymentUnit);
         units.add(deploymentUnit);
         DeployedUnit deployedGeneral = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
@@ -591,7 +379,7 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
         assertNotNull(deployedGeneral.getDeploymentUnit());
         assertNotNull(deployedGeneral.getRuntimeManager());
 
-        DeploymentDescriptor descriptor = ((InternalRuntimeManager)deployedGeneral.getRuntimeManager()).getDeploymentDescriptor();
+        DeploymentDescriptor descriptor = ((InternalRuntimeManager) deployedGeneral.getRuntimeManager()).getDeploymentDescriptor();
         assertNotNull(descriptor);
         assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
         assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
@@ -621,18 +409,270 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
 
         manager.disposeRuntimeEngine(engine);
 
-        checkFormsDeployment( deploymentUnit.getIdentifier() );
+        checkFormsDeployment(deploymentUnit.getIdentifier());
     }
 
-    protected void checkFormsDeployment( String deploymentId ) {
-        Map<String, String> deployedForms = formManagerService.getAllFormsByDeployment( deploymentId );
+    @Test(expected = SecurityException.class)
+    public void testDeploymentOfProcessWithDescriptorWitSecurityManager() {
 
-        assertNotNull( deployedForms );
-        assertEquals( 3, deployedForms.size() );
+        assertNotNull(deploymentService);
 
-        assertNotNull( deployedForms.get( "DefaultProcess.frm" ) );
-        assertNotNull( deployedForms.get( "DefaultProcess.form" ) );
-        assertNotNull( deployedForms.get( "DefaultProcess.ftl" ) );
+        KieServices ks = KieServices.Factory.get();
+        ReleaseId releaseId = ks.newReleaseId(GROUP_ID, "kjar-with-dd", VERSION);
+        List<String> processes = new ArrayList<String>();
+        processes.add("repo/processes/general/customtask.bpmn");
+        processes.add("repo/processes/general/humanTask.bpmn");
+        processes.add("repo/processes/general/import.bpmn");
+
+        DeploymentDescriptor customDescriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
+        customDescriptor.getBuilder()
+                .runtimeStrategy(RuntimeStrategy.PER_PROCESS_INSTANCE)
+                .addWorkItemHandler(new NamedObjectModel("Log", "org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler"))
+                .addRequiredRole("experts");
+
+        Map<String, String> resources = new HashMap<String, String>();
+        resources.put("src/main/resources/" + DeploymentDescriptor.META_INF_LOCATION, customDescriptor.toXml());
+
+        InternalKieModule kJar1 = createKieJar(ks, releaseId, processes, resources);
+        File pom = new File("target/kmodule", "pom.xml");
+        pom.getParentFile().mkdir();
+        try {
+            FileOutputStream fs = new FileOutputStream(pom);
+            fs.write(getPom(releaseId).getBytes());
+            fs.close();
+        } catch (Exception e) {
+
+        }
+        KieMavenRepository repository = getKieMavenRepository();
+        repository.deployArtifact(releaseId, kJar1, pom);
+
+        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, "kjar-with-dd", VERSION, "KBase-test", "ksession-test2");
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+        DeployedUnit deployedGeneral = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
+        assertNotNull(deployedGeneral);
+        assertNotNull(deployedGeneral.getDeploymentUnit());
+        assertNotNull(deployedGeneral.getRuntimeManager());
+
+        DeploymentDescriptor descriptor = ((InternalRuntimeManager) deployedGeneral.getRuntimeManager()).getDeploymentDescriptor();
+        assertNotNull(descriptor);
+        assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, descriptor.getAuditMode());
+        assertEquals(PersistenceMode.JPA, descriptor.getPersistenceMode());
+        assertEquals(RuntimeStrategy.PER_PROCESS_INSTANCE, descriptor.getRuntimeStrategy());
+        assertEquals(0, descriptor.getMarshallingStrategies().size());
+        assertEquals(0, descriptor.getConfiguration().size());
+        assertEquals(0, descriptor.getEnvironmentEntries().size());
+        assertEquals(0, descriptor.getEventListeners().size());
+        assertEquals(0, descriptor.getGlobals().size());
+        assertEquals(0, descriptor.getTaskEventListeners().size());
+        assertEquals(1, descriptor.getWorkItemHandlers().size());
+        assertEquals(1, descriptor.getRequiredRoles().size());
+
+        RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
+        assertNotNull(manager);
+
+        manager.getRuntimeEngine(EmptyContext.get());
+
+        checkFormsDeployment(deploymentUnit.getIdentifier());
     }
 
+    @Test
+    public void testDeploymentOfProcessWithDescriptorKieConteinerInjection() {
+
+        assertNotNull(deploymentService);
+
+        KieServices ks = KieServices.Factory.get();
+        ReleaseId releaseId = ks.newReleaseId(GROUP_ID, "kjar-with-dd", VERSION);
+        List<String> processes = new ArrayList<String>();
+        processes.add("repo/processes/general/customtask.bpmn");
+        processes.add("repo/processes/general/humanTask.bpmn");
+        processes.add("repo/processes/general/import.bpmn");
+
+        DeploymentDescriptor customDescriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
+        customDescriptor.getBuilder()
+                .runtimeStrategy(RuntimeStrategy.PER_REQUEST)
+                .addWorkItemHandler(new NamedObjectModel("mvel", "Log", "new org.jbpm.kie.services.test.objects.KieConteinerSystemOutWorkItemHandler(kieContainer)"));
+
+        Map<String, String> resources = new HashMap<String, String>();
+        resources.put("src/main/resources/" + DeploymentDescriptor.META_INF_LOCATION, customDescriptor.toXml());
+
+        InternalKieModule kJar1 = createKieJar(ks, releaseId, processes, resources);
+        File pom = new File("target/kmodule", "pom.xml");
+        pom.getParentFile().mkdir();
+        try {
+            FileOutputStream fs = new FileOutputStream(pom);
+            fs.write(getPom(releaseId).getBytes());
+            fs.close();
+        } catch (Exception e) {
+
+        }
+        KieMavenRepository repository = getKieMavenRepository();
+        repository.deployArtifact(releaseId, kJar1, pom);
+
+        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, "kjar-with-dd", VERSION, "KBase-test", "ksession-test2");
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+        DeployedUnit deployedGeneral = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
+        assertNotNull(deployedGeneral);
+        assertNotNull(deployedGeneral.getDeploymentUnit());
+        assertNotNull(deployedGeneral.getRuntimeManager());
+
+        DeploymentDescriptor descriptor = ((InternalRuntimeManager) deployedGeneral.getRuntimeManager()).getDeploymentDescriptor();
+        assertNotNull(descriptor);
+        assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, descriptor.getAuditMode());
+        assertEquals(PersistenceMode.JPA, descriptor.getPersistenceMode());
+        assertEquals(RuntimeStrategy.PER_REQUEST, descriptor.getRuntimeStrategy());
+        assertEquals(0, descriptor.getMarshallingStrategies().size());
+        assertEquals(0, descriptor.getConfiguration().size());
+        assertEquals(0, descriptor.getEnvironmentEntries().size());
+        assertEquals(0, descriptor.getEventListeners().size());
+        assertEquals(0, descriptor.getGlobals().size());
+        assertEquals(0, descriptor.getTaskEventListeners().size());
+        assertEquals(1, descriptor.getWorkItemHandlers().size());
+        assertEquals(0, descriptor.getRequiredRoles().size());
+
+        RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
+        assertNotNull(manager);
+
+        RuntimeEngine engine = manager.getRuntimeEngine(EmptyContext.get());
+        assertNotNull(engine);
+
+        Map<String, Object> params = new HashMap<String, Object>();
+
+        ProcessInstance processInstance = engine.getKieSession().startProcess("customtask", params);
+
+        assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
+        manager.disposeRuntimeEngine(engine);
+
+        checkFormsDeployment(deploymentUnit.getIdentifier());
+    }
+
+    @Test
+    public void testDeploymentOfProcessesKieConteinerInjection() {
+
+        assertNotNull(deploymentService);
+
+        KModuleDeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION, "KBase-test", "ksession-test-2");
+
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+
+        assertNotNull(deploymentUnit.getDeploymentDescriptor());
+
+        DeployedUnit deployed = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
+        assertNotNull(deployed);
+        assertNotNull(deployed.getDeploymentUnit());
+        assertNotNull(deployed.getRuntimeManager());
+        assertNull(deployed.getDeployedAssetLocation("customtask"));
+        assertEquals(GROUP_ID + ":" + ARTIFACT_ID + ":" + VERSION + ":" + "KBase-test" + ":" + "ksession-test-2",
+                     deployed.getDeploymentUnit().getIdentifier());
+
+        RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
+        assertNotNull(manager);
+
+        RuntimeEngine engine = manager.getRuntimeEngine(EmptyContext.get());
+        assertNotNull(engine);
+
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("id", "test");
+        ProcessInstance processInstance = engine.getKieSession().startProcess("customtask", params);
+
+        assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
+        manager.disposeRuntimeEngine(engine);
+
+        checkFormsDeployment(deploymentUnit.getIdentifier());
+    }
+
+    @Test
+    public void testDeploymentAvoidEmptyDescriptorOverride() {
+
+        assertNotNull(deploymentService);
+
+        KieServices ks = KieServices.Factory.get();
+        ReleaseId releaseId = ks.newReleaseId(GROUP_ID, "kjar-with-dd", VERSION);
+        List<String> processes = new ArrayList<String>();
+        processes.add("repo/processes/general/customtask.bpmn");
+        processes.add("repo/processes/general/humanTask.bpmn");
+        processes.add("repo/processes/general/import.bpmn");
+
+        DeploymentDescriptor customDescriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
+        customDescriptor.getBuilder()
+                .runtimeStrategy(RuntimeStrategy.PER_REQUEST)
+                .addWorkItemHandler(new NamedObjectModel("Log", "org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler"));
+
+        Map<String, String> resources = new HashMap<String, String>();
+        resources.put("src/main/resources/" + DeploymentDescriptor.META_INF_LOCATION, customDescriptor.toXml());
+
+        InternalKieModule kJar1 = createKieJar(ks, releaseId, processes, resources);
+        File pom = new File("target/kmodule", "pom.xml");
+        pom.getParentFile().mkdir();
+        try {
+            FileOutputStream fs = new FileOutputStream(pom);
+            fs.write(getPom(releaseId).getBytes());
+            fs.close();
+        } catch (Exception e) {
+
+        }
+        KieMavenRepository repository = getKieMavenRepository();
+        repository.deployArtifact(releaseId, kJar1, pom);
+
+        KModuleDeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, "kjar-with-dd", VERSION, "KBase-test", "ksession-test2");
+
+        // let's simulate change of deployment descriptor on deploy time
+        deploymentUnit.setDeploymentDescriptor(new DeploymentDescriptorImpl()); // set empty one...
+
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+        DeployedUnit deployedGeneral = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
+        assertNotNull(deployedGeneral);
+        assertNotNull(deployedGeneral.getDeploymentUnit());
+        assertNotNull(deployedGeneral.getRuntimeManager());
+
+        DeploymentDescriptor descriptor = ((InternalRuntimeManager) deployedGeneral.getRuntimeManager()).getDeploymentDescriptor();
+        assertNotNull(descriptor);
+        assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, descriptor.getAuditMode());
+        assertEquals(PersistenceMode.JPA, descriptor.getPersistenceMode());
+        assertEquals(RuntimeStrategy.PER_REQUEST, descriptor.getRuntimeStrategy());
+        assertEquals(0, descriptor.getMarshallingStrategies().size());
+        assertEquals(0, descriptor.getConfiguration().size());
+        assertEquals(0, descriptor.getEnvironmentEntries().size());
+        assertEquals(0, descriptor.getEventListeners().size());
+        assertEquals(0, descriptor.getGlobals().size());
+        assertEquals(0, descriptor.getTaskEventListeners().size());
+        assertEquals(1, descriptor.getWorkItemHandlers().size());
+        assertEquals(0, descriptor.getRequiredRoles().size());
+
+        RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
+        assertNotNull(manager);
+
+        RuntimeEngine engine = manager.getRuntimeEngine(EmptyContext.get());
+        assertNotNull(engine);
+
+        Map<String, Object> params = new HashMap<String, Object>();
+
+        ProcessInstance processInstance = engine.getKieSession().startProcess("customtask", params);
+
+        assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
+
+        manager.disposeRuntimeEngine(engine);
+
+        checkFormsDeployment(deploymentUnit.getIdentifier());
+    }
+
+    protected void checkFormsDeployment(String deploymentId) {
+        Map<String, String> deployedForms = formManagerService.getAllFormsByDeployment(deploymentId);
+
+        assertNotNull(deployedForms);
+        assertEquals(3, deployedForms.size());
+
+        assertNotNull(deployedForms.get("DefaultProcess.frm"));
+        assertNotNull(deployedForms.get("DefaultProcess.form"));
+        assertNotNull(deployedForms.get("DefaultProcess.ftl"));
+    }
 }

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/KModuleDeploymentServiceTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/KModuleDeploymentServiceTest.java
@@ -151,6 +151,8 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
 
         assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
 
+        manager.disposeRuntimeEngine(engine);
+
         checkFormsDeployment(deploymentUnit.getIdentifier());
     }
 
@@ -199,6 +201,8 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
         ProcessInstance processInstance = engine.getKieSession().startProcess("customtask", params);
 
         assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
+
+        manager.disposeRuntimeEngine(engine);
 
         checkFormsDeployment(deploymentUnit.getIdentifier());
     }
@@ -253,30 +257,9 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
 
         engine.getKieSession().abortProcessInstance(processInstance.getId());
 
+        manager.disposeRuntimeEngine(engine);
+
         checkFormsDeployment(deploymentUnit.getIdentifier());
-    }
-
-    @Test
-    public void testUnDeploymentWithoutActiveProcesses() {
-
-        assertNotNull(deploymentService);
-
-        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
-        deploymentService.deploy(deploymentUnit);
-        units.add(deploymentUnit);
-        DeployedUnit deployedGeneral = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
-
-        assertNotNull(deployedGeneral);
-        assertNotNull(deployedGeneral.getDeploymentUnit());
-        assertNotNull(deployedGeneral.getRuntimeManager());
-
-        RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
-        assertNotNull(manager);
-
-        RuntimeEngine engine = manager.getRuntimeEngine(EmptyContext.get());
-        assertNotNull(engine);
-
-        deploymentService.undeploy(deploymentUnit);
     }
 
     @Test
@@ -308,6 +291,8 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
         ProcessInstanceDesc processInstanceDesc = runtimeDataService.getProcessInstanceById(processInstance.getId());
 
         assertEquals(ProcessInstance.STATE_ABORTED, processInstanceDesc.getState().intValue());
+
+        manager.disposeRuntimeEngine(engine);
     }
 
     @Test
@@ -335,7 +320,10 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
 
         assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
 
+        manager.disposeRuntimeEngine(engine);
+
         checkFormsDeployment(deploymentUnit.getIdentifier());
+
     }
 
     @Test
@@ -473,7 +461,11 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
         RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
         assertNotNull(manager);
 
-        manager.getRuntimeEngine(EmptyContext.get());
+        RuntimeEngine engine = manager.getRuntimeEngine(EmptyContext.get());
+
+        assertNotNull(engine);
+
+        manager.disposeRuntimeEngine(engine);
 
         checkFormsDeployment(deploymentUnit.getIdentifier());
     }
@@ -546,6 +538,7 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
         ProcessInstance processInstance = engine.getKieSession().startProcess("customtask", params);
 
         assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
+
         manager.disposeRuntimeEngine(engine);
 
         checkFormsDeployment(deploymentUnit.getIdentifier());

--- a/jbpm-services/jbpm-services-api/src/build/revapi-config.json
+++ b/jbpm-services/jbpm-services-api/src/build/revapi-config.json
@@ -14,7 +14,6 @@
       }
     }
   },
-
   "ignores": {
     "revapi": {
       "_comment": "Changes between 7.11.0.Final and the current branch. These changes are desired and thus ignored.",
@@ -47,29 +46,38 @@
           "justification": "JBPM-7632 - Enhance process definition data including timers and nodes"
         },
         {
-  	  "code": "java.field.enumConstantOrderChanged",
-   	  "old": "field org.jbpm.services.api.query.model.QueryDefinition.Target.CUSTOM",
-   	  "new": "field org.jbpm.services.api.query.model.QueryDefinition.Target.CUSTOM",
-   	  "oldOrdinal": "8",
-   	  "newOrdinal": "9",
-   	  "package": "org.jbpm.services.api.query.model",
-   	  "classSimpleName": "Target",
-   	  "fieldName": "CUSTOM",
-   	  "elementKind": "enumConstant",
-   	  "justification": "JBPM-8155 -Adding new target for custom queries USER_GROUPS_TASK and moving CUSTOM"
- 	},
-	{
-  	  "code": "java.field.enumConstantOrderChanged",
+          "code": "java.field.enumConstantOrderChanged",
+          "old": "field org.jbpm.services.api.query.model.QueryDefinition.Target.CUSTOM",
+          "new": "field org.jbpm.services.api.query.model.QueryDefinition.Target.CUSTOM",
+          "oldOrdinal": "8",
+          "newOrdinal": "9",
+          "package": "org.jbpm.services.api.query.model",
+          "classSimpleName": "Target",
+          "fieldName": "CUSTOM",
+          "elementKind": "enumConstant",
+          "justification": "JBPM-8155 -Adding new target for custom queries USER_GROUPS_TASK and moving CUSTOM"
+        },
+        {
+          "code": "java.field.enumConstantOrderChanged",
           "old": "field org.jbpm.services.api.query.model.QueryDefinition.Target.USER_GROUPS_TASK",
-  	  "new": "field org.jbpm.services.api.query.model.QueryDefinition.Target.USER_GROUPS_TASK",
-  	  "oldOrdinal": "9",
-  	  "newOrdinal": "8",
-  	  "package": "org.jbpm.services.api.query.model",
-  	  "classSimpleName": "Target",
-  	  "fieldName": "USER_GROUPS_TASK",
-  	  "elementKind": "enumConstant",
-  	  "justification": "JBPM-8155 -Adding new target for custom queries USER_GROUPS_TASK"
-	}
+          "new": "field org.jbpm.services.api.query.model.QueryDefinition.Target.USER_GROUPS_TASK",
+          "oldOrdinal": "9",
+          "newOrdinal": "8",
+          "package": "org.jbpm.services.api.query.model",
+          "classSimpleName": "Target",
+          "fieldName": "USER_GROUPS_TASK",
+          "elementKind": "enumConstant",
+          "justification": "JBPM-8155 -Adding new target for custom queries USER_GROUPS_TASK"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.jbpm.services.api.DeploymentService::undeploy(org.jbpm.services.api.model.DeploymentUnit, boolean)",
+          "package": "org.jbpm.services.api",
+          "classSimpleName": "DeploymentService",
+          "methodName": "undeploy",
+          "elementKind": "method",
+          "justification": "AF-1685: Development Lifecycle Streamline"
+        }
       ]
     }
   }

--- a/jbpm-services/jbpm-services-api/src/build/revapi-config.json
+++ b/jbpm-services/jbpm-services-api/src/build/revapi-config.json
@@ -71,7 +71,7 @@
         },
         {
           "code": "java.method.addedToInterface",
-          "new": "method void org.jbpm.services.api.DeploymentService::undeploy(org.jbpm.services.api.model.DeploymentUnit, boolean)",
+          "new": "method void org.jbpm.services.api.DeploymentService::undeploy(org.jbpm.services.api.model.DeploymentUnit, java.util.function.Function<org.jbpm.services.api.model.DeploymentUnit, java.lang.Boolean>)",
           "package": "org.jbpm.services.api",
           "classSimpleName": "DeploymentService",
           "methodName": "undeploy",

--- a/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/DeploymentService.java
+++ b/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/DeploymentService.java
@@ -43,6 +43,14 @@ public interface DeploymentService {
 	 * @throws RuntimeException in case of problems encountered while deploying unit
 	 */
     void undeploy(DeploymentUnit unit);
+
+    /**
+     * Performs undeployment operation of given <code>unit</code> aborting existing process instances if needed.
+     * @param unit deployment unit to be undeployed from runtime
+     * @param abortInstances determines if existing process instances should be aborted or not.
+     * @throws RuntimeException in case of problems encountered while deploying unit
+     */
+    void undeploy(DeploymentUnit unit, boolean abortInstances);
     
     /**
      * Returns <code>RuntimeManager</code> instance dedicated to deployment unit identified by given id 

--- a/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/DeploymentService.java
+++ b/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/DeploymentService.java
@@ -40,7 +40,7 @@ public interface DeploymentService {
     /**
 	 * Performs undeployment operation of given <code>unit</code>.
 	 * @param unit deployment unit to be undeployed from runtime
-	 * @throws RuntimeException in case of problems encountered while deploying unit
+	 * @throws RuntimeException in case of problems encountered while undeploying unit
 	 */
     void undeploy(DeploymentUnit unit);
 
@@ -48,7 +48,7 @@ public interface DeploymentService {
      * Performs undeployment operation of given <code>unit</code> aborting existing process instances if needed.
      * @param unit deployment unit to be undeployed from runtime
      * @param abortInstances determines if existing process instances should be aborted or not.
-     * @throws RuntimeException in case of problems encountered while deploying unit
+     * @throws RuntimeException in case of problems encountered while undeploying unit
      */
     void undeploy(DeploymentUnit unit, boolean abortInstances);
     

--- a/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/DeploymentService.java
+++ b/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/DeploymentService.java
@@ -17,6 +17,8 @@
 package org.jbpm.services.api;
 
 import java.util.Collection;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.jbpm.services.api.model.DeployedUnit;
 import org.jbpm.services.api.model.DeploymentUnit;
@@ -47,10 +49,11 @@ public interface DeploymentService {
     /**
      * Performs undeployment operation of given <code>unit</code> aborting existing process instances if needed.
      * @param unit deployment unit to be undeployed from runtime
-     * @param abortInstances determines if existing process instances should be aborted or not.
+     * @param beforeUndeploy a function to run custom actions before undeploying a given {@link DeploymentUnit} . It should return if the unit can be deployed or not
+     * determining if the deployment can continue.
      * @throws RuntimeException in case of problems encountered while undeploying unit
      */
-    void undeploy(DeploymentUnit unit, boolean abortInstances);
+    void undeploy(DeploymentUnit unit, Function<DeploymentUnit, Boolean> beforeUndeploy);
     
     /**
      * Returns <code>RuntimeManager</code> instance dedicated to deployment unit identified by given id 

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-api/src/main/java/org/jbpm/services/ejb/api/DeploymentServiceEJBRemote.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-api/src/main/java/org/jbpm/services/ejb/api/DeploymentServiceEJBRemote.java
@@ -58,7 +58,14 @@ public interface DeploymentServiceEJBRemote  {
      * @param deploymentId unique identifier of the deployment
      */
     void undeploy(String deploymentId);
-    
+
+	/**
+	 * Undeploys currently active deployment unit identified by given deploymentId
+	 * @param deploymentId unique identifier of the deployment
+	 * @param abortInstances determines if existing process instances should be aborted or not.
+	 */
+	void undeploy(String deploymentId, boolean abortInstances);
+
     /**
      * Activates given deployment by making sure it will be available for execution.
      * @param deploymentId

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-api/src/main/java/org/jbpm/services/ejb/api/DeploymentServiceEJBRemote.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-api/src/main/java/org/jbpm/services/ejb/api/DeploymentServiceEJBRemote.java
@@ -16,7 +16,11 @@
 
 package org.jbpm.services.ejb.api;
 
+import java.util.function.Function;
+
 import javax.ejb.Remote;
+
+import org.jbpm.services.api.model.DeploymentUnit;
 
 @Remote
 public interface DeploymentServiceEJBRemote  {
@@ -62,9 +66,10 @@ public interface DeploymentServiceEJBRemote  {
 	/**
 	 * Undeploys currently active deployment unit identified by given deploymentId
 	 * @param deploymentId unique identifier of the deployment
-	 * @param abortInstances determines if existing process instances should be aborted or not.
+	 * @param beforeUndeploy a function to run custom actions before undeploying a given {@link DeploymentUnit}.
+	 * It should return if the unit can be undeployed or not determining if the deployment can continue.
 	 */
-	void undeploy(String deploymentId, boolean abortInstances);
+	void undeploy(String deploymentId, Function<DeploymentUnit, Boolean> beforeUndeploy);
 
     /**
      * Activates given deployment by making sure it will be available for execution.

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-client/src/test/java/org/jbpm/services/ejb/client/helper/DeploymentServiceWrapper.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-client/src/test/java/org/jbpm/services/ejb/client/helper/DeploymentServiceWrapper.java
@@ -17,6 +17,7 @@
 package org.jbpm.services.ejb.client.helper;
 
 import java.util.Collection;
+import java.util.function.Function;
 
 import org.jbpm.kie.services.impl.KModuleDeploymentUnit;
 import org.jbpm.services.api.DeploymentService;
@@ -46,8 +47,8 @@ public class DeploymentServiceWrapper implements DeploymentService {
 	}
 
 	@Override
-	public void undeploy(DeploymentUnit unit, boolean abortInstances) {
-		remote.undeploy(unit.getIdentifier(), abortInstances);
+	public void undeploy(DeploymentUnit unit, Function<DeploymentUnit, Boolean> beforeUndeploy) {
+		remote.undeploy(unit.getIdentifier(), beforeUndeploy);
 	}
 
 	@Override

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-client/src/test/java/org/jbpm/services/ejb/client/helper/DeploymentServiceWrapper.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-client/src/test/java/org/jbpm/services/ejb/client/helper/DeploymentServiceWrapper.java
@@ -46,6 +46,11 @@ public class DeploymentServiceWrapper implements DeploymentService {
 	}
 
 	@Override
+	public void undeploy(DeploymentUnit unit, boolean abortInstances) {
+		remote.undeploy(unit.getIdentifier(), abortInstances);
+	}
+
+	@Override
 	public RuntimeManager getRuntimeManager(String deploymentUnitId) {
 		throw new UnsupportedOperationException("Not supported");
 	}

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-impl/src/main/java/org/jbpm/services/ejb/impl/DeploymentServiceEJBImpl.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-impl/src/main/java/org/jbpm/services/ejb/impl/DeploymentServiceEJBImpl.java
@@ -16,6 +16,8 @@
 
 package org.jbpm.services.ejb.impl;
 
+import java.util.function.Function;
+
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.annotation.Resource;
@@ -173,15 +175,15 @@ public class DeploymentServiceEJBImpl extends KModuleDeploymentService implement
 		}
 	}
 
-    @Override
-    public void undeploy(String deploymentId, boolean abortInstances) {
-        DeployedUnit deployed = getDeployedUnit(deploymentId);
-        if (deployed != null) {
-            super.undeploy(deployed.getDeploymentUnit(), abortInstances);
-        }
-    }
+	@Override
+	public void undeploy(String deploymentId, Function<DeploymentUnit, Boolean> beforeUndeploy) {
+		DeployedUnit deployed = getDeployedUnit(deploymentId);
+		if (deployed != null) {
+			super.undeploy(deployed.getDeploymentUnit(), beforeUndeploy);
+		}
+	}
 
-    protected void addAsyncHandler(KModuleDeploymentUnit unit) {
+	protected void addAsyncHandler(KModuleDeploymentUnit unit) {
 		// add async only when the executor component is not disabled
 		if (isExecutorAvailable) {
 			DeploymentDescriptor descriptor = unit.getDeploymentDescriptor();

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-impl/src/main/java/org/jbpm/services/ejb/impl/DeploymentServiceEJBImpl.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-impl/src/main/java/org/jbpm/services/ejb/impl/DeploymentServiceEJBImpl.java
@@ -172,8 +172,16 @@ public class DeploymentServiceEJBImpl extends KModuleDeploymentService implement
 			super.undeploy(deployed.getDeploymentUnit());
 		}
 	}
-	
-	protected void addAsyncHandler(KModuleDeploymentUnit unit) {
+
+    @Override
+    public void undeploy(String deploymentId, boolean abortInstances) {
+        DeployedUnit deployed = getDeployedUnit(deploymentId);
+        if (deployed != null) {
+            super.undeploy(deployed.getDeploymentUnit(), abortInstances);
+        }
+    }
+
+    protected void addAsyncHandler(KModuleDeploymentUnit unit) {
 		// add async only when the executor component is not disabled
 		if (isExecutorAvailable) {
 			DeploymentDescriptor descriptor = unit.getDeploymentDescriptor();


### PR DESCRIPTION
AF-1687: Align with 'kie-server' with development mode

Added extra param to decide if existing process instances must be aborted or not when undeploying.

@mswiderski @tomasdavidorg could you please take a look?

This is part of an ensemble, please merge with:
https://github.com/kiegroup/appformer/pull/614
https://github.com/kiegroup/jbpm/pull/1424
https://github.com/kiegroup/droolsjbpm-integration/pull/1698
https://github.com/kiegroup/kie-wb-common/pull/2422