### PR TITLE
JBPM-8701 - Remove unnecessary sleeps from jbpm-in-container tests

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/archive/LocalTransactions.java
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/archive/LocalTransactions.java
@@ -76,6 +76,8 @@ public class LocalTransactions {
                 .addClass(KieUtils.class);
 
         war.addPackages(true, "org.jbpm.test.container.groups");
+        // NodeCountDownProcessEventListener and its ancestors from jbpm-test-util
+        war.addPackages(true, "org.jbpm.test.listener.process");
 
         // WEB-INF resources
         war.addAsWebResource(getClass().getResource("/logback.xml"), ArchivePaths.create("logback.xml"));


### PR DESCRIPTION
Or how to shave off nearly 20 seconds from test execution...