### PR TITLE
dependencyManagement section added after jboss_ip_bom replacement

### DIFF
--- a/jbpm-runtime-manager/src/test/resources/META-INF/beans.xml
+++ b/jbpm-runtime-manager/src/test/resources/META-INF/beans.xml
@@ -17,13 +17,9 @@
 
 -->
 
-    
-<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-       xmlns:s="urn:java:ee"
-       xmlns:task="urn:java:org.jbpm.services.task.annotations"
-       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd">
-    
 
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
 </beans>
 
     

--- a/jbpm-runtime-manager/src/test/resources/META-INF/beans.xml
+++ b/jbpm-runtime-manager/src/test/resources/META-INF/beans.xml
@@ -17,9 +17,13 @@
 
 -->
 
-
-<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:s="urn:java:ee"
+       xmlns:task="urn:java:org.jbpm.services.task.annotations"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+    
+
 </beans>
 
     

--- a/jbpm-services/jbpm-executor-cdi/src/main/resources/META-INF/beans.xml
+++ b/jbpm-services/jbpm-executor-cdi/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,7 @@
-<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:s="urn:java:ee"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+    
 </beans>
 
     

--- a/jbpm-services/jbpm-executor-cdi/src/main/resources/META-INF/beans.xml
+++ b/jbpm-services/jbpm-executor-cdi/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,5 @@
-<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-       xmlns:s="urn:java:ee"
-       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd">
-    
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
 </beans>
 
     

--- a/jbpm-services/jbpm-executor-cdi/src/test/resources/META-INF/beans.xml
+++ b/jbpm-services/jbpm-executor-cdi/src/test/resources/META-INF/beans.xml
@@ -1,5 +1,7 @@
-<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:s="urn:java:ee"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+    
 </beans>
 
     

--- a/jbpm-services/jbpm-executor-cdi/src/test/resources/META-INF/beans.xml
+++ b/jbpm-services/jbpm-executor-cdi/src/test/resources/META-INF/beans.xml
@@ -1,7 +1,5 @@
-<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-       xmlns:s="urn:java:ee"
-       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd">
-    
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
 </beans>
 
     

--- a/jbpm-xes/pom.xml
+++ b/jbpm-xes/pom.xml
@@ -32,21 +32,7 @@
     <version.commons-cli>1.4</version.commons-cli>
     <version.com.h2database>1.4.193</version.com.h2database>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>commons-cli</groupId>
-        <artifactId>commons-cli</artifactId>
-        <version>${version.commons-cli}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.h2database</groupId>
-        <artifactId>h2</artifactId>
-        <version>${version.com.h2database}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>   
+   
 
   <dependencies>
 

--- a/jbpm-xes/pom.xml
+++ b/jbpm-xes/pom.xml
@@ -32,7 +32,21 @@
     <version.commons-cli>1.4</version.commons-cli>
     <version.com.h2database>1.4.193</version.com.h2database>
   </properties>
-   
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>commons-cli</groupId>
+        <artifactId>commons-cli</artifactId>
+        <version>${version.commons-cli}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>${version.com.h2database}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>   
 
   <dependencies>
 


### PR DESCRIPTION
@cristianonicolai @MarianMacik please review.
After jboss ip bom replacement, XES Main tests were failing due to incorrect versions of commons-cli library. New dependencyManagement section has been added to handle right ones.