### PR TITLE
JBPM-8485 - Add support ISO8601 expressions for user task notificatio…

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/util/DeadlineSchedulerHelper.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/util/DeadlineSchedulerHelper.java
@@ -44,6 +44,12 @@ public class DeadlineSchedulerHelper {
         List<DeadlineType> deadlineTypes = Arrays.asList(types);
 
         Deadlines deadlines = HumanTaskHandlerHelper.setDeadlines(task.getTaskData().getTaskInputVariables(), businessAdministrators, environment, unboundRepeatableOnly);
+
+        if (deadlines.getStartDeadlines().isEmpty() && deadlines.getEndDeadlines().isEmpty()) {
+            // If there are no deadlines to schedule, skip scheduling completely
+            return;
+        }
+
         if(deadlineTypes.contains(DeadlineType.START)) {
             for(Deadline deadline : deadlines.getStartDeadlines()) {
                 task.getDeadlines().getStartDeadlines().add(deadline);

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/DeadlinesBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/DeadlinesBaseTest.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.drools.core.impl.EnvironmentFactory;
 import org.jbpm.services.task.deadlines.NotificationListener;
@@ -35,6 +36,7 @@ import org.jbpm.test.listener.task.CountDownTaskEventListener;
 import org.jbpm.services.task.utils.ContentMarshallerHelper;
 import org.junit.Test;
 import org.kie.api.runtime.Environment;
+import org.kie.api.task.TaskEvent;
 import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.Status;
 import org.kie.api.task.model.Task;
@@ -483,7 +485,14 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
 
         taskService.addTask(task, inputVars);
 
-        CountDownTaskEventListener countDownListener = new CountDownTaskEventListener(1, true, false);
+        AtomicInteger timersTriggeredCount = new AtomicInteger();
+        CountDownTaskEventListener countDownListener = new CountDownTaskEventListener(1, true, false) {
+            @Override
+            public void afterTaskReassignedEvent(TaskEvent event) {
+                super.afterTaskReassignedEvent(event);
+                timersTriggeredCount.incrementAndGet();
+            }
+        };
         addCountDownListner(countDownListener);
 
         long taskId = task.getId();
@@ -504,6 +513,9 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
             task = taskService.getTaskById(taskId);
             assertThat(task.getTaskData().getActualOwner()).as("Task was not reclaimed").isNull();
         }
+
+        assertThat(timersTriggeredCount).as("Some deadlines have fired more than once!").hasValue(3);
+
         taskService.claim(taskId, "Bobba Fet");
         taskService.start(taskId, "Bobba Fet");
         taskService.complete(taskId, "Bobba Fet", Collections.<String, Object>emptyMap());
@@ -523,7 +535,14 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
 
         taskService.addTask(task, inputVars);
 
-        CountDownTaskEventListener countDownListener = new CountDownTaskEventListener(1, true, false);
+        AtomicInteger timersTriggeredCount = new AtomicInteger();
+        CountDownTaskEventListener countDownListener = new CountDownTaskEventListener(1, true, false) {
+            @Override
+            public void afterTaskReassignedEvent(TaskEvent event) {
+                super.afterTaskReassignedEvent(event);
+                timersTriggeredCount.incrementAndGet();
+            }
+        };
         addCountDownListner(countDownListener);
 
         long taskId = task.getId();
@@ -546,6 +565,60 @@ public abstract class DeadlinesBaseTest extends HumanTaskServicesBaseTest {
             task = (InternalTask) taskService.getTaskById(taskId);
             assertThat(task.getTaskData().getActualOwner()).as("Task was not reclaimed").isNull();
         }
+
+        assertThat(timersTriggeredCount).as("Some deadlines have fired more than once!").hasValue(3);
+
+        taskService.claim(taskId, "Bobba Fet");
+        taskService.start(taskId, "Bobba Fet");
+        taskService.complete(taskId, "Bobba Fet", Collections.<String, Object>emptyMap());
+    }
+
+    @Test(timeout = 10000)
+    public void testTaskNotCompletedReassignBounded() throws Exception {
+        Reader reader = new InputStreamReader(getClass().getResourceAsStream(MvelFilePath.DeadlineWithMultipleReassignment));
+        Map<String, Object> vars = new HashMap<String, Object>();
+        vars.put("now", new Date());
+        InternalTask task = (InternalTask) TaskFactory.evalTask(reader, vars);
+
+        Environment environment = EnvironmentFactory.newEnvironment();
+        Map<String, Object> inputVars = new HashMap<String, Object>();
+        inputVars.put("NotCompletedReassign", "[users:Tony Stark,Bobba Fet,Jabba Hutt|groups:]@[R3/PT2S]");
+        ((InternalTask) task).setDeadlines(HumanTaskHandlerHelper.setDeadlines(inputVars, Collections.emptyList(), environment, false));
+
+        taskService.addTask(task, inputVars);
+
+        AtomicInteger timersTriggeredCount = new AtomicInteger();
+        CountDownTaskEventListener countDownListener = new CountDownTaskEventListener(1, true, false) {
+            @Override
+            public void afterTaskReassignedEvent(TaskEvent event) {
+                super.afterTaskReassignedEvent(event);
+                timersTriggeredCount.incrementAndGet();
+            }
+        };
+        addCountDownListner(countDownListener);
+
+        long taskId = task.getId();
+
+        String []owners = new String[] {
+                "Tony Stark", "Bobba Fet", "Jabba Hutt"
+        };
+
+        for(String owner : owners) {
+            countDownListener.reset(1);
+
+            taskService.claim(taskId, owner);
+            task = (InternalTask) taskService.getTaskById(taskId);
+            assertThat(task.getTaskData().getActualOwner().getId()).isEqualTo(owner);
+
+            taskService.start(taskId, owner);
+
+            countDownListener.waitTillCompleted();
+
+            task = (InternalTask) taskService.getTaskById(taskId);
+            assertThat(task.getTaskData().getActualOwner()).as("Task was not reclaimed").isNull();
+        }
+
+        assertThat(timersTriggeredCount).as("Some deadlines have fired more than once!").hasValue(3);
 
         taskService.claim(taskId, "Bobba Fet");
         taskService.start(taskId, "Bobba Fet");


### PR DESCRIPTION
…ns - reschedule only if deadlines not empty

@martinweiler @tsurdilo Please have a look. It fixes the added test, which is otherwise failing.

The issue was that when the first deadline of R3/PT2S was triggered, then it again parsed this String etc. and since we don't reschedule R3/PT2S - only R/ is rescheduled, no deadlines were find, but the attempt to scheduling was made. This attempt will iterate over all deadlines and schedule ones which are not escalated, which means the 2nd and 3rd are scheduled again, leaving 2 timers for 2nd and 3rd deadlines. When 2nd deadlines timers are executed (now there is 2 of them), each of them will create another timer for 3rd deadline. So for 3rd execution, there will be 4 timers.

https://github.com/kiegroup/jbpm/blob/cd57cd17925f37e9abe9188e5bff44126464c619/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/util/DeadlineSchedulerHelper.java#L84-L92

This fix simply won't reschedule if no deadlines are set by `HumanTaskHandlerHelper#setDeadlines`. This should work since we currently support either more bounded deadlines (setDeadlines will always return no deadlines) or just one unbounded (setDeadlines will always return only the deadline being executed).