### PR TITLE
JBPM-8404

### DIFF
--- a/jbpm-document/src/main/java/org/jbpm/document/DocumentCollection.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/DocumentCollection.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.document;
+
+import java.io.Serializable;
+import java.util.List;
+
+public interface DocumentCollection<T extends Document> extends Serializable {
+    
+    void addDocument(T document);
+	
+	List<T>getDocuments();
+}
+
+

--- a/jbpm-document/src/main/java/org/jbpm/document/Documents.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/Documents.java
@@ -16,43 +16,44 @@
 
 package org.jbpm.document;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAnyElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import org.jbpm.document.service.impl.DocumentCollectionImpl;
 
 /**
  * A collection of {@link Document Documents}.
+ * 
+ * @deprecated This class is deprecated because of potential issues with marshalling and unmarshalling this type when used in RESTful APIs.
+ *             When you want to represent a collection of {@link Document documents), please use the {@link DocumentCollection} interface and the
+ *             {@link DocumentCollectionImpl} implementation class. 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "documents-object")
-public class Documents implements Serializable {
+@Deprecated
+public class Documents implements DocumentCollection<Document> {
 
-	private static final long serialVersionUID = 6962662228758156488L;
-	
-	@XmlElementWrapper
-	@XmlAnyElement(lax=true)
-	private List<Document> documents = new ArrayList<>();
+    private static final long serialVersionUID = 6962662228758156488L;
 
-	public Documents() {
-	}
+    private List<Document> documents = new ArrayList<>();
 
-	public Documents(List<Document> documents) {
-		this.documents = new ArrayList<Document>(documents);
-	}
-	
-	public void addDocument(Document document) {
-		documents.add(document);
-	}
-	
-	public List<Document> getDocuments() {
-	    return documents;
-	}	
-	
+    public Documents() {
+    }
+
+    public Documents(List<Document> documents) {
+        this.documents = new ArrayList<Document>(documents);
+    }
+
+    public void addDocument(Document document) {
+        documents.add(document);
+    }
+
+    public List<Document> getDocuments() {
+        return documents;
+    }
+
 }
-

--- a/jbpm-document/src/main/java/org/jbpm/document/Documents.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/Documents.java
@@ -18,11 +18,12 @@ package org.jbpm.document;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -34,6 +35,8 @@ public class Documents implements Serializable {
 
 	private static final long serialVersionUID = 6962662228758156488L;
 	
+	@XmlElementWrapper
+	@XmlAnyElement(lax=true)
 	private List<Document> documents = new ArrayList<>();
 
 	public Documents() {
@@ -48,7 +51,7 @@ public class Documents implements Serializable {
 	}
 	
 	public List<Document> getDocuments() {
-		return Collections.unmodifiableList(documents);
+	    return documents;
 	}	
 	
 }

--- a/jbpm-document/src/main/java/org/jbpm/document/marshalling/AbstractDocumentCollectionMarshallingStrategy.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/marshalling/AbstractDocumentCollectionMarshallingStrategy.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.document.marshalling;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.drools.core.common.DroolsObjectInputStream;
+import org.jbpm.document.Document;
+import org.jbpm.document.DocumentCollection;
+import org.kie.api.marshalling.ObjectMarshallingStrategy;
+
+/**
+ * Marshalling strategy definition to Marshal a collection of documents.
+ */
+public abstract class AbstractDocumentCollectionMarshallingStrategy implements ObjectMarshallingStrategy {
+
+    /**
+	 * Marshalling strategy that marshals the individual documents of our
+	 * collection.
+	 */
+	private DocumentMarshallingStrategy docMarshallingStrategy;
+
+	public AbstractDocumentCollectionMarshallingStrategy(DocumentMarshallingStrategy docMarshallingStrategy) {
+		this.docMarshallingStrategy = docMarshallingStrategy;
+	}
+
+	public byte[] marshal(Context ctx, ObjectOutputStream objectOutputStream, Object o) throws IOException {
+		ByteArrayOutputStream buff = new ByteArrayOutputStream();
+		try (ObjectOutputStream oos = new ObjectOutputStream(buff)) {
+			
+			DocumentCollection<?> documents = (DocumentCollection<?>) o;
+			
+			// Write the number of documents in the list.
+			oos.writeInt(documents.getDocuments().size());
+			for (Document nextDocument : documents.getDocuments()) {
+				// Use the DocumentMarshallingStrategy to marshal individual documents.
+				byte[] nextMarshalledDocument = docMarshallingStrategy.marshal(ctx, objectOutputStream, nextDocument);
+				oos.writeInt(nextMarshalledDocument.length);
+				oos.write(nextMarshalledDocument);
+				// Need to call reset on the stream in order for the Document bytes to be
+				// written correctly.
+				oos.reset();
+			}
+		}
+
+		return buff.toByteArray();
+	}
+
+	public Object unmarshal(Context ctx, ObjectInputStream objectInputStream, byte[] object, ClassLoader classLoader)
+			throws IOException, ClassNotFoundException {
+
+		try (DroolsObjectInputStream is = new DroolsObjectInputStream(new ByteArrayInputStream(object), classLoader)) {
+            
+            DocumentCollection storedDocuments = buildDocumentCollection();
+            
+			// first we read the size of the list we've stored.
+			int size = is.readInt();
+
+			for (int i = 0; i < size; i++) {
+				// Use the DocumentMarshallingStrategy to unmarshal the individual documents.
+				int length = is.readInt();
+				byte[] marshalledDocument = new byte[length];
+				is.readFully(marshalledDocument);
+				Document nextDocument = (Document) docMarshallingStrategy.unmarshal(ctx, objectInputStream, marshalledDocument,
+                        classLoader);
+                storedDocuments.addDocument(nextDocument);
+            }
+            return storedDocuments;
+		}
+
+	}
+
+	public Object read(ObjectInputStream arg0) throws IOException, ClassNotFoundException {
+		// Read and write are only used in previous versions of jBPM before the platform used protobuf storage for sessions.
+		throw new UnsupportedOperationException("This marshalling strategy supports jBPM 6.5 and higher.");
+	}
+
+	public void write(ObjectOutputStream arg0, Object arg1) throws IOException {
+		// Read and write are only used in previous versions of jBPM before the platform used protobuf storage for sessions.
+		throw new UnsupportedOperationException("This marshalling strategy supports jBPM 6.5 and higher.");
+	}
+
+	public Context createContext() {
+		return null;
+    }
+    
+    public abstract DocumentCollection<? extends Document> buildDocumentCollection();
+
+}
+

--- a/jbpm-document/src/main/java/org/jbpm/document/marshalling/DocumentCollectionImplMarshallingStrategy.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/marshalling/DocumentCollectionImplMarshallingStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.document.marshalling;
+
+import org.jbpm.document.DocumentCollection;
+import org.jbpm.document.service.impl.DocumentCollectionImpl;
+import org.jbpm.document.service.impl.DocumentImpl;
+
+public class DocumentCollectionImplMarshallingStrategy extends AbstractDocumentCollectionMarshallingStrategy {
+
+	public DocumentCollectionImplMarshallingStrategy(DocumentMarshallingStrategy docMarshallingStrategy) {
+		super(docMarshallingStrategy);
+	}
+
+	public boolean accept(Object o) {
+		return o instanceof DocumentCollectionImpl;
+	}
+
+	@Override
+	public DocumentCollection<DocumentImpl> buildDocumentCollection() {
+		return new DocumentCollectionImpl();
+	}
+	
+}

--- a/jbpm-document/src/main/java/org/jbpm/document/marshalling/DocumentsMarshallingStrategy.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/marshalling/DocumentsMarshallingStrategy.java
@@ -16,89 +16,33 @@
 
 package org.jbpm.document.marshalling;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-
-import org.drools.core.common.DroolsObjectInputStream;
 import org.jbpm.document.Document;
+import org.jbpm.document.DocumentCollection;
 import org.jbpm.document.Documents;
+import org.jbpm.document.service.impl.DocumentCollectionImpl;
 import org.kie.api.marshalling.ObjectMarshallingStrategy;
 
 /**
  * {@link ObjectMarshallingStrategy} for a collection (List) of {@link Document Documents}.
+ * 
+ * 
+ * * @deprecated This class is deprecated because the deprecation of {@link Documents} class. Please use the
+ * {@link DocumentCollectionImplMarshallingStrategy} to marshal and unmarshal a collection of {@link DocumentCollectionImpl}.
  */
-public class DocumentsMarshallingStrategy implements ObjectMarshallingStrategy {
+@Deprecated
+public class DocumentsMarshallingStrategy extends AbstractDocumentCollectionMarshallingStrategy {
 
-	/**
-	 * Marshalling strategy that marshals the individual documents of our collection.
-	 */
-	private DocumentMarshallingStrategy docMarshallingStrategy;
+    public DocumentsMarshallingStrategy(DocumentMarshallingStrategy docMarshallingStrategy) {
+        super(docMarshallingStrategy);
+    }
 
-	public DocumentsMarshallingStrategy(DocumentMarshallingStrategy docMarshallingStrategy) {
-		this.docMarshallingStrategy = docMarshallingStrategy;
-	}
+    public boolean accept(Object o) {
+        return o instanceof Documents;
+    }
 
-	public boolean accept(Object o) {
-		return o instanceof Documents;
-	}
-
-	public byte[] marshal(Context ctx, ObjectOutputStream objectOutputStream, Object o) throws IOException {
-		ByteArrayOutputStream buff = new ByteArrayOutputStream();
-		try (ObjectOutputStream oos = new ObjectOutputStream(buff)) {
-			Documents documents = (Documents) o;
-			// Write the number of documents in the list.
-			oos.writeInt(documents.getDocuments().size());
-			for (Document nextDocument : documents.getDocuments()) {
-				// Use the DocumentMarshallingStrategy to marshal individual documents.
-				byte[] nextMarshalledDocument = docMarshallingStrategy.marshal(ctx, objectOutputStream, nextDocument);
-				oos.writeInt(nextMarshalledDocument.length);
-				oos.write(nextMarshalledDocument);
-				// Need to call reset on the stream in order for the Document bytes to be written correctly.
-				oos.reset();
-			}
-		}
-
-		return buff.toByteArray();
-	}
-
-	public Object unmarshal(Context ctx, ObjectInputStream objectInputStream, byte[] object, ClassLoader classLoader)
-			throws IOException, ClassNotFoundException {
-
-		Documents documents = new Documents();
-
-		try (DroolsObjectInputStream is = new DroolsObjectInputStream(new ByteArrayInputStream(object), classLoader)) {
-			// first we read the size of the list we've stored.
-			int size = is.readInt();
-
-			for (int i = 0; i < size; i++) {
-				// Use the DocumentMarshallingStrategy to unmarshal the individual documents.
-				int length = is.readInt();
-				byte[] marshalledDocument = new byte[length];
-				is.readFully(marshalledDocument);
-				Document nextDocument = (Document) docMarshallingStrategy.unmarshal(ctx, objectInputStream, marshalledDocument,
-						classLoader);
-				documents.addDocument(nextDocument);
-			}
-		}
-
-		return documents;
-	}
-
-	public Object read(ObjectInputStream arg0) throws IOException, ClassNotFoundException {
-		// Read and write are only used in previous versions of jBPM before the platform used protobuf storage for sessions.
-		throw new UnsupportedOperationException("This marshalling strategy supports jBPM 6.5 and higher.");
-	}
-
-	public void write(ObjectOutputStream arg0, Object arg1) throws IOException {
-		// Read and write are only used in previous versions of jBPM before the platform used protobuf storage for sessions.
-		throw new UnsupportedOperationException("This marshalling strategy supports jBPM 6.5 and higher.");
-	}
-
-	public Context createContext() {
-		return null;
-	}
+    @Override
+    public DocumentCollection<Document> buildDocumentCollection() {
+        return new Documents();
+    }
 
 }

--- a/jbpm-document/src/main/java/org/jbpm/document/service/impl/DocumentCollectionImpl.java
+++ b/jbpm-document/src/main/java/org/jbpm/document/service/impl/DocumentCollectionImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.document.service.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.jbpm.document.DocumentCollection;
+
+/**
+ * A collection of {@link DocumentImpl}.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "documentcollection-object")
+public class DocumentCollectionImpl implements DocumentCollection<DocumentImpl> {
+
+    private static final long serialVersionUID = 1314653812921110025L;
+    
+    private List<DocumentImpl> documents;
+
+    public DocumentCollectionImpl() {
+        this.documents = new ArrayList<>();
+    }
+
+    public DocumentCollectionImpl(List<DocumentImpl> documents) {
+        this.documents = new ArrayList<DocumentImpl>(documents);
+    }
+
+    @Override
+    public void addDocument(DocumentImpl document) {
+        documents.add(document);
+    }
+
+    @Override
+    public List<DocumentImpl> getDocuments() {
+        return Collections.unmodifiableList(documents);
+    }
+    
+}

--- a/jbpm-document/src/test/java/org/jbpm/document/marshalling/DocumentCollectionImplMarshallingStrategyTest.java
+++ b/jbpm-document/src/test/java/org/jbpm/document/marshalling/DocumentCollectionImplMarshallingStrategyTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.document.marshalling;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.jbpm.document.Document;
+import org.jbpm.document.DocumentCollection;
+import org.jbpm.document.service.impl.DocumentCollectionImpl;
+import org.jbpm.document.service.impl.DocumentImpl;
+import org.jbpm.document.service.impl.DocumentStorageServiceImpl;
+import org.junit.Test;
+
+public class DocumentCollectionImplMarshallingStrategyTest {
+
+	private static final String STORAGE_PATH_TEST = "target/docs";
+	
+	private DocumentCollectionImplMarshallingStrategy docsMarshallingStrategy = new DocumentCollectionImplMarshallingStrategy(createSingleDocMarshallingStrategy());
+	
+	@Test
+	public void testMarshallUnmarshall() throws IOException, ClassNotFoundException {
+		
+		List<DocumentImpl> documents = getDocuments();
+		DocumentCollectionImpl docs = new DocumentCollectionImpl(documents);
+		
+		byte[] marshalledDocs = docsMarshallingStrategy.marshal(null, null, docs);
+		
+		DocumentCollectionImpl unmarshalledDocs = (DocumentCollectionImpl) docsMarshallingStrategy.unmarshal(null, null, marshalledDocs, this.getClass().getClassLoader());
+		
+		assertEquals(docs.getDocuments().size(), unmarshalledDocs.getDocuments().size());
+		
+		List<DocumentImpl> unmarshalledDocumentsList = unmarshalledDocs.getDocuments();
+		
+		assertEquals(documents.size(), unmarshalledDocumentsList.size());
+		
+		assertEquals(unmarshalledDocumentsList.get(0).getName(), docs.getDocuments().get(0).getName());
+		assertEquals(unmarshalledDocumentsList.get(0).getLink(), docs.getDocuments().get(0).getLink());
+		assertEquals(unmarshalledDocumentsList.get(1).getName(), docs.getDocuments().get(1).getName());
+		assertEquals(unmarshalledDocumentsList.get(1).getLink(), docs.getDocuments().get(1).getLink());
+	}
+	
+	private DocumentImpl getDocument(String documentName) {
+		DocumentImpl documentOne = new DocumentImpl();
+		documentOne.setIdentifier(documentName);
+		documentOne.setLastModified(new Date());
+		documentOne.setLink("http://" +  documentName);
+		documentOne.setName(documentName + " Name");
+		documentOne.setSize(1);
+		documentOne.setContent(documentName.getBytes());
+		return documentOne;
+	}
+	
+	private List<DocumentImpl> getDocuments() {
+		
+		List<DocumentImpl> documents = new ArrayList<>();
+		
+		documents.add(getDocument("documentOne"));
+		documents.add(getDocument("documentTwo"));
+		
+		return documents;
+	}
+	
+	private DocumentMarshallingStrategy createSingleDocMarshallingStrategy() {
+        return new DocumentMarshallingStrategy(new DocumentStorageServiceImpl(STORAGE_PATH_TEST));
+    }
+
+}


### PR DESCRIPTION
Introduced new DocumentCollection and DocumentCollectionImpl to split interface and impl defitinition of a collection of documents. Deprecated the old Documents impl as that gave problems when marshalling and unmarshalling via JSON and JAXB due to the Collection of interfaces it contained.