### PR TITLE
[RHPAM-2077] Cannot configure CXF Client connectionTimeout/receiveTim…

### DIFF
--- a/jbpm-workitems/jbpm-workitems-bpmn2/src/test/java/org/jbpm/process/workitem/bpmn2/JaxWSServiceTaskTest.java
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/src/test/java/org/jbpm/process/workitem/bpmn2/JaxWSServiceTaskTest.java
@@ -20,7 +20,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.net.SocketTimeoutException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -263,6 +265,65 @@ public class JaxWSServiceTaskTest {
                      processInstance.getState());
     }
 
+    @Test
+    public void testTimeoutViaSystemProperty() throws Exception {
+        System.setProperty("org.jbpm.cxf.client.connectionTimeout", "10");
+        System.setProperty("org.jbpm.cxf.client.receiveTimeout", "10");
+        try {
+            KieBase kbase = readKnowledgeBase();
+            KieSession ksession = createSession(kbase);
+            ksession.getWorkItemManager().registerWorkItemHandler("Service Task",
+                                                                  new WebServiceWorkItemHandler(ksession));
+            Map<String, Object> params = new HashMap<String, Object>();
+            params.put("s",
+                       "john");
+            params.put("mode",
+                       "sync");
+
+            WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.startProcess("org.jboss.qa.jbpm.CallWS",
+                                                                                                      params);
+            fail("should throw Read Timeout error");
+        } catch (Exception e) {
+            assertTrue(isCausedBySocketTimeoutException(e));
+        } finally {
+            System.clearProperty("org.jbpm.cxf.client.connectionTimeout");
+            System.clearProperty("org.jbpm.cxf.client.receiveTimeout");
+        }
+    }
+
+
+    @Test
+    public void testTimeoutViaParameters() throws Exception {
+        try {
+            KieBase kbase = readKnowledgeBase();
+            KieSession ksession = createSession(kbase);
+            ksession.getWorkItemManager().registerWorkItemHandler("Service Task",
+                                                                  new WebServiceWorkItemHandler(ksession));
+            Map<String, Object> params = new HashMap<String, Object>();
+            params.put("s",
+                       "john");
+            params.put("mode",
+                       "sync");
+
+            WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.startProcess("org.jboss.qa.jbpm.CallWS2",
+                                                                                                      params);
+            fail("should throw Read Timeout error");
+        } catch (Exception e) {
+            assertTrue(isCausedBySocketTimeoutException(e));
+        }
+    }
+
+    private boolean isCausedBySocketTimeoutException(Exception e) {
+        while (e.getCause() != null) {
+            Exception cause = (Exception)e.getCause();
+            if (cause instanceof SocketTimeoutException) {
+                return true;
+            }
+            e = cause;
+        }
+        return false;
+    }
+
     private void startWebService() {
         this.service = new SimpleService();
         this.endpoint = Endpoint.publish("http://127.0.0.1:9876/HelloService/greeting",
@@ -289,6 +350,8 @@ public class JaxWSServiceTaskTest {
         kbuilder.add(ResourceFactory.newClassPathResource("BPMN2-MultipleParamsWebService.bpmn"),
                      ResourceType.BPMN2);
         kbuilder.add(ResourceFactory.newClassPathResource("BPMN2-MultipleIntParamsWebService.bpmn"),
+                     ResourceType.BPMN2);
+        kbuilder.add(ResourceFactory.newClassPathResource("BPMN2-TwoWebServiceImportsWithTimeout.bpmn"),
                      ResourceType.BPMN2);
         return kbuilder.newKieBase();
     }

--- a/jbpm-workitems/jbpm-workitems-bpmn2/src/test/resources/BPMN2-TwoWebServiceImportsWithTimeout.bpmn
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/src/test/resources/BPMN2-TwoWebServiceImportsWithTimeout.bpmn
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- origin at X=0.0 Y=0.0 -->
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:java="http://www.java.com/javaTypes" xmlns:tns="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="Definition" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.2.4.Final-v20160330-1625-B110" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.jboss.org/drools" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:import importType="http://schemas.xmlsoap.org/wsdl/" location="http://127.0.0.1:9877/SecondService/greeting?wsdl" namespace="http://bpmn2.workitem.process.jbpm.org/"/>
+  <bpmn2:import importType="http://schemas.xmlsoap.org/wsdl/" location="http://127.0.0.1:9876/HelloService/greeting?wsdl" namespace="http://bpmn2.workitem.process.jbpm.org/"/>
+  <bpmn2:itemDefinition id="_sItem" isCollection="false" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="_sItem2" isCollection="false" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="_2_InMessageType" isCollection="false" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="ItemDefinition_39" isCollection="false" structureRef="String"/>
+  <bpmn2:message id="_2_InMessage" itemRef="_2_InMessageType" name="_2_InMessage"/>
+  <bpmn2:interface id="_2_ServiceInterface" implementationRef="SimpleService" name="SimpleService">
+    <bpmn2:operation id="_2_ServiceOperation" implementationRef="hello" name="hello">
+      <bpmn2:inMessageRef>_2_InMessage</bpmn2:inMessageRef>
+    </bpmn2:operation>
+  </bpmn2:interface>
+  <bpmn2:process id="org.jboss.qa.jbpm.CallWS2" tns:version="1" tns:packageName="defaultPackage" tns:adHoc="false" name="CallWS2" isExecutable="true" processType="Private">
+    <bpmn2:property id="s" itemSubjectRef="_sItem" name="s"/>
+    <bpmn2:property id="mode" itemSubjectRef="_sItem2" name="mode"/>
+    <bpmn2:startEvent id="StartEvent_1" name="Start">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Start]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:endEvent id="EndEvent_1" name="End">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[End]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="TerminateEventDefinition_1"/>
+    </bpmn2:endEvent>
+    <bpmn2:serviceTask id="ServiceTask_2" name="Service Task 2" implementation="##WebService" operationRef="_2_ServiceOperation">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Service Task 2]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_4</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="InputOutputSpecification_1">
+        <bpmn2:dataInput id="DataInput_1" name="Implementation"/>
+        <bpmn2:dataInput id="DataInput_2" name="Operation"/>
+        <bpmn2:dataInput id="DataInput_3" name="Mode"/>
+        <bpmn2:dataInput id="DataInput_4" name="Interface"/>
+        <bpmn2:dataInput id="DataInput_6" name="Interface_"/>
+        <bpmn2:dataInput id="DataInput_5" name="Parameter"/>
+        <bpmn2:dataInput id="DataInput_7" itemSubjectRef="ItemDefinition_39" name="ConnectionTimeout"/>
+        <bpmn2:dataInput id="DataInput_8" itemSubjectRef="ItemDefinition_39" name="ReceiveTimeout"/>
+        <bpmn2:dataOutput id="_2_result" name="Result"/>
+        <bpmn2:inputSet id="InputSet_1">
+          <bpmn2:dataInputRefs>DataInput_1</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_2</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_3</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_4</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_5</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_6</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_7</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_8</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="OutputSet_1">
+          <bpmn2:dataOutputRefs>_2_result</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_1">
+        <bpmn2:targetRef>DataInput_1</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_1">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_2">##WebService</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_1">DataInput_1</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_2">
+        <bpmn2:targetRef>DataInput_2</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_2">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_4">hello</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_3">DataInput_2</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_3">
+        <bpmn2:targetRef>DataInput_3</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_3">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_6">#{mode}</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_5">DataInput_3</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_4">
+        <bpmn2:targetRef>DataInput_4</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_4">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_8">SimpleService</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_7">DataInput_4</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_5">
+        <bpmn2:targetRef>DataInput_5</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_5">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_10">#{s}</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_9">DataInput_5</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_6">
+        <bpmn2:targetRef>DataInput_6</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_6">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_12">SimpleService</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_11">DataInput_6</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_7">
+        <bpmn2:targetRef>DataInput_7</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_8">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_18">10</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_16">DataInput_7</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_8">
+        <bpmn2:targetRef>DataInput_8</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_9">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_21">10</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_19">DataInput_8</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="DataOutputAssociation_1">
+        <bpmn2:sourceRef>_2_result</bpmn2:sourceRef>
+        <bpmn2:targetRef>s</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:serviceTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_3" tns:priority="1" name="" sourceRef="StartEvent_1" targetRef="ServiceTask_2"/>
+    <bpmn2:sequenceFlow id="SequenceFlow_4" tns:priority="1" name="" sourceRef="ServiceTask_2" targetRef="EndEvent_1"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="org.jboss.qa.jbpm.CallWS2">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="180.0" y="200.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="14.0" width="25.0" x="185.0" y="236.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="EndEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="508.0" y="200.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="14.0" width="22.0" x="515.0" y="236.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ServiceTask_2" bpmnElement="ServiceTask_2">
+        <dc:Bounds height="50.0" width="110.0" x="300.0" y="200.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="14.0" width="79.0" x="315.0" y="218.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3" sourceElement="BPMNShape_StartEvent_1" targetElement="BPMNShape_ServiceTask_2">
+        <di:waypoint xsi:type="dc:Point" x="216.0" y="218.0"/>
+        <di:waypoint xsi:type="dc:Point" x="300.0" y="225.0"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="BPMNShape_ServiceTask_2" targetElement="BPMNShape_EndEvent_1">
+        <di:waypoint xsi:type="dc:Point" x="410.0" y="225.0"/>
+        <di:waypoint xsi:type="dc:Point" x="508.0" y="218.0"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>


### PR DESCRIPTION
…eout for WebServiceWorkItemHandler
- fix and unit test

This fix introduced 2 configuration places:

- System properties which affect globally

```
<property name="org.jbpm.cxf.client.connectionTimeout" value="300000"/>
<property name="org.jbpm.cxf.client.receiveTimeout" value="300000"/>
```

- WorkItem parameters which affect per cached client
"ConnectionTimeout" and "ReceiveTimeout" (See details in BPMN2-TwoWebServiceImportsWithTimeout.bpmn)

Both values are milliseconds.

I will split one more configuration place (kie-deployment-descriptor.xml) for another JIRA and PR. 

Please review, thanks!