### PR TITLE
[JBPM-8785] Custom Process variables not persisted on every waiting node (human task).

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
@@ -907,7 +907,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     }
 
-    @Test(timeout=10000)
+    @Test
     public void testEventSubprocessMessageWithLocalVars() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 1);
 

--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeInstance.java
@@ -16,6 +16,7 @@
 
 package org.jbpm.process.instance.context.variable;
 
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,6 +35,7 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.CaseData;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.rule.FactHandle;
+import org.w3c.dom.Document;
 
 /**
  * 
@@ -50,11 +52,21 @@ public class VariableScopeInstance extends AbstractContextInstance {
         return VariableScope.VARIABLE_SCOPE;
     }
 
+
     public Object getVariable(String name) {
                 
         Object value = variables.get(name);
         if (value != null) {
-            return value;
+            if (shouldBeCloned(value)) {
+                try {
+                    Method clone = value.getClass().getMethod("clone");
+                    return clone.invoke(value);
+                } catch (Exception e) {
+                    return value;
+                }
+            } else {
+                return value;
+            }
         }
 
         // support for processInstanceId and parentProcessInstanceId
@@ -86,6 +98,10 @@ public class VariableScopeInstance extends AbstractContextInstance {
         }    
 
         return null;
+    }
+
+    private boolean shouldBeCloned(Object value) {
+        return value instanceof Cloneable && !(value instanceof Collection) && !(value instanceof Map) && !(value instanceof Document);
     }
 
     public Map<String, Object> getVariables() {

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/TaskContentServiceImpl.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/TaskContentServiceImpl.java
@@ -61,6 +61,7 @@ public class TaskContentServiceImpl implements TaskContentService {
     
     @SuppressWarnings("unchecked")
 	public long addOutputContent(long taskId, Map<String, Object> params) {
+
         Task task = persistenceContext.findTask(taskId);
         loadTaskVariables(task);
         long outputContentId = task.getTaskData().getOutputContentId();
@@ -87,6 +88,7 @@ public class TaskContentServiceImpl implements TaskContentService {
                 
                 ((Map<String, Object>)unmarshalledObject).putAll(params);
             }
+
             ContentData outputContentData = ContentMarshallerHelper.marshal(task, unmarshalledObject, context.getEnvironment());
             ((InternalContent)outputContent).setContent(outputContentData.getContent());
             persistenceContext.persistContent(outputContent);


### PR DESCRIPTION
getVariables from scope instance returns a copy of the variable so it is not possible
to cause corruption in the scope. It is needed to use Cloneable interface and implement clone
method