### PR TITLE
BAQE-826 - Solve Apache CXF issue in jBPM tests

### DIFF
--- a/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
@@ -260,6 +260,12 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>javax.activation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -321,6 +327,10 @@
     <dependency>
       <groupId>javax.jws</groupId>
       <artifactId>javax.jws-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
     </dependency>
 
     <dependency>
@@ -559,25 +569,6 @@
       <id>skipITs-by-default</id>
       <activation>
         <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <artifactId>maven-failsafe-plugin</artifactId>
-              <configuration>
-                <skipITs>true</skipITs>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-    <profile>
-      <!-- Integration tests are skipped on jdk9 due to problem with jboss-marshalling that accesses sun.reflect.... -->
-      <id>skipITs-on-jdk9</id>
-      <activation>
-        <jdk>9</jdk>
       </activation>
       <build>
         <pluginManagement>

--- a/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/src/test/java/org/jbpm/remote/ejb/test/task/EWebServiceTaskTest.java
+++ b/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/src/test/java/org/jbpm/remote/ejb/test/task/EWebServiceTaskTest.java
@@ -16,6 +16,8 @@
 
 package org.jbpm.remote.ejb.test.task;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +49,12 @@ public class EWebServiceTaskTest extends RemoteEjbTest {
 
     @BeforeClass
     public static void startWebService() {
+        //Ignore tests fot JDK11+
+        String javaVersion = System.getProperty("java.version");
+        String firstNumber = javaVersion.substring(0, javaVersion.indexOf('.'));
+        int major = Integer.parseInt(firstNumber);
+        assumeTrue(major < 11);
+
         WebService.start();
     }
 

--- a/jbpm-workitems/jbpm-workitems-webservice/src/main/java/org/jbpm/process/workitem/webservice/WebServiceWorkItemHandler.java
+++ b/jbpm-workitems/jbpm-workitems-webservice/src/main/java/org/jbpm/process/workitem/webservice/WebServiceWorkItemHandler.java
@@ -52,7 +52,12 @@ import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
+/**
+ * Web Service Work Item Handler that performs a WebService call.
+ * It is not supported out of the box on JDK11+ when running inside WildFly/EAP container
+ * with JDK11+ due to Apache CXF not properly resolving classpath.
+ * @see https://issues.apache.org/jira/browse/CXF-7925
+ */
 @Wid(widfile = "WebServiceDefinitions.wid", name = "WebService",
         displayName = "WebService",
         defaultHandler = "mvel: new org.jbpm.process.workitem.webservice.WebServiceWorkItemHandler()",


### PR DESCRIPTION
@mswiderski Finally after some time this is "fixed". Please check especially the javadoc for WIH and notice that I have also removed (probably no more used) JDK9 profile, since I tested that it now works with JDK10 and JDK11 (except for WS tests), so probably will also work with JDK9 (which is EOL anyway).