### PR TITLE
Fix WebServiceWorkitemHandler with JDK 11

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
@@ -350,6 +350,13 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Needed for JDK 11 -->
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/jbpm-workitems/jbpm-workitems-webservice/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-webservice/pom.xml
@@ -45,11 +45,6 @@
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-databinding-jaxb</artifactId>
     </dependency>
-    <!-- Needed by the cxf-rt-databinding-jaxb as that one only depends on jaxb-impl and we need jaxb-core as well. -->
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-transports-http</artifactId>


### PR DESCRIPTION
@gmunozfe There was an issue on JDK11 in jbpm-container tests. An upgrade of cxf-rt-databinding-jaxb no longer depends on jaxb-impl (see https://github.com/apache/cxf/commit/54b71171e89bb1be7d169ac91bb626c9c1ca293b#diff-3ab950a3633cee6bcef4ee7e98da8d33), so I had to add it in jbpm-container test suite. Moreover, we don't need jaxb-core there since cxf-rt-databinding-jaxb no longer depends on it and tests are passing (at least locally).