### PR TITLE
add new feature to mask the original sender's address. 

### DIFF
--- a/jbpm-workitems/jbpm-workitems-email/src/main/java/org/jbpm/process/workitem/email/EmailWorkItemHandler.java
+++ b/jbpm-workitems/jbpm-workitems-email/src/main/java/org/jbpm/process/workitem/email/EmailWorkItemHandler.java
@@ -142,6 +142,7 @@ public class EmailWorkItemHandler extends AbstractLogOrThrowWorkItemHandler {
         Message message = new Message();
         message.setFrom((String) workItem.getParameter("From"));
         message.setReplyTo( (String) workItem.getParameter("Reply-To"));
+        message.setDisplayName((String) workItem.getParameter("DisplayName"));
 
         // Set recipients
         Recipients recipients = new Recipients();

--- a/jbpm-workitems/jbpm-workitems-email/src/main/java/org/jbpm/process/workitem/email/Message.java
+++ b/jbpm-workitems/jbpm-workitems-email/src/main/java/org/jbpm/process/workitem/email/Message.java
@@ -28,6 +28,7 @@ public class Message {
     private String body;
     private String documentFormat = "html";
     private List<String> attachments;
+    private String displayName;
 
     public Message() {
         this.recipients = new Recipients();
@@ -94,6 +95,14 @@ public class Message {
         return !this.attachments.isEmpty();
     }
 
+    public String getDisplayName() {
+    	return this.displayName;
+    }
+        
+    public void setDisplayName(String displayName) {
+       	this.displayName = displayName;
+    }
+    
     public int hashCode() {
         final int prime = 31;
         int result = 1;
@@ -104,6 +113,7 @@ public class Message {
         result = prime * result + ((replyTo == null) ? 0 : replyTo.hashCode());
         result = prime * result + ((subject == null) ? 0 : subject.hashCode());
         result = prime * result + ((attachments == null) ? 0 : attachments.hashCode());
+        result = prime * result + ((displayName==null) ? 0 : displayName.hashCode());
         return result;
     }
 
@@ -166,6 +176,14 @@ public class Message {
             }
         } else if (!attachments.equals(other.attachments)) {
             return false;
+        }
+        
+        if (displayName == null) {
+        	if (other.displayName != null) {
+        	    return false;
+        	}
+        } else if (!displayName.equals(other.displayName)) {
+        	return false;
         }
         return true;
     }

--- a/jbpm-workitems/jbpm-workitems-email/src/main/java/org/jbpm/process/workitem/email/SendHtml.java
+++ b/jbpm-workitems/jbpm-workitems-email/src/main/java/org/jbpm/process/workitem/email/SendHtml.java
@@ -121,6 +121,7 @@ public class SendHtml {
         String subject = message.getSubject();
         String from = message.getFrom();
         String replyTo = message.getReplyTo();
+        String displayName = message.getDisplayName();
 
         String mailer = "sendhtml";
 
@@ -136,7 +137,11 @@ public class SendHtml {
         Message msg = null;
         try {
             msg = new MimeMessage(session);
-            msg.setFrom(new InternetAddress(from));
+            if(null != displayName) {
+                msg.setFrom(new InternetAddress(from, displayName));
+            } else {
+                msg.setFrom(new InternetAddress(from));
+            }
             msg.setReplyTo(new InternetAddress[]{new InternetAddress(replyTo)});
 
             for (Recipient recipient : message.getRecipients().getRecipients()) {


### PR DESCRIPTION
see https://issues.jboss.org/browse/RHPAM-1854 for details.

This new feature introduces a new variable name called "DisplayName" passed in EmailWorkItemHandler. 
This variable holds the value to show the name for displaying instead of the sender's original email address.  
The main change in the code is in SendHtml.java:

previous code:
            msg.setFrom(new InternetAddress(from));

proposed changes:

            if(null != displayName) {
                msg.setFrom(new InternetAddress(from, displayName));
            } else {
                msg.setFrom(new InternetAddress(from));
            }