### PR TITLE
Raise scope of jaxws-api for jbpm-workitems-bpmn2

### DIFF
--- a/jbpm-workitems/jbpm-workitems-bpmn2/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/pom.xml
@@ -42,6 +42,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.jboss.spec.javax.xml.ws</groupId>
+      <artifactId>jboss-jaxws-api_2.3_spec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-databinding-jaxb</artifactId>
     </dependency>
@@ -95,11 +99,6 @@
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
       <artifactId>jboss-servlet-api_3.1_spec</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.spec.javax.xml.ws</groupId>
-      <artifactId>jboss-jaxws-api_2.3_spec</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
org.apache.cxf:cxf-rt-frontend-jaxws depends on JAX-WS API (at compile time), but for JDK 11 these classes are not part of JDK. This can cause issues in any component which uses jbpm-workitems-bpmn2 artifact, i.e. Spring Boot.

It is interesting that although Apache CXF 3.3.0 officially supports JDK 11, the dependency on JAX-WS API still wasn't added, although now we use version 3.1.16.