### PR TITLE
[JBPM-8644] AsyncMode doesn't wait on Inclusive converging Gateway

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/AsyncEventNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/AsyncEventNodeInstance.java
@@ -93,8 +93,10 @@ public class AsyncEventNodeInstance extends EventNodeInstance {
     @Override
     protected NodeInstance getFrom() {
         AsyncEventNode node = (AsyncEventNode) getNode();
+        int level = getLevel();
         org.jbpm.workflow.instance.NodeInstance instance = ((org.jbpm.workflow.instance.NodeInstanceContainer) getNodeInstanceContainer()).getNodeInstance(node.getPreviousNode());
         ((org.jbpm.workflow.instance.NodeInstanceContainer) getNodeInstanceContainer()).removeNodeInstance(instance);
+        ((org.jbpm.workflow.instance.impl.NodeInstanceImpl) instance).setLevel(level);
         return instance;
     }
 

--- a/jbpm-services/jbpm-executor/src/test/java/org/jbpm/executor/impl/wih/AsyncContinuationSupportTest.java
+++ b/jbpm-services/jbpm-executor/src/test/java/org/jbpm/executor/impl/wih/AsyncContinuationSupportTest.java
@@ -1208,7 +1208,7 @@ public class AsyncContinuationSupportTest extends AbstractExecutorBaseTest {
     @Test(timeout = 10000)
     public void testAsyncModeWithInclusiveGateway() throws Exception {
         // JBPM-7414 // there are two paths for end process , therefore it is executed twice
-        final NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("EndProcess", 2);
+        final NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("EndProcess", 1);
         final NodeTriggerCountListener triggerListener = new NodeTriggerCountListener("ScriptTask-4");
 
         RuntimeEnvironment environment = RuntimeEnvironmentBuilder.Factory.get().newDefaultBuilder()
@@ -1252,7 +1252,7 @@ public class AsyncContinuationSupportTest extends AbstractExecutorBaseTest {
         processInstance = runtime.getKieSession().getProcessInstance(processInstanceId);
         assertNull(processInstance);
 
-        assertEquals(2, triggerListener.getCount().intValue());
+        assertEquals(1, triggerListener.getCount().intValue());
     }
 
     private static class NodeTriggerCountListener extends DefaultProcessEventListener {


### PR DESCRIPTION
setting the proper level when we are moving backward in the flow
so it is not interpreted incorrectly by the iteration level.