### PR TITLE
Refactoring of WorkItemNodeInstance for extensibility

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/RuleSetNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/RuleSetNodeInstance.java
@@ -274,7 +274,7 @@ public class RuleSetNodeInstance extends StateBasedNodeInstance implements Event
         factHandles.clear();
 	}
 	
-	private void processOutputs(Map<String, Object> objects) {
+	protected void processOutputs(Map<String, Object> objects) {
 	    RuleSetNode ruleSetNode = getRuleSetNode();
         if (ruleSetNode != null) {
             for (Iterator<DataAssociation> iterator = ruleSetNode.getOutAssociations().iterator(); iterator.hasNext(); ) {


### PR DESCRIPTION
I have refactored (no logic changed) the WorkItemNodeInstance class to allow redefining the data mapping logic when inheriting from the class. No behavior was changed.

Basically this let us extend the class and customize how we do the data mapping for the inputs/outputs.

Let me know if you have questions!

Thanks