### PR TITLE
[JBPM-8801] Process instance assign first potencial actor to field "created by" when it is empty in process definition

### DIFF
--- a/jbpm-human-task/jbpm-human-task-workitems/src/main/java/org/jbpm/services/task/wih/util/PeopleAssignmentHelper.java
+++ b/jbpm-human-task/jbpm-human-task-workitems/src/main/java/org/jbpm/services/task/wih/util/PeopleAssignmentHelper.java
@@ -108,14 +108,6 @@ public class PeopleAssignmentHelper {
             processPeopleAssignments((String)actorIds, potentialOwners, true);
         }
 
-        // Set the first user as creator ID??? hmmm might be wrong
-        if (potentialOwners.size() > 0 && taskData.getCreatedBy() == null) {
-        	
-        	OrganizationalEntity firstPotentialOwner = potentialOwners.get(0);
-        	taskData.setCreatedBy((User) firstPotentialOwner);
-
-        }
-        
 	}
 	@SuppressWarnings("unchecked")
 	protected void assignGroups(WorkItem workItem, PeopleAssignments peopleAssignments) {

--- a/jbpm-human-task/jbpm-human-task-workitems/src/test/java/org/jbpm/services/task/wih/HTWorkItemHandlerBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-workitems/src/test/java/org/jbpm/services/task/wih/HTWorkItemHandlerBaseTest.java
@@ -15,18 +15,11 @@
  */
 package org.jbpm.services.task.wih;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.drools.core.impl.EnvironmentFactory;
 import org.drools.core.process.instance.impl.WorkItemImpl;
 import org.jbpm.process.core.timer.DateTimeUtils;
 import org.jbpm.services.task.events.DefaultTaskEventListener;
@@ -49,6 +42,13 @@ import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.task.api.EventService;
 import org.kie.internal.task.api.model.AccessType;
 import org.kie.internal.task.api.model.InternalTaskData;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 public abstract class HTWorkItemHandlerBaseTest extends AbstractBaseTest {
@@ -600,7 +600,7 @@ public abstract class HTWorkItemHandlerBaseTest extends AbstractBaseTest {
         assertEquals("Comment", task.getDescription());
         assertEquals(Status.Reserved, task.getStatus());
         assertEquals("Darth Vader", task.getActualOwner().getId());
-        assertEquals("Darth Vader", task.getCreatedBy().getId());
+        assertNull(task.getCreatedBy());
         assertEquals(10, task.getProcessInstanceId().intValue());
 
         taskService.start(task.getId(), "Darth Vader");

--- a/jbpm-human-task/jbpm-human-task-workitems/src/test/java/org/jbpm/services/task/wih/util/PeopleAssignmentHelperTest.java
+++ b/jbpm-human-task/jbpm-human-task-workitems/src/test/java/org/jbpm/services/task/wih/util/PeopleAssignmentHelperTest.java
@@ -15,10 +15,6 @@
  */
 package org.jbpm.services.task.wih.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,6 +32,11 @@ import org.kie.internal.task.api.TaskModelProvider;
 import org.kie.internal.task.api.model.InternalPeopleAssignments;
 import org.kie.internal.task.api.model.InternalTask;
 import org.kie.internal.task.api.model.InternalTaskData;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 
 public class PeopleAssignmentHelperTest  extends AbstractBaseTest {
@@ -124,7 +125,7 @@ public class PeopleAssignmentHelperTest  extends AbstractBaseTest {
 		OrganizationalEntity organizationalEntity1 = peopleAssignments.getPotentialOwners().get(0);
 		assertTrue(organizationalEntity1 instanceof User);
 		assertEquals(actorId, organizationalEntity1.getId());		
-		assertEquals(actorId, taskData.getCreatedBy().getId());
+        assertNull(taskData.getCreatedBy());
 		
 		workItem = new WorkItemImpl();
 		peopleAssignments = peopleAssignmentHelper.getNullSafePeopleAssignments(task);				
@@ -133,7 +134,7 @@ public class PeopleAssignmentHelperTest  extends AbstractBaseTest {
 		assertEquals(2, peopleAssignments.getPotentialOwners().size());
 		organizationalEntity1 = peopleAssignments.getPotentialOwners().get(0);
 		assertEquals(actorId, organizationalEntity1.getId());		
-		assertEquals(actorId, taskData.getCreatedBy().getId());
+        assertNull(taskData.getCreatedBy());
 		OrganizationalEntity organizationalEntity2 = peopleAssignments.getPotentialOwners().get(1);
 		assertEquals("drbug", organizationalEntity2.getId());
 
@@ -162,7 +163,7 @@ public class PeopleAssignmentHelperTest  extends AbstractBaseTest {
         OrganizationalEntity organizationalEntity1 = peopleAssignments.getPotentialOwners().get(0);
         assertTrue(organizationalEntity1 instanceof User);
         assertEquals("user1", organizationalEntity1.getId());       
-        assertEquals("user1", taskData.getCreatedBy().getId());
+        assertNull(taskData.getCreatedBy());
         
         OrganizationalEntity organizationalEntity2 = peopleAssignments.getPotentialOwners().get(1);
         assertTrue(organizationalEntity2 instanceof User);
@@ -175,7 +176,7 @@ public class PeopleAssignmentHelperTest  extends AbstractBaseTest {
         assertEquals(3, peopleAssignments.getPotentialOwners().size());
         organizationalEntity1 = peopleAssignments.getPotentialOwners().get(0);
         assertEquals("user1", organizationalEntity1.getId());       
-        assertEquals("user1", taskData.getCreatedBy().getId());
+        assertNull(taskData.getCreatedBy());
         organizationalEntity2 = peopleAssignments.getPotentialOwners().get(1);
         assertTrue(organizationalEntity2 instanceof User);
         assertEquals("user2", organizationalEntity2.getId()); 
@@ -206,7 +207,7 @@ public class PeopleAssignmentHelperTest  extends AbstractBaseTest {
         OrganizationalEntity organizationalEntity1 = peopleAssignments.getPotentialOwners().get(0);
         assertTrue(organizationalEntity1 instanceof User);
         assertEquals("user1", organizationalEntity1.getId());       
-        assertEquals("user1", taskData.getCreatedBy().getId());
+        assertNull(taskData.getCreatedBy());
         
         OrganizationalEntity organizationalEntity2 = peopleAssignments.getPotentialOwners().get(1);
         assertTrue(organizationalEntity2 instanceof User);
@@ -219,7 +220,7 @@ public class PeopleAssignmentHelperTest  extends AbstractBaseTest {
         assertEquals(3, peopleAssignments.getPotentialOwners().size());
         organizationalEntity1 = peopleAssignments.getPotentialOwners().get(0);
         assertEquals("user1", organizationalEntity1.getId());       
-        assertEquals("user1", taskData.getCreatedBy().getId());
+        assertNull(taskData.getCreatedBy());
         organizationalEntity2 = peopleAssignments.getPotentialOwners().get(1);
         assertTrue(organizationalEntity2 instanceof User);
         assertEquals("user2", organizationalEntity2.getId()); 


### PR DESCRIPTION

remove default createdBy assignment to a task