### PR TITLE
Fix jbpm-workitems tests to run with JDK 11

### DIFF
--- a/jbpm-workitems/jbpm-workitems-bpmn2/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/pom.xml
@@ -162,6 +162,16 @@
       <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/jbpm-workitems/jbpm-workitems-rest/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-rest/pom.xml
@@ -107,6 +107,11 @@
       <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Another fix for JDK 11...

* jbpm-workitems-bpmn2 needs deps for WebServices which are used in tests
* jbpm-workitems-rest needs activation dep because CXF used in tests depends on javax/activation/DataSource