### PR TITLE
Send UTF-8 encoded content to Elasticsearch

### DIFF
--- a/jbpm-event-emitters/jbpm-event-emitters-elasticsearch/src/main/java/org/jbpm/event/emitters/elasticsearch/ElasticSearchEventEmitter.java
+++ b/jbpm-event-emitters/jbpm-event-emitters-elasticsearch/src/main/java/org/jbpm/event/emitters/elasticsearch/ElasticSearchEventEmitter.java
@@ -135,7 +135,7 @@ public class ElasticSearchEventEmitter implements EventEmitter {
 
             try {
                 HttpPut httpPut = new HttpPut(elasticSearchUrl + "/_bulk");
-                httpPut.setEntity(new StringEntity(content.toString()));
+                httpPut.setEntity(new StringEntity(content.toString(), "UTF-8"));
 
                 logger.debug("Executing request " + httpPut.getRequestLine());
                 httpPut.setHeader("Content-Type", "application/x-ndjson");


### PR DESCRIPTION
This is a bugfix for the extension jbpm-event-emitters-elasticsearch, which converts explicitely using UTF-8.

Some variables values might contain special characters. For example in German that are umlauts (ä,ö,ü).
Currently if some variable contains one of these characters, they are not stored in Elasticsearch.
Instead you will get this error from Elasticsearch:
```
org.elasticsearch.index.mapper.MapperParsingException: failed to parse
com.fasterxml.jackson.core.JsonParseException: Invalid UTF-8 start byte
```

