### PR TITLE
JBPM-8374 Added support for invoking Decision Services from BPMN Business Rule Tasks

### DIFF
--- a/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BusinessRuleTaskHandler.java
+++ b/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BusinessRuleTaskHandler.java
@@ -40,6 +40,7 @@ public class BusinessRuleTaskHandler extends AbstractNodeHandler {
     private static final String NAMESPACE_PROP = "namespace";
     private static final String MODEL_PROP = "model";
     private static final String DECISION_PROP = "decision";
+    private static final String DECISION_SERVICE_PROP = "decisionService";
 	private DataTransformerRegistry transformerRegistry = DataTransformerRegistry.get();
     
     protected Node createNode(Attributes attrs) {
@@ -80,7 +81,8 @@ public class BusinessRuleTaskHandler extends AbstractNodeHandler {
 		ruleSetNode.setNamespace((String) ruleSetNode.removeParameter(NAMESPACE_PROP));
 		ruleSetNode.setModel((String) ruleSetNode.removeParameter(MODEL_PROP));
 		ruleSetNode.setDecision((String) ruleSetNode.removeParameter(DECISION_PROP));
-		
+		ruleSetNode.setDecisionService((String) ruleSetNode.removeParameter(DECISION_SERVICE_PROP));
+
         handleScript(ruleSetNode, element, "onEntry");
         handleScript(ruleSetNode, element, "onExit");
 	}

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
@@ -51,7 +51,8 @@ public class RuleSetNode extends StateBasedNode implements ContextContainer {
     private String namespace;
     private String model;
     private String decision;
-    
+    private String decisionService;
+
     private List<DataAssociation> inMapping = new LinkedList<DataAssociation>();
     private List<DataAssociation> outMapping = new LinkedList<DataAssociation>();
     
@@ -96,6 +97,15 @@ public class RuleSetNode extends StateBasedNode implements ContextContainer {
     public void setDecision(String decision) {
         this.decision = decision;
     }
+
+    public String getDecisionService() {
+        return decisionService;
+    }
+
+    public void setDecisionService(String decisionService) {
+        this.decisionService = decisionService;
+    }
+
 
     public void validateAddIncomingConnection(final String type, final Connection connection) {
         super.validateAddIncomingConnection(type, connection);

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/RuleSetNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/RuleSetNodeInstance.java
@@ -108,6 +108,7 @@ public class RuleSetNodeInstance extends StateBasedNodeInstance implements Event
                 String namespace = resolveVariable(ruleSetNode.getNamespace());
                 String model = resolveVariable(ruleSetNode.getModel());
                 String decision = resolveVariable(ruleSetNode.getDecision());
+                String decisionService = resolveVariable(ruleSetNode.getDecisionService());
 
                 DMNRuntime runtime = ((KieSession) kruntime).getKieRuntime(DMNRuntime.class);
                 DMNModel dmnModel = runtime.getModel(namespace, model);
@@ -128,6 +129,8 @@ public class RuleSetNodeInstance extends StateBasedNodeInstance implements Event
 
                 if (decision != null && !decision.isEmpty()) {
                     dmnResult = runtime.evaluateByName(dmnModel, context, decision);
+                } else if (decisionService != null && !decisionService.isEmpty()) {
+                    dmnResult = runtime.evaluateDecisionService(dmnModel, context, decisionService);
                 } else {
                     dmnResult = runtime.evaluateAll(dmnModel, context);
                 }
@@ -321,10 +324,10 @@ public class RuleSetNodeInstance extends StateBasedNodeInstance implements Event
                     }
 
                 }               
+                }
             }
-        }
         
-    }
+        }
 
     protected Map<String, Object> evaluateParameters(RuleSetNode ruleSetNode) {
 	    Map<String, Object> replacements = new HashMap<String, Object>();

--- a/jbpm-workitems/jbpm-workitems-bpmn2/src/test/java/org/jbpm/process/workitem/bpmn2/BusinessRuleTaskTest.java
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/src/test/java/org/jbpm/process/workitem/bpmn2/BusinessRuleTaskTest.java
@@ -167,6 +167,34 @@ public class BusinessRuleTaskTest {
                      output);
     }
 
+    @Test
+    public void testCallingDecisionService() throws Exception {
+        //This test make sure that null variables are passed to the DMN execution context, otherwise DMN will throw an exception that an input requirement is missing
+        KieBase kbase = readKnowledgeBase();
+        KieSession ksession = createSession(kbase);
+
+        BusinessRuleTaskHandler handler = new BusinessRuleTaskHandler(GROUP_ID,
+                                                                      ARTIFACT_ID,
+                                                                      VERSION);
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("Input",
+                   "Hello World");
+
+        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.startProcess("CallDecision",
+                                                                                                  params);
+        Object output = processInstance.getVariable("Output Decision");
+        //This is mapped with data associations to Output Decision in the DMN model	
+        assertEquals("Hello World",
+                     output);
+
+        Object encapsulatedOutput = processInstance.getVariable("Encapsulated Output");
+
+        //This is mapped with data associations to Encapsulated Output in the DMN model	 and should not be part of the returned model because encapsulated decisions are not returned
+        assertEquals(null,
+                     encapsulatedOutput);
+
+    }
+
     private static KieBase readKnowledgeBase() throws Exception {
         ProcessBuilderFactory.setProcessBuilderFactoryService(new ProcessBuilderFactoryServiceImpl());
         ProcessRuntimeFactory.setProcessRuntimeFactoryService(new ProcessRuntimeFactoryServiceImpl());
@@ -178,6 +206,10 @@ public class BusinessRuleTaskTest {
         kbuilder.add(ResourceFactory.newClassPathResource("string-passthru.dmn"),
                      ResourceType.DMN);
         kbuilder.add(ResourceFactory.newClassPathResource("calling-dmn-passthru.bpmn2"),
+                     ResourceType.BPMN2);
+        kbuilder.add(ResourceFactory.newClassPathResource("decision-service.dmn"),
+                     ResourceType.DMN);
+        kbuilder.add(ResourceFactory.newClassPathResource("calling-dmn-decision-service.bpmn2"),
                      ResourceType.BPMN2);
         return kbuilder.newKieBase();
     }

--- a/jbpm-workitems/jbpm-workitems-bpmn2/src/test/java/org/jbpm/process/workitem/bpmn2/BusinessRuleTaskTest.java
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/src/test/java/org/jbpm/process/workitem/bpmn2/BusinessRuleTaskTest.java
@@ -131,9 +131,6 @@ public class BusinessRuleTaskTest {
         KieBase kbase = readKnowledgeBase();
         KieSession ksession = createSession(kbase);
 
-        BusinessRuleTaskHandler handler = new BusinessRuleTaskHandler(GROUP_ID,
-                                                                      ARTIFACT_ID,
-                                                                      VERSION);
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("Input",
                    null);
@@ -152,9 +149,6 @@ public class BusinessRuleTaskTest {
         KieBase kbase = readKnowledgeBase();
         KieSession ksession = createSession(kbase);
 
-        BusinessRuleTaskHandler handler = new BusinessRuleTaskHandler(GROUP_ID,
-                                                                      ARTIFACT_ID,
-                                                                      VERSION);
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("Input",
                    "Hello World");
@@ -173,9 +167,6 @@ public class BusinessRuleTaskTest {
         KieBase kbase = readKnowledgeBase();
         KieSession ksession = createSession(kbase);
 
-        BusinessRuleTaskHandler handler = new BusinessRuleTaskHandler(GROUP_ID,
-                                                                      ARTIFACT_ID,
-                                                                      VERSION);
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("Input",
                    "Hello World");

--- a/jbpm-workitems/jbpm-workitems-bpmn2/src/test/resources/calling-dmn-decision-service.bpmn2
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/src/test/resources/calling-dmn-decision-service.bpmn2
@@ -1,0 +1,134 @@
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL"  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"  xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0"  xmlns:trisobpmn="http://www.trisotech.com/2014/triso/bpmn"  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"  xmlns:trisofeed="http://trisotech.com/feed"  xmlns:bpsim="http://www.bpsim.org/schemas/1.0"  xmlns:rss="http://purl.org/rss/2.0/"  xmlns:drools="http://www.jboss.org/drools"  xmlns="http://www.trisotech.com/definitions/_db0a3faf-5a4d-4c13-8ac7-53926f34282c" id="_db0a3faf-5a4d-4c13-8ac7-53926f34282c" targetNamespace="http://www.trisotech.com/definitions/_db0a3faf-5a4d-4c13-8ac7-53926f34282c" expressionLanguage="http://www.w3.org/1999/XPath" exporter="BPMN Modeler" exporterVersion="6.1.19.201901311152" name="Passing null" trisobpmn:logoChoice="Default">
+    <semantic:itemDefinition id="_08a68aa7-b978-4837-8025-79b5f9ff9ceb" structureRef="java.lang.String"/>
+    <semantic:process id="CallDecision" name="CallDecision" isClosed="false">
+		<semantic:property name="Input" itemSubjectRef="_08a68aa7-b978-4837-8025-79b5f9ff9ceb" isCollection="false" id="Input"/>
+		<semantic:property name="Output Decision" itemSubjectRef="_08a68aa7-b978-4837-8025-79b5f9ff9ceb" isCollection="false" id="Output Decision"/>
+		<semantic:property name="Encapsulated Decision" itemSubjectRef="_08a68aa7-b978-4837-8025-79b5f9ff9ceb" isCollection="false" id="Encapsulated Decision"/>
+        <semantic:startEvent id="_b71530f7-2034-4d24-b0f4-906267a2ca3b">
+            <semantic:outgoing>_35c3275b-00cb-4bd2-9577-ff6cab203a89</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:businessRuleTask id="_ffb21a7b-fdfe-42c9-a241-3e7a3a28282d" name="Passthru" implementation="http://www.jboss.org/drools/dmn">
+            <semantic:extensionElements>
+                <triso:interrelationship fileId="eyJmIjp7InNrdSI6IjViMzEzZTFmLTVmM2QtNDg4ZS1hNTFlLTU5YjJlYmZiMTUzOSIsIm5hbWUiOiJQYXNzdGhydSIsIm1pbWV0eXBlIjoiYXBwbGljYXRpb24vdm5kLnRyaXNvLWRtbitqc29uIn19" elementId="_a9d02986-191d-4dd2-9c24-a0b5ebc66da7" uri="http://www.trisotech.com/definitions/_c6e6a79a-b263-4db5-92cb-d3e527c3212d#_a9d02986-191d-4dd2-9c24-a0b5ebc66da7" name="Output" modelId="_c6e6a79a-b263-4db5-92cb-d3e527c3212d" mimeType="application/vnd.triso-dmn+json"/>
+                <drools:metaData name="elementname">
+                    <drools:metaValue><![CDATA[Output Decision]]></drools:metaValue>
+                </drools:metaData>
+            </semantic:extensionElements>
+            <semantic:incoming>_35c3275b-00cb-4bd2-9577-ff6cab203a89</semantic:incoming>
+            <semantic:outgoing>_012fcea3-cc23-46a2-bbe1-c96b7be11b2c</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="Input" name="Input"/>
+                <semantic:dataInput id="model" name="model"/>
+                <semantic:dataInput id="namespace" name="namespace"/>
+                <semantic:dataInput id="decisionService" name="decisionService"/>
+                <semantic:dataOutput id="Output Decision" name="Output Decision"/>
+				<semantic:dataOutput id="Encapsulated Decision" name="Encapsulated Decision"/>
+                <semantic:inputSet id="_422f9236-efdb-42a3-977e-0e6a4bc04d42">
+                    <semantic:dataInputRefs>Input</semantic:dataInputRefs>
+                    <semantic:dataInputRefs>model</semantic:dataInputRefs>
+                    <semantic:dataInputRefs>namespace</semantic:dataInputRefs>
+                    <semantic:dataInputRefs>decisionService</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_42ad7136-711f-47a6-851c-9a130eb171ba">
+                    <semantic:dataOutputRefs>Output Decision</semantic:dataOutputRefs>
+                    <semantic:dataOutputRefs>Encapsulated Decision</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_5ce9dfb0-1969-432c-89b2-581d0bc6a8e0">
+                <semantic:sourceRef>Input</semantic:sourceRef>
+                <semantic:targetRef>Input</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataInputAssociation>
+                <semantic:targetRef>model</semantic:targetRef>
+                <semantic:assignment>
+                    <semantic:from>DecisionService</semantic:from>
+                    <semantic:to>model</semantic:to>
+                </semantic:assignment>
+            </semantic:dataInputAssociation>
+            <semantic:dataInputAssociation>
+                <semantic:targetRef>namespace</semantic:targetRef>
+                <semantic:assignment>
+                    <semantic:from>http://www.trisotech.com/definitions/_7e1d1ae1-cfef-442a-b358-a80330e6a930</semantic:from>
+                    <semantic:to>namespace</semantic:to>
+                </semantic:assignment>
+            </semantic:dataInputAssociation>
+             <semantic:dataInputAssociation>
+                <semantic:targetRef>decisionService</semantic:targetRef>
+                <semantic:assignment>
+                    <semantic:from>Decision Service</semantic:from>
+                    <semantic:to>decisionService</semantic:to>
+                </semantic:assignment>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_cf3c840a-39e6-4866-8b9a-fd08dfaae265">
+                <semantic:sourceRef>Output Decision</semantic:sourceRef>
+                <semantic:targetRef>Output Decision</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:dataOutputAssociation id="_cf3c840a-39e6-4866-8b9a-fd08dfaae267">
+                <semantic:sourceRef>Encapsulated Decision</semantic:sourceRef>
+                <semantic:targetRef>Encapsulated Decision</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:businessRuleTask>
+        <semantic:endEvent id="_ed257209-bb75-4472-839a-c41785186c76">
+            <semantic:incoming>_012fcea3-cc23-46a2-bbe1-c96b7be11b2c</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:sequenceFlow id="_35c3275b-00cb-4bd2-9577-ff6cab203a89" sourceRef="_b71530f7-2034-4d24-b0f4-906267a2ca3b" targetRef="_ffb21a7b-fdfe-42c9-a241-3e7a3a28282d"/>
+        <semantic:sequenceFlow id="_012fcea3-cc23-46a2-bbe1-c96b7be11b2c" sourceRef="_ffb21a7b-fdfe-42c9-a241-3e7a3a28282d" targetRef="_ed257209-bb75-4472-839a-c41785186c76"/>
+    </semantic:process>
+    <bpmndi:BPMNDiagram id="_dcc64943-77fa-44c0-94f2-09d3dbba1cf6" name="Page 1">
+        <bpmndi:BPMNPlane bpmnElement="_cf9cddbd-f220-44a1-aa5e-0ddc209cbb58" id="_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_plane" trisobpmn:diagramWidth="1485" trisobpmn:diagramHeight="1050">
+            <bpmndi:BPMNShape id="_e92f3762-423e-430f-a593-3dabc852c711" bpmnElement="_b71530f7-2034-4d24-b0f4-906267a2ca3b" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="230.5" y="261" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_abe5f41e-fe08-416c-b341-08f9f85a340d" bpmnElement="_ffb21a7b-fdfe-42c9-a241-3e7a3a28282d" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="317.5" y="239" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0">
+                    <dc:Bounds height="12" width="89" x="321" y="271"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_83a9cd4d-ecec-4dd7-b96e-b7ab98b5debf" bpmnElement="_ed257209-bb75-4472-839a-c41785186c76" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="468.5" y="259" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_03cfe122-3133-4a92-a51b-bfe86948fe4c" bpmnElement="Input" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="287.5" y="369" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0">
+                    <dc:Bounds height="12" width="25.40625" x="291.796875" y="414"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_81dcd916-3c66-425c-9429-709ebe2996d9" bpmnElement="Output" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="400.5" y="369" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0">
+                    <dc:Bounds height="12" width="33.953125" x="400.5234375" y="414"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_a4540d3d-7902-4f95-8c8b-5e0e8d785c17" color:border-color="#000000" bpmnElement="_35c3275b-00cb-4bd2-9577-ff6cab203a89">
+                <di:waypoint x="261.5" y="277"/>
+                <di:waypoint x="317.5" y="277"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_b9f5203b-1d4d-4ea3-8b62-63516ef4e4d9" color:border-color="#000000" bpmnElement="_012fcea3-cc23-46a2-bbe1-c96b7be11b2c">
+                <di:waypoint x="412.5" y="277"/>
+                <di:waypoint x="468.5" y="277"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_dededff4-94f4-42f7-82fe-aa47ee5636da" color:border-color="#000000" bpmnElement="_5ce9dfb0-1969-432c-89b2-581d0bc6a8e0" targetElement="_abe5f41e-fe08-416c-b341-08f9f85a340d">
+                <di:waypoint x="304.5" y="370"/>
+                <di:waypoint x="304.5" y="342.5"/>
+                <di:waypoint x="365.5" y="342.5"/>
+                <di:waypoint x="365.5" y="315"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_9b25bcd6-3af5-4a40-b6f2-42550f2d0160" color:border-color="#000000" bpmnElement="_cf3c840a-39e6-4866-8b9a-fd08dfaae265" sourceElement="_abe5f41e-fe08-416c-b341-08f9f85a340d">
+                <di:waypoint x="365.5" y="314"/>
+                <di:waypoint x="365.5" y="344"/>
+                <di:waypoint x="417.5" y="344"/>
+                <di:waypoint x="417.5" y="370"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS_dcc64943-77fa-44c0-94f2-09d3dbba1cf6_0">
+            <dc:Font name="arial,helvetica,sans-serif" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>

--- a/jbpm-workitems/jbpm-workitems-bpmn2/src/test/resources/decision-service.dmn
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/src/test/resources/decision-service.dmn
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.trisotech.com/definitions/_7e1d1ae1-cfef-442a-b358-a80330e6a930" id="_7e1d1ae1-cfef-442a-b358-a80330e6a930" namespace="http://www.trisotech.com/definitions/_7e1d1ae1-cfef-442a-b358-a80330e6a930"          exporter="DMN Modeler" exporterVersion="6.1.22.3" name="DecisionService" triso:logoChoice="Default">
+    <semantic:extensionElements/>
+    <semantic:decision id="_a98bce32-0e55-4600-a9a1-93b2cc3b1f3b" name="Output Decision">
+        <semantic:variable name="Output Decision" id="_9cc9e459-6de3-4994-a550-1a682acdd318" typeRef="string"/>
+        <semantic:informationRequirement id="_7f8606db-b3de-4a74-a774-3b0c2fdec619">
+            <semantic:requiredDecision href="#_87ba1e4b-9d58-4674-8e62-d5dcfb414d17"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_9f6ff36d-30a4-4975-86d0-18774fa58f26" typeRef="string" triso:expressionId="_252323c5-c93c-400b-87b1-0a8aa6aa2e7c">
+            <semantic:text>Encapsulated Decision</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:inputData id="_a76ae0f7-e1e5-4f7f-9e5c-e39d26c5b936" name="Input">
+        <semantic:variable name="Input" id="_d1cbf4d8-9577-4dc7-98d4-a5066a726375" typeRef="string"/>
+    </semantic:inputData>
+    <semantic:decisionService id="_2cfdf482-a636-41f0-98a4-b8c0971dd17f" name="Decision Service">
+        <semantic:variable name="Decision Service" id="_6ec8b98d-6fe7-41d3-a56d-ed820ce9fb50" typeRef="Any"/>
+        <semantic:outputDecision href="#_a98bce32-0e55-4600-a9a1-93b2cc3b1f3b"/>
+        <semantic:encapsulatedDecision href="#_87ba1e4b-9d58-4674-8e62-d5dcfb414d17"/>
+        <semantic:inputData href="#_a76ae0f7-e1e5-4f7f-9e5c-e39d26c5b936"/>
+    </semantic:decisionService>
+    <semantic:decision id="_87ba1e4b-9d58-4674-8e62-d5dcfb414d17" name="Encapsulated Decision">
+        <semantic:variable name="Encapsulated Decision" id="_36cffa2f-2890-4857-a9df-5e8c7e637da8" typeRef="string"/>
+        <semantic:informationRequirement id="_9f98d3ff-2051-4d82-b8b9-448227134b3d">
+            <semantic:requiredInput href="#_a76ae0f7-e1e5-4f7f-9e5c-e39d26c5b936"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_72c88eab-c9f6-4c63-a9fe-e8041f8d32a4" typeRef="string" triso:expressionId="_634640da-5e8a-44b5-96c7-9f1892e5adf9">
+            <semantic:text>Input</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_0f46ea00-6f83-41b1-b9ec-03cce725305a" name="Other Decision">
+        <semantic:variable name="Other Decision" id="_92f3dff3-2e70-4c53-af9a-c3cdbb8cf9b1" typeRef="string"/>
+        <semantic:informationRequirement id="_4be99e52-dc76-4204-b4a4-f2cbe8250cd5">
+            <semantic:requiredInput href="#_2ec0d7ab-f24f-4f45-86f4-f4eb641ccba6"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_451df794-fbbe-4324-a8e3-64148eff2908" typeRef="string" triso:expressionId="_32fd1751-5a0d-4b2e-8979-a3ca9985e40e">
+            <semantic:text>Other Input</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:inputData id="_2ec0d7ab-f24f-4f45-86f4-f4eb641ccba6" name="Other Input">
+        <semantic:variable name="Other Input" id="_f098d7c9-2b8c-4b2a-addf-a76d60712318" typeRef="string"/>
+    </semantic:inputData>
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="_a55af80d-bae1-4fad-b912-d220d0f787ad" name="Page 1">
+            <dmndi:Size height="1065" width="1518.5"/>
+            <dmndi:DMNShape id="_e0f7be6c-745b-407c-b397-3e7bccfc6156" dmnElementRef="_a76ae0f7-e1e5-4f7f-9e5c-e39d26c5b936">
+                <dc:Bounds x="155.7588291168213" y="507.99999618530273" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_7e1d1ae1-cfef-442a-b358-a80330e6a930_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="94" x="174.99680137634277" y="530.9999961853027"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_740d1a49-90a3-4548-a999-36e86468b1ad" dmnElementRef="_2cfdf482-a636-41f0-98a4-b8c0971dd17f" isCollapsed="false">
+                <dc:Bounds x="93.5" y="199" width="260" height="238"/>
+                <dmndi:DMNLabel sharedStyle="LS_7e1d1ae1-cfef-442a-b358-a80330e6a930_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="254" x="109.5" y="215"/>
+                </dmndi:DMNLabel>
+                <dmndi:DMNDecisionServiceDividerLine>
+                    <di:waypoint x="93.5" y="322"/>
+                    <di:waypoint x="353.5" y="322"/>
+                </dmndi:DMNDecisionServiceDividerLine>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_601ea605-7e78-437b-9a03-434766f18d2b" dmnElementRef="_a98bce32-0e55-4600-a9a1-93b2cc3b1f3b">
+                <dc:Bounds x="147" y="247" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_7e1d1ae1-cfef-442a-b358-a80330e6a930_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="146" x="150" y="271"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_49e7f581-6563-4b24-8bff-74cbbe839e10" dmnElementRef="_87ba1e4b-9d58-4674-8e62-d5dcfb414d17">
+                <dc:Bounds x="147" y="352" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_7e1d1ae1-cfef-442a-b358-a80330e6a930_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="146" x="150" y="376"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_38490e10-3cbe-4f0d-ae4c-776af19f57be" dmnElementRef="_0f46ea00-6f83-41b1-b9ec-03cce725305a">
+                <dc:Bounds x="456.75" y="352" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_7e1d1ae1-cfef-442a-b358-a80330e6a930_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="146" x="459.75" y="376"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4ef75bcb-6cd9-411c-8012-b902c9fb8a3a" dmnElementRef="_2ec0d7ab-f24f-4f45-86f4-f4eb641ccba6">
+                <dc:Bounds x="465.5088291168213" y="467" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_7e1d1ae1-cfef-442a-b358-a80330e6a930_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="94" x="484.7468013763428" y="490"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_51b69de2-5243-4d9b-99ed-9eb82af89ca6" dmnElementRef="_9f98d3ff-2051-4d82-b8b9-448227134b3d">
+                <di:waypoint x="223.49680137634277" y="507.99999618530273"/>
+                <di:waypoint x="223.5" y="412"/>
+                <dmndi:DMNLabel sharedStyle="LS_7e1d1ae1-cfef-442a-b358-a80330e6a930_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_eae10c3c-16da-488d-b073-2db7dc10c3a0" dmnElementRef="_7f8606db-b3de-4a74-a774-3b0c2fdec619">
+                <di:waypoint x="223.5" y="352"/>
+                <di:waypoint x="223.5" y="307"/>
+                <dmndi:DMNLabel sharedStyle="LS_7e1d1ae1-cfef-442a-b358-a80330e6a930_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ac734b28-6e31-41d7-8712-588975d55e80" dmnElementRef="_4be99e52-dc76-4204-b4a4-f2cbe8250cd5">
+                <di:waypoint x="533.25" y="467"/>
+                <di:waypoint x="533.25" y="412"/>
+                <dmndi:DMNLabel sharedStyle="LS_7e1d1ae1-cfef-442a-b358-a80330e6a930_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNStyle id="LS_7e1d1ae1-cfef-442a-b358-a80330e6a930_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+    </dmndi:DMNDI>
+</semantic:definitions>


### PR DESCRIPTION
I've update the business rule task code to allow invocation of DMN decision services.

I'm also contributing a test case that tests that only the output decisions of the decision service are returned and that the encapsulated ones are not. The test case also show that the rest of the model is not executed as the rest of the model has an input that is not provided.