### PR TITLE
Stabilize tests due to fast exec at win2k16 servers

### DIFF
--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/ExecutorLogCleanTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/ExecutorLogCleanTest.java
@@ -120,11 +120,22 @@ public class ExecutorLogCleanTest extends JbpmAsyncJobTestCase {
                 .date(errorList.get(0).getTime())
                 .build()
                 .execute();
-        Assertions.assertThat(resultCount).isEqualTo(1);
+        
+        //normal scenario, i.e, errorList time is different for both
+        int deleted = 1;
+        int remaining = 1;
+        
+        //if both have the same time
+        if (errorList.get(0).getTime().equals(errorList.get(1).getTime())) {
+            deleted=2;
+            remaining=0;
+        }
+        
+        Assertions.assertThat(resultCount).isEqualTo(deleted);
 
         // Assert remaining records
-        Assertions.assertThat(getExecutorService().getAllErrors(new QueryContext())).hasSize(1);
-
+        Assertions.assertThat(getExecutorService().getAllErrors(new QueryContext())).hasSize(remaining);
+        
         // Abort running process instance
         ksession.abortProcessInstance(pi.getId());
     }

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/service/ServiceTaskHandlerTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/service/ServiceTaskHandlerTest.java
@@ -16,7 +16,7 @@
 
 package org.jbpm.test.functional.service;
 
-import java.util.Date;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -97,7 +97,9 @@ public class ServiceTaskHandlerTest extends JbpmTestCase {
         Map<String, Object> params = new HashMap<String, Object>();
         
         params.put("IntegerVar", new Integer(12345));
-        params.put("DateVar", new Date());
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.DATE, -1); // Previous day      
+        params.put("DateVar", c.getTime());
         WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.startProcess(processName.replace("-", ""), params);
         assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
         assertEquals(Integer.valueOf(1), processInstance.getVariable("IntegerVar"));


### PR DESCRIPTION
Some tests need a little tuning due to fast execution at windows 2016 servers:

-deleteErrorLogsByDate, it's removing two logs (instead of expecting one) because dates are the same for both. Added this scenario to the test.

-ServiceTaskHandlerTests (testShorten[Full]InterfaceNameBPMN2[Workitems]) are expecting 1 as result (input date lower) but obtaining 0 (same date). Updated to pass a previous date (day before) instead of current date.