### PR TITLE
jbpm-installer test: Exclude executing drop ddl scripts

### DIFF
--- a/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/util/TestsUtil.java
+++ b/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/util/TestsUtil.java
@@ -47,7 +47,7 @@ public final class TestsUtil {
             final File[] foundFiles = folderWithScripts.listFiles(new FilenameFilter() {
                 @Override
                 public boolean accept(File dir, String name) {
-                    return name.toLowerCase().endsWith(".sql");
+                    return name.toLowerCase().endsWith(".sql") && !name.contains("drop");
                 }
             });
 


### PR DESCRIPTION
This is just to exclude drop scripts in DDL tests since there is currently no support for them. Creation and drop of schema is done by hibernate.