### PR TITLE
Allow extensibility in the process builder/validator 

### DIFF
--- a/jbpm-flow-builder/src/main/java/org/jbpm/compiler/ProcessBuilderImpl.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/compiler/ProcessBuilderImpl.java
@@ -125,10 +125,7 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
             if ( errors.length != 0 ) {
                 hasErrors = true;
                 for ( int i = 0; i < errors.length; i++ ) {
-                    this.errors.add( new ParserError( resource,
-                                                      errors[i].toString(),
-                                                      -1,
-                                                      -1 ) );
+                    this.errors.add( newParserError(resource, errors[i], -1, -1));
                 }
             }
         }
@@ -208,6 +205,13 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
 			}
         }
     }
+
+	protected ParserError newParserError(Resource resource, ProcessValidationError error, int row, int col){
+		return new ParserError( resource,
+                                error.toString(),
+                                row,
+								col );
+	}
 
     public void buildContexts(ContextContainer contextContainer, ProcessBuildContext buildContext) {
     	List<Context> exceptionScopes = contextContainer.getContexts(ExceptionScope.EXCEPTION_SCOPE);

--- a/jbpm-flow/src/main/java/org/jbpm/process/core/validation/impl/ProcessNodeValidationErrorImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/validation/impl/ProcessNodeValidationErrorImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.process.core.validation.impl;
+
+import org.kie.api.definition.process.Node;
+import org.kie.api.definition.process.Process;
+import org.jbpm.process.core.validation.ProcessValidationError;
+
+public class ProcessNodeValidationErrorImpl extends ProcessValidationErrorImpl {
+
+	private Node node;
+	
+	private String rawMessage;
+	
+	public ProcessNodeValidationErrorImpl(Process process, String message, Node node) {
+		super(process, String.format("Node '%s' [%d] " + message, node.getName(), node.getId()));
+		this.rawMessage = message;
+		this.node = node;
+	}
+
+	public String getRawMessage() {
+		return rawMessage;
+	}
+	
+	public Node getNode() {
+		return node;
+	}
+}

--- a/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/validation/RuleFlowProcessValidator.java
+++ b/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/validation/RuleFlowProcessValidator.java
@@ -36,6 +36,7 @@ import org.jbpm.process.core.timer.DateTimeUtils;
 import org.jbpm.process.core.timer.Timer;
 import org.jbpm.process.core.validation.ProcessValidationError;
 import org.jbpm.process.core.validation.ProcessValidator;
+import org.jbpm.process.core.validation.impl.ProcessNodeValidationErrorImpl;
 import org.jbpm.process.core.validation.impl.ProcessValidationErrorImpl;
 import org.jbpm.ruleflow.core.RuleFlowProcess;
 import org.jbpm.workflow.core.WorkflowProcess;
@@ -1013,10 +1014,9 @@ public class RuleFlowProcessValidator implements ProcessValidator {
                                    Node node,
                                    List<ProcessValidationError> errors,
                                    String message) {
-        String error = String.format("Node '%s' [%d] " + message,
-                                     node.getName(),
-                                     node.getId());
-        errors.add(new ProcessValidationErrorImpl(process,
-                                                  error));
+
+        errors.add(new ProcessNodeValidationErrorImpl(process,
+                                                  message,
+												  node));
     }
 }


### PR DESCRIPTION
These 2 changes allows us to have extensibility options to keep node information with the error message for builder/validation.

Our tool highlights the shape in error after a publication and those simple modifications let us hook into the framework and retrieve the info we need in the fronted.

The default behavior of the engine is not changed at all.

ProcessBuilderImpl: Icreated a method to transfer the error into ParseEerror so that we can overload it to provide our own class that extends ParserError and keep the node information

RuleFlowProcessValidator: The message formating hardcoding is moved to the new class that extends the previous class. The non formatted message is also accessible as well as the node.