### PR TITLE
RuleSetNodeInstance should pass null variable values to DMN

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/RuleSetNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/RuleSetNodeInstance.java
@@ -336,7 +336,7 @@ public class RuleSetNodeInstance extends StateBasedNodeInstance implements Event
             	DataTransformer transformer = DataTransformerRegistry.get().find(transformation.getLanguage());
             	if (transformer != null) {
             		Object parameterValue = transformer.transform(transformation.getCompiledExpression(), getSourceParameters(association));
-            		if (parameterValue != null) {
+            		if (parameterValue != null || ruleSetNode.isDMN()) {
             			replacements.put(association.getTarget(), parameterValue);
                     }
             	}
@@ -355,7 +355,7 @@ public class RuleSetNodeInstance extends StateBasedNodeInstance implements Event
                         logger.error("Continuing without setting parameter.");
                     }
                 }
-                if (parameterValue != null) {
+                if (parameterValue != null || ruleSetNode.isDMN()) {
                 	replacements.put(association.getTarget(), parameterValue);
                 }
             }

--- a/jbpm-workitems/jbpm-workitems-bpmn2/src/test/java/org/jbpm/process/workitem/bpmn2/BusinessRuleTaskTest.java
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/src/test/java/org/jbpm/process/workitem/bpmn2/BusinessRuleTaskTest.java
@@ -125,6 +125,48 @@ public class BusinessRuleTaskTest {
                      processInstance.getState());
     }
 
+    @Test
+    public void testDecisionPassingNullToDMN() throws Exception {
+        //This test make sure that null variables are passed to the DMN execution context, otherwise DMN will throw an exception that an input requirement is missing
+        KieBase kbase = readKnowledgeBase();
+        KieSession ksession = createSession(kbase);
+
+        BusinessRuleTaskHandler handler = new BusinessRuleTaskHandler(GROUP_ID,
+                                                                      ARTIFACT_ID,
+                                                                      VERSION);
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("Input",
+                   null);
+
+        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.startProcess("passthru",
+                                                                                                  params);
+        Object output = processInstance.getVariable("Output");
+
+        assertEquals(null,
+                     output);
+    }
+
+    @Test
+    public void testDecisionPassingNonNullToDMN() throws Exception {
+        //This test make sure that null variables are passed to the DMN execution context, otherwise DMN will throw an exception that an input requirement is missing
+        KieBase kbase = readKnowledgeBase();
+        KieSession ksession = createSession(kbase);
+
+        BusinessRuleTaskHandler handler = new BusinessRuleTaskHandler(GROUP_ID,
+                                                                      ARTIFACT_ID,
+                                                                      VERSION);
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("Input",
+                   "Hello World");
+
+        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.startProcess("passthru",
+                                                                                                  params);
+        Object output = processInstance.getVariable("Output");
+
+        assertEquals("Hello World",
+                     output);
+    }
+
     private static KieBase readKnowledgeBase() throws Exception {
         ProcessBuilderFactory.setProcessBuilderFactoryService(new ProcessBuilderFactoryServiceImpl());
         ProcessRuntimeFactory.setProcessRuntimeFactoryService(new ProcessRuntimeFactoryServiceImpl());
@@ -132,6 +174,10 @@ public class BusinessRuleTaskTest {
         kbuilder.add(ResourceFactory.newClassPathResource("businessRuleTaskProcess.bpmn2"),
                      ResourceType.BPMN2);
         kbuilder.add(ResourceFactory.newClassPathResource("businessRuleTaskDMN.bpmn2"),
+                     ResourceType.BPMN2);
+        kbuilder.add(ResourceFactory.newClassPathResource("string-passthru.dmn"),
+                     ResourceType.DMN);
+        kbuilder.add(ResourceFactory.newClassPathResource("calling-dmn-passthru.bpmn2"),
                      ResourceType.BPMN2);
         return kbuilder.newKieBase();
     }

--- a/jbpm-workitems/jbpm-workitems-bpmn2/src/test/resources/calling-dmn-passthru.bpmn2
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/src/test/resources/calling-dmn-passthru.bpmn2
@@ -1,0 +1,118 @@
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL"  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"  xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0"  xmlns:trisobpmn="http://www.trisotech.com/2014/triso/bpmn"  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"  xmlns:trisofeed="http://trisotech.com/feed"  xmlns:bpsim="http://www.bpsim.org/schemas/1.0"  xmlns:rss="http://purl.org/rss/2.0/"  xmlns:drools="http://www.jboss.org/drools"  xmlns="http://www.trisotech.com/definitions/_db0a3faf-5a4d-4c13-8ac7-53926f34282c" id="_db0a3faf-5a4d-4c13-8ac7-53926f34282c" targetNamespace="http://www.trisotech.com/definitions/_db0a3faf-5a4d-4c13-8ac7-53926f34282c" expressionLanguage="http://www.w3.org/1999/XPath" exporter="BPMN Modeler" exporterVersion="6.1.19.201901311152" name="Passing null" trisobpmn:logoChoice="Default">
+    <semantic:itemDefinition id="_08a68aa7-b978-4837-8025-79b5f9ff9ceb" structureRef="java.lang.String"/>
+    <semantic:process id="passthru" name="passthru" isClosed="false">
+		<semantic:property name="Input" itemSubjectRef="_08a68aa7-b978-4837-8025-79b5f9ff9ceb" isCollection="false" id="Input"/>
+		<semantic:property name="Output" itemSubjectRef="_08a68aa7-b978-4837-8025-79b5f9ff9ceb" isCollection="false" id="Output"/>
+        <semantic:startEvent id="_b71530f7-2034-4d24-b0f4-906267a2ca3b">
+            <semantic:outgoing>_35c3275b-00cb-4bd2-9577-ff6cab203a89</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:businessRuleTask id="_ffb21a7b-fdfe-42c9-a241-3e7a3a28282d" name="Passthru" implementation="http://www.jboss.org/drools/dmn">
+            <semantic:extensionElements>
+                <triso:interrelationship fileId="eyJmIjp7InNrdSI6IjViMzEzZTFmLTVmM2QtNDg4ZS1hNTFlLTU5YjJlYmZiMTUzOSIsIm5hbWUiOiJQYXNzdGhydSIsIm1pbWV0eXBlIjoiYXBwbGljYXRpb24vdm5kLnRyaXNvLWRtbitqc29uIn19" elementId="_a9d02986-191d-4dd2-9c24-a0b5ebc66da7" uri="http://www.trisotech.com/definitions/_c6e6a79a-b263-4db5-92cb-d3e527c3212d#_a9d02986-191d-4dd2-9c24-a0b5ebc66da7" name="Output" modelId="_c6e6a79a-b263-4db5-92cb-d3e527c3212d" mimeType="application/vnd.triso-dmn+json"/>
+                <drools:metaData name="elementname">
+                    <drools:metaValue><![CDATA[Output]]></drools:metaValue>
+                </drools:metaData>
+            </semantic:extensionElements>
+            <semantic:incoming>_35c3275b-00cb-4bd2-9577-ff6cab203a89</semantic:incoming>
+            <semantic:outgoing>_012fcea3-cc23-46a2-bbe1-c96b7be11b2c</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="Input" name="Input"/>
+                <semantic:dataInput id="model" name="model"/>
+                <semantic:dataInput id="namespace" name="namespace"/>
+                <semantic:dataOutput id="Output" name="Output"/>
+                <semantic:inputSet id="_422f9236-efdb-42a3-977e-0e6a4bc04d42">
+                    <semantic:dataInputRefs>Input</semantic:dataInputRefs>
+                    <semantic:dataInputRefs>model</semantic:dataInputRefs>
+                    <semantic:dataInputRefs>namespace</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_42ad7136-711f-47a6-851c-9a130eb171ba">
+                    <semantic:dataOutputRefs>Output</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_5ce9dfb0-1969-432c-89b2-581d0bc6a8e0">
+                <semantic:sourceRef>Input</semantic:sourceRef>
+                <semantic:targetRef>Input</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataInputAssociation>
+                <semantic:targetRef>model</semantic:targetRef>
+                <semantic:assignment>
+                    <semantic:from>Passthru</semantic:from>
+                    <semantic:to>model</semantic:to>
+                </semantic:assignment>
+            </semantic:dataInputAssociation>
+            <semantic:dataInputAssociation>
+                <semantic:targetRef>namespace</semantic:targetRef>
+                <semantic:assignment>
+                    <semantic:from>http://www.trisotech.com/definitions/_c6e6a79a-b263-4db5-92cb-d3e527c3212d</semantic:from>
+                    <semantic:to>namespace</semantic:to>
+                </semantic:assignment>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_cf3c840a-39e6-4866-8b9a-fd08dfaae265">
+                <semantic:sourceRef>Output</semantic:sourceRef>
+                <semantic:targetRef>Output</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:businessRuleTask>
+        <semantic:endEvent id="_ed257209-bb75-4472-839a-c41785186c76">
+            <semantic:incoming>_012fcea3-cc23-46a2-bbe1-c96b7be11b2c</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:sequenceFlow id="_35c3275b-00cb-4bd2-9577-ff6cab203a89" sourceRef="_b71530f7-2034-4d24-b0f4-906267a2ca3b" targetRef="_ffb21a7b-fdfe-42c9-a241-3e7a3a28282d"/>
+        <semantic:sequenceFlow id="_012fcea3-cc23-46a2-bbe1-c96b7be11b2c" sourceRef="_ffb21a7b-fdfe-42c9-a241-3e7a3a28282d" targetRef="_ed257209-bb75-4472-839a-c41785186c76"/>
+    </semantic:process>
+    <bpmndi:BPMNDiagram id="_dcc64943-77fa-44c0-94f2-09d3dbba1cf6" name="Page 1">
+        <bpmndi:BPMNPlane bpmnElement="_cf9cddbd-f220-44a1-aa5e-0ddc209cbb58" id="_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_plane" trisobpmn:diagramWidth="1485" trisobpmn:diagramHeight="1050">
+            <bpmndi:BPMNShape id="_e92f3762-423e-430f-a593-3dabc852c711" bpmnElement="_b71530f7-2034-4d24-b0f4-906267a2ca3b" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="230.5" y="261" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_abe5f41e-fe08-416c-b341-08f9f85a340d" bpmnElement="_ffb21a7b-fdfe-42c9-a241-3e7a3a28282d" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="317.5" y="239" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0">
+                    <dc:Bounds height="12" width="89" x="321" y="271"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_83a9cd4d-ecec-4dd7-b96e-b7ab98b5debf" bpmnElement="_ed257209-bb75-4472-839a-c41785186c76" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="468.5" y="259" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_03cfe122-3133-4a92-a51b-bfe86948fe4c" bpmnElement="Input" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="287.5" y="369" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0">
+                    <dc:Bounds height="12" width="25.40625" x="291.796875" y="414"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_81dcd916-3c66-425c-9429-709ebe2996d9" bpmnElement="Output" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="400.5" y="369" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0">
+                    <dc:Bounds height="12" width="33.953125" x="400.5234375" y="414"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_a4540d3d-7902-4f95-8c8b-5e0e8d785c17" color:border-color="#000000" bpmnElement="_35c3275b-00cb-4bd2-9577-ff6cab203a89">
+                <di:waypoint x="261.5" y="277"/>
+                <di:waypoint x="317.5" y="277"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_b9f5203b-1d4d-4ea3-8b62-63516ef4e4d9" color:border-color="#000000" bpmnElement="_012fcea3-cc23-46a2-bbe1-c96b7be11b2c">
+                <di:waypoint x="412.5" y="277"/>
+                <di:waypoint x="468.5" y="277"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_dededff4-94f4-42f7-82fe-aa47ee5636da" color:border-color="#000000" bpmnElement="_5ce9dfb0-1969-432c-89b2-581d0bc6a8e0" targetElement="_abe5f41e-fe08-416c-b341-08f9f85a340d">
+                <di:waypoint x="304.5" y="370"/>
+                <di:waypoint x="304.5" y="342.5"/>
+                <di:waypoint x="365.5" y="342.5"/>
+                <di:waypoint x="365.5" y="315"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_9b25bcd6-3af5-4a40-b6f2-42550f2d0160" color:border-color="#000000" bpmnElement="_cf3c840a-39e6-4866-8b9a-fd08dfaae265" sourceElement="_abe5f41e-fe08-416c-b341-08f9f85a340d">
+                <di:waypoint x="365.5" y="314"/>
+                <di:waypoint x="365.5" y="344"/>
+                <di:waypoint x="417.5" y="344"/>
+                <di:waypoint x="417.5" y="370"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0">
+            <dc:Font name="arial,helvetica,sans-serif" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>

--- a/jbpm-workitems/jbpm-workitems-bpmn2/src/test/resources/string-passthru.dmn
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/src/test/resources/string-passthru.dmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.trisotech.com/definitions/_c6e6a79a-b263-4db5-92cb-d3e527c3212d" id="_c6e6a79a-b263-4db5-92cb-d3e527c3212d" namespace="http://www.trisotech.com/definitions/_c6e6a79a-b263-4db5-92cb-d3e527c3212d"          exporter="DMN Modeler" exporterVersion="6.1.19.201901311152" name="Passthru" triso:logoChoice="Default">
+    <semantic:extensionElements/>
+    <semantic:inputData id="_7bb74762-79aa-483b-b791-fe8f24e653ef" name="Input">
+        <semantic:variable name="Input" id="_0266b60c-d8eb-469d-8c15-a2e0a145f1bd" typeRef="string"/>
+    </semantic:inputData>
+    <semantic:decision id="_a9d02986-191d-4dd2-9c24-a0b5ebc66da7" name="Output">
+        <semantic:variable name="Output" id="_724bef58-5999-4135-9b9e-b2b12303076c" typeRef="string"/>
+        <semantic:informationRequirement id="_65dbd316-5c4d-4a80-b71b-f352e81eacac">
+            <semantic:requiredInput href="#_7bb74762-79aa-483b-b791-fe8f24e653ef"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_0d0c3fb2-463e-4907-912b-381092052d85" typeRef="string" triso:expressionId="_63283b63-d6e4-4d6d-a1ab-3b7298522946">
+            <semantic:text>Input</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="_e43fd281-9cdf-49bf-9b38-0c361ed3b9eb" name="Page 1">
+            <dmndi:Size height="1050" width="1485"/>
+            <dmndi:DMNShape id="_01d49fe7-fed7-4f66-a8c5-7fe10f5ef985" dmnElementRef="_7bb74762-79aa-483b-b791-fe8f24e653ef">
+                <dc:Bounds x="476.7588291168213" y="507.99999618530273" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_c6e6a79a-b263-4db5-92cb-d3e527c3212d_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="94" x="495.9968013763428" y="530.9999961853027"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_5572a193-9150-42b3-88ea-a5d61835ab18" dmnElementRef="_a9d02986-191d-4dd2-9c24-a0b5ebc66da7">
+                <dc:Bounds x="468" y="392.99999618530273" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_c6e6a79a-b263-4db5-92cb-d3e527c3212d_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="146" x="471" y="416.99999618530273"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_d217287d-1641-4eeb-a2e2-3454cbfc76de" dmnElementRef="_65dbd316-5c4d-4a80-b71b-f352e81eacac">
+                <di:waypoint x="544.4968013763428" y="507.99999618530273"/>
+                <di:waypoint x="544.5" y="452.99999618530273"/>
+                <dmndi:DMNLabel sharedStyle="LS_c6e6a79a-b263-4db5-92cb-d3e527c3212d_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNStyle id="LS_c6e6a79a-b263-4db5-92cb-d3e527c3212d_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+    </dmndi:DMNDI>
+</semantic:definitions>


### PR DESCRIPTION
In the DMN engine, there is a difference between passing a variable with a null value and not passing a variable. If a DMN model would support receiving a null input. it is currently impossible to invoke this model from BPMN. The DMN model will complain about a missing input requirement (since the null value variable was not passed) and the execution will not append. With this fix, null value variables are passed to DMN and the execution works.

