### PR TITLE
JBPM-8856 - Fix code coverage in the jbpm-runtime-manager module

### DIFF
--- a/jbpm-runtime-manager/pom.xml
+++ b/jbpm-runtime-manager/pom.xml
@@ -259,6 +259,8 @@
           <!-- Properties for Byteman which allows it to run on IBM Java as well -->
           <argLine>
             -javaagent:${project.build.directory}/agents/byteman.jar=port:9091,boot:${project.build.directory}/agents/byteman.jar
+            -Dfile.encoding=${project.build.sourceEncoding}
+            ${jacoco.agent.line}
           </argLine>
           <systemPropertyVariables>
             <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>

--- a/jbpm-services/jbpm-kie-services/pom.xml
+++ b/jbpm-services/jbpm-kie-services/pom.xml
@@ -259,27 +259,6 @@
       <artifactId>jbpm-shared-services</artifactId>
     </dependency>
 
-    <!-- test: byteman -->
-    <dependency>
-      <groupId>org.jboss.byteman</groupId>
-      <artifactId>byteman</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.byteman</groupId>
-      <artifactId>byteman-submit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.byteman</groupId>
-      <artifactId>byteman-install</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.byteman</groupId>
-      <artifactId>byteman-bmunit</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
 \*\/$
 ]]>
         </checkstyle.header.template>
+        <jacoco.agent.line/>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Guys,

this should fix the issue with code coverage reporting. Now the `jacoco.exec` file is present in the `target` of the directory the Maven command is run from. The other option was to create a new profile section in the `jbpm-runtime-manager` POM so it would override the Byteman-only section defined in it. I have also noticed that there were unused Byteman dependencies declared, so I removed them. Feel free to comment.

Thanks @rsynek for having the devil idea about having 2 java agents!