### PR TITLE
JBPM-8200 - Unify QueryContext count handling in Hibernate

### DIFF
--- a/jbpm-human-task/jbpm-human-task-audit/src/test/java/org/jbpm/services/task/audit/service/LocalWithCustomCallbackTaskAuditTest.java
+++ b/jbpm-human-task/jbpm-human-task-audit/src/test/java/org/jbpm/services/task/audit/service/LocalWithCustomCallbackTaskAuditTest.java
@@ -113,7 +113,7 @@ public class LocalWithCustomCallbackTaskAuditTest extends HumanTaskServicesBaseT
         assertTrue(allGroupTasks.get(0).getStatusId().equals("Ready"));
 
         List<AuditTask> allGroupAuditTasksByUser = taskAuditService.getAllGroupAuditTasksByUser("salaboy",
-                new QueryFilter(0, 10));
+                new QueryFilter(0, 0));
         assertEquals(1, allGroupAuditTasksByUser.size());
         assertTrue(allGroupAuditTasksByUser.get(0).getStatus().equals("Ready"));
     }

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/persistence/JPATaskPersistenceContext.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/persistence/JPATaskPersistenceContext.java
@@ -644,7 +644,7 @@ public class JPATaskPersistenceContext implements TaskPersistenceContext {
 					query.setFirstResult((Integer) paramEntry.getValue());
 					continue;
 				} else if (MAX_RESULTS.equals(name)) {
-					if (((Integer) paramEntry.getValue()) > -1) {
+					if (((Integer) paramEntry.getValue()) > 0) {
 						query.setMaxResults((Integer) paramEntry.getValue());
 					}
 					continue;

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/RuntimeDataServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/RuntimeDataServiceImplTest.java
@@ -1657,4 +1657,39 @@ public class RuntimeDataServiceImplTest extends AbstractKieServicesBaseTest {
 	    // should throw TaskNotFoundException
 	    runtimeDataService.getTaskEvents(-9999l, new QueryFilter());
 	}
+
+	@Test
+	public void testGetProcessInstancesPaging() {
+		Collection<ProcessInstanceDesc> instances = runtimeDataService.getProcessInstances(new QueryContext());
+		assertNotNull(instances);
+		assertEquals(0, instances.size());
+
+		List<Long> pids = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			pids.add(processService.startProcess(deploymentUnit.getIdentifier(), "org.jbpm.writedocument"));
+		}
+
+		instances = runtimeDataService.getProcessInstances(new QueryContext(0, -1));
+		assertEquals(10, instances.size());
+
+		instances = runtimeDataService.getProcessInstances(new QueryContext(0, 0));
+		assertEquals(10, instances.size());
+
+		instances = runtimeDataService.getProcessInstances(new QueryContext(0, 3));
+		assertEquals(3, instances.size());
+
+		instances = runtimeDataService.getProcessInstances(new QueryContext(2, 5, "log.processInstanceId", true));
+		assertEquals(5, instances.size());
+
+		List<ProcessInstanceDesc> instancesList = new ArrayList<>(instances);
+		for (int i = 0; i < instancesList.size(); i++) {
+			ProcessInstanceDesc piDesc = instancesList.get(i);
+			assertEquals(piDesc.getId(), pids.get(i + 2));
+		}
+
+		Collection<ProcessInstanceDesc> activeProcesses = runtimeDataService.getProcessInstances(new QueryContext(0, 20));
+		for (ProcessInstanceDesc pi : activeProcesses) {
+			processService.abortProcessInstance(pi.getId());
+		}
+	}
 }

--- a/jbpm-services/jbpm-shared-services/src/main/java/org/jbpm/shared/services/impl/JpaPersistenceContext.java
+++ b/jbpm-services/jbpm-shared-services/src/main/java/org/jbpm/shared/services/impl/JpaPersistenceContext.java
@@ -179,7 +179,7 @@ public class JpaPersistenceContext implements Context {
 					continue;
 				}
 				else if (MAX_RESULTS.equals(name)) {
-					if (((Integer) params.get(name)) > -1) {
+					if (((Integer) params.get(name)) > 0) {
 						query.setMaxResults((Integer) params.get(name));
 					}
 					continue;


### PR DESCRIPTION
I have also reverted some of the QueryContext calls to 0,0 as they were before the hibernate upgrade. Now we should have this unified across JPAPersistenceContext, JPATaskPersistenceContext and JPAAuditLogService (there was already >0 condition).