### PR TITLE
Fix NullPointerException when undeploy

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/FormManagerServiceImpl.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/FormManagerServiceImpl.java
@@ -37,7 +37,10 @@ public class FormManagerServiceImpl implements FormManagerService {
 
     @Override
     public void unRegisterForms( String deploymentId ) {
-        formsRegistry.remove( deploymentId );
+		if (formsRegistry.get(deploymentId) != null) {
+			formsRegistry.get(deploymentId).clear();
+			formsRegistry.remove(deploymentId);
+		}
     }
 
     @Override


### PR DESCRIPTION
When call KModuleDeploymentService.undeploy#230, it will unregister forms, if the kjar doesn't contains any forms, then it throws NullPointerException