### PR TITLE
jbpm-remote-ejb: Disable deployment sync

### DIFF
--- a/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
@@ -379,6 +379,9 @@
             <container>
               <containerId>${container.id}</containerId>
               <timeout>600000</timeout>
+              <systemProperties>
+                <org.jbpm.deploy.sync.enabled>false</org.jbpm.deploy.sync.enabled>
+              </systemProperties>
               <dependencies>
                 <dependency>
                   <groupId>com.h2database</groupId>


### PR DESCRIPTION
This should help avoid false negatives in duplicate deploy/undeploy tests.