### PR TITLE
Don't use forkMode because it is deprecated

### DIFF
--- a/jbpm-runtime-manager/pom.xml
+++ b/jbpm-runtime-manager/pom.xml
@@ -255,7 +255,6 @@
       and to avoid clashing between them as both need to setup data source and bound it to JNDI -->
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkMode>always</forkMode>
           <!-- Properties for Byteman which allows it to run on IBM Java as well -->
           <argLine>
             -javaagent:${project.build.directory}/agents/byteman.jar=port:9091,boot:${project.build.directory}/agents/byteman.jar

--- a/jbpm-runtime-manager/pom.xml
+++ b/jbpm-runtime-manager/pom.xml
@@ -251,10 +251,10 @@
     </testResources>
     <plugins>
       <plugin>
-        <!-- we need to fork always as we have mixture of both arquillian tests and regular
-      and to avoid clashing between them as both need to setup data source and bound it to JNDI -->
+        <!-- We need to fork always as we have tests which are configured by system properties when a JVM starts -->
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <reuseForks>false</reuseForks>
           <!-- Properties for Byteman which allows it to run on IBM Java as well -->
           <argLine>
             -javaagent:${project.build.directory}/agents/byteman.jar=port:9091,boot:${project.build.directory}/agents/byteman.jar

--- a/jbpm-services/jbpm-kie-services/pom.xml
+++ b/jbpm-services/jbpm-kie-services/pom.xml
@@ -309,6 +309,13 @@
         </configuration>
       </plugin>
       <plugin>
+        <!-- We need to fork always as we have tests which are configured by system properties when a JVM starts -->
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <reuseForks>false</reuseForks>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>

--- a/jbpm-services/jbpm-kie-services/pom.xml
+++ b/jbpm-services/jbpm-kie-services/pom.xml
@@ -309,14 +309,6 @@
         </configuration>
       </plugin>
       <plugin>
-      <!-- we need to fork always as we have mixture of both arquillian tests and regular 
-          and to avoid clashing between them as both need to setup data source and bound it to JNDI -->
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkMode>always</forkMode>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/DeactivateDeploymentServiceWithSyncTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/DeactivateDeploymentServiceWithSyncTest.java
@@ -30,10 +30,9 @@ import org.jbpm.kie.services.impl.KModuleDeploymentUnit;
 import org.jbpm.kie.services.impl.store.DeploymentStore;
 import org.jbpm.kie.services.impl.store.DeploymentSyncInvoker;
 import org.jbpm.kie.services.impl.store.DeploymentSynchronizer;
-import org.jbpm.kie.services.test.objects.CoundDownDeploymentListener;
+import org.jbpm.kie.services.test.objects.CountDownDeploymentListener;
 import org.jbpm.kie.test.util.AbstractKieServicesBaseTest;
 import org.jbpm.services.api.DeploymentEvent;
-import org.jbpm.services.api.DeploymentEventListener;
 import org.jbpm.services.api.ListenerSupport;
 import org.jbpm.services.api.model.DeployedUnit;
 import org.jbpm.services.api.model.DeploymentUnit;
@@ -164,7 +163,8 @@ public class DeactivateDeploymentServiceWithSyncTest extends AbstractKieServices
         assertNotNull(deployed);
         assertEquals(0, deployed.size());
         
-        KModuleDeploymentUnit unit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);        
+        KModuleDeploymentUnit unit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
+        units.add(unit);
         deploymentService.deploy(unit);
         deploymentService.deactivate(unit.getIdentifier());
         
@@ -173,7 +173,7 @@ public class DeactivateDeploymentServiceWithSyncTest extends AbstractKieServices
         
         AtomicBoolean deploymentActive = new AtomicBoolean(true);
 
-        CoundDownDeploymentListener countDownListener = new CoundDownDeploymentListener(1) {
+        CountDownDeploymentListener countDownListener = new CountDownDeploymentListener(1) {
             @Override
             public void onDeploy(DeploymentEvent event) {
                 // This used to use a specific listener for setting the active state

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/DeploymentServiceWithSyncTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/DeploymentServiceWithSyncTest.java
@@ -28,7 +28,7 @@ import org.jbpm.kie.services.impl.KModuleDeploymentUnit;
 import org.jbpm.kie.services.impl.store.DeploymentStore;
 import org.jbpm.kie.services.impl.store.DeploymentSyncInvoker;
 import org.jbpm.kie.services.impl.store.DeploymentSynchronizer;
-import org.jbpm.kie.services.test.objects.CoundDownDeploymentListener;
+import org.jbpm.kie.services.test.objects.CountDownDeploymentListener;
 import org.jbpm.kie.test.util.AbstractKieServicesBaseTest;
 import org.jbpm.services.api.ListenerSupport;
 import org.jbpm.services.api.model.DeployedUnit;
@@ -131,8 +131,12 @@ public class DeploymentServiceWithSyncTest extends AbstractKieServicesBaseTest {
         invoker.start();
     }
     
-    protected CoundDownDeploymentListener configureListener(int threads, boolean deploy, boolean undeploy, boolean activate, boolean deactivate) {
-        CoundDownDeploymentListener countDownListener = new CoundDownDeploymentListener(threads);
+    protected CountDownDeploymentListener configureListener(int threads, boolean deploy, boolean undeploy, boolean activate, boolean deactivate) {
+        CountDownDeploymentListener countDownListener = new CountDownDeploymentListener(threads);
+        countDownListener.setDeploy(deploy);
+        countDownListener.setUndeploy(undeploy);
+        countDownListener.setActivate(activate);
+        countDownListener.setDeactivate(deactivate);
         ((ListenerSupport)deploymentService).addListener(countDownListener);
         
         return countDownListener;
@@ -162,7 +166,7 @@ public class DeploymentServiceWithSyncTest extends AbstractKieServicesBaseTest {
     @Test
     public void testDeploymentOfProcessesBySync() throws Exception {
         
-        CoundDownDeploymentListener countDownListener = configureListener(1, true, false, false, false);
+        CountDownDeploymentListener countDownListener = configureListener(1, true, false, false, false);
 
     	Collection<DeployedUnit> deployed = deploymentService.getDeployedUnits();
     	assertNotNull(deployed);
@@ -183,7 +187,7 @@ public class DeploymentServiceWithSyncTest extends AbstractKieServicesBaseTest {
     
     @Test
     public void testUndeploymentOfProcessesBySync() throws Exception {
-        CoundDownDeploymentListener countDownListener = configureListener(1, false, true, false, false);
+        CountDownDeploymentListener countDownListener = configureListener(1, false, true, false, false);
         
     	Collection<DeployedUnit> deployed = deploymentService.getDeployedUnits();
     	assertNotNull(deployed);
@@ -210,7 +214,7 @@ public class DeploymentServiceWithSyncTest extends AbstractKieServicesBaseTest {
     
     @Test
     public void testDeactivateAndActivateOfProcessesBySync() throws Exception {
-        CoundDownDeploymentListener countDownListener = configureListener(2, false, false, true, true);
+        CountDownDeploymentListener countDownListener = configureListener(2, false, false, true, true);
         
     	Collection<DeployedUnit> deployed = deploymentService.getDeployedUnits();
     	assertNotNull(deployed);
@@ -247,7 +251,7 @@ public class DeploymentServiceWithSyncTest extends AbstractKieServicesBaseTest {
     
     @Test
     public void testDeploymentOfProcessesBySyncWithDisabledAttribute() throws Exception {
-        CoundDownDeploymentListener countDownListener = configureListener(1, true, false, false, false);
+        CountDownDeploymentListener countDownListener = configureListener(1, true, false, false, false);
         
     	Collection<DeployedUnit> deployed = deploymentService.getDeployedUnits();
     	assertNotNull(deployed);

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/objects/CountDownDeploymentListener.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/objects/CountDownDeploymentListener.java
@@ -24,8 +24,8 @@ import org.jbpm.services.api.DeploymentEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CoundDownDeploymentListener implements DeploymentEventListener {
-    private static Logger logger = LoggerFactory.getLogger(CoundDownDeploymentListener.class);
+public class CountDownDeploymentListener implements DeploymentEventListener {
+    private static Logger logger = LoggerFactory.getLogger(CountDownDeploymentListener.class);
 
     private CountDownLatch latch;
     
@@ -34,11 +34,11 @@ public class CoundDownDeploymentListener implements DeploymentEventListener {
     private boolean activate;
     private boolean deactivate;
     
-    public CoundDownDeploymentListener() {
+    public CountDownDeploymentListener() {
         this.latch = new CountDownLatch(0);
     }
     
-    public CoundDownDeploymentListener(int threads) {
+    public CountDownDeploymentListener(int threads) {
         this.latch = new CountDownLatch(threads);
     }
     

--- a/jbpm-services/jbpm-kie-services/src/test/resources/entity/entity-test-persistence.xml
+++ b/jbpm-services/jbpm-kie-services/src/test/resources/entity/entity-test-persistence.xml
@@ -9,7 +9,7 @@
     <exclude-unlisted-classes>true</exclude-unlisted-classes>
     <properties>
       <property name="hibernate.max_fetch_depth" value="3"/>
-      <property name="hibernate.hbm2ddl.auto" value="update"/>
+      <property name="hibernate.hbm2ddl.auto" value="create"/>
       <property name="hibernate.show_sql" value="false"/>
       <property name="hibernate.id.new_generator_mappings" value="false"/>
       </properties>

--- a/jbpm-services/jbpm-services-cdi/pom.xml
+++ b/jbpm-services/jbpm-services-cdi/pom.xml
@@ -238,7 +238,7 @@
     and to avoid clashing between them as both need to setup data source and bound it to JNDI -->
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkMode>always</forkMode>
+          <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
       <plugin>

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/impl/admin/ProcessInstanceMigrationServiceCDIImplTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/impl/admin/ProcessInstanceMigrationServiceCDIImplTest.java
@@ -105,7 +105,7 @@ public class ProcessInstanceMigrationServiceCDIImplTest extends ProcessInstanceM
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/impl/manager/MultipleRuntimeManagerTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/impl/manager/MultipleRuntimeManagerTest.java
@@ -126,7 +126,7 @@ public class MultipleRuntimeManagerTest extends AbstractKieServicesBaseTest {
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService") 
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties","jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/Taskorm.xml", ArchivePaths.create("Taskorm.xml"))

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/impl/manager/SingleRuntimeManagerTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/impl/manager/SingleRuntimeManagerTest.java
@@ -125,7 +125,7 @@ public class SingleRuntimeManagerTest extends AbstractKieServicesBaseTest {
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties","jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/Taskorm.xml", ArchivePaths.create("Taskorm.xml"))

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/impl/manager/SingleRuntimeManagerWithEmbeddedTaskServiceTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/impl/manager/SingleRuntimeManagerWithEmbeddedTaskServiceTest.java
@@ -119,7 +119,7 @@ public class SingleRuntimeManagerWithEmbeddedTaskServiceTest extends AbstractKie
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties","jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/Taskorm.xml", ArchivePaths.create("Taskorm.xml"))

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/impl/manager/SingleRuntimeManagerWithListenersTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/impl/manager/SingleRuntimeManagerWithListenersTest.java
@@ -132,7 +132,7 @@ public class SingleRuntimeManagerWithListenersTest extends AbstractKieServicesBa
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties","jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/Taskorm.xml", ArchivePaths.create("Taskorm.xml"))

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/BPMN2DataServiceCDIImplTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/BPMN2DataServiceCDIImplTest.java
@@ -102,7 +102,7 @@ public class BPMN2DataServiceCDIImplTest extends BPMN2DataServicesTest {
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/DeploymentServiceCDIImplTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/DeploymentServiceCDIImplTest.java
@@ -102,7 +102,7 @@ public class DeploymentServiceCDIImplTest extends DeploymentServiceTest {
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/DeploymentServiceCDIImplWithSyncTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/DeploymentServiceCDIImplWithSyncTest.java
@@ -26,7 +26,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jbpm.kie.services.impl.store.DeploymentStore;
 import org.jbpm.kie.services.test.DeploymentServiceWithSyncTest;
-import org.jbpm.kie.services.test.objects.CoundDownDeploymentListener;
+import org.jbpm.kie.services.test.objects.CountDownDeploymentListener;
 import org.jbpm.services.api.DefinitionService;
 import org.jbpm.services.api.DeploymentService;
 import org.jbpm.services.api.ProcessService;
@@ -108,7 +108,7 @@ public class DeploymentServiceCDIImplWithSyncTest extends DeploymentServiceWithS
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));
@@ -126,7 +126,7 @@ public class DeploymentServiceCDIImplWithSyncTest extends DeploymentServiceWithS
 	}
 
 	@Override
-    protected CoundDownDeploymentListener configureListener(int threads, boolean deploy, boolean undeploy, boolean activate, boolean deactivate) {
+    protected CountDownDeploymentListener configureListener(int threads, boolean deploy, boolean undeploy, boolean activate, boolean deactivate) {
         countDownListner.reset(threads);
         countDownListner.setDeploy(deploy);
         countDownListner.setUndeploy(undeploy);

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/ProcessServiceCDIImplTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/ProcessServiceCDIImplTest.java
@@ -102,7 +102,7 @@ public class ProcessServiceCDIImplTest extends ProcessServiceImplTest {
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/QueryServiceCDIImplTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/QueryServiceCDIImplTest.java
@@ -114,7 +114,7 @@ public class QueryServiceCDIImplTest extends QueryServiceImplTest {
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")                
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/RuntimeDataServiceCDIImplTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/RuntimeDataServiceCDIImplTest.java
@@ -109,7 +109,7 @@ public class RuntimeDataServiceCDIImplTest extends RuntimeDataServiceImplTest {
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/RuntimeDataServiceTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/RuntimeDataServiceTest.java
@@ -130,7 +130,7 @@ public class RuntimeDataServiceTest extends AbstractKieServicesBaseTest {
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/UserTaskServiceCDIImplTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/UserTaskServiceCDIImplTest.java
@@ -106,7 +106,7 @@ public class UserTaskServiceCDIImplTest extends UserTaskServiceImplTest {
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/hr/HumanResourcesHiringTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/hr/HumanResourcesHiringTest.java
@@ -140,7 +140,7 @@ public class HumanResourcesHiringTest extends AbstractKieServicesBaseTest {
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/CustomHumanTaskServiceTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/CustomHumanTaskServiceTest.java
@@ -110,7 +110,7 @@ public class CustomHumanTaskServiceTest extends AbstractKieServicesBaseTest {
                 .addPackage("org.jbpm.services.cdi.test.humantaskservice")
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties","jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/Taskorm.xml", ArchivePaths.create("Taskorm.xml"))

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/HumanTaskServiceWithAuditExclusionTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/HumanTaskServiceWithAuditExclusionTest.java
@@ -115,7 +115,7 @@ public class HumanTaskServiceWithAuditExclusionTest extends AbstractKieServicesB
                 .addPackage("org.jbpm.services.cdi.test.humantaskservice")
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addClass("org.jbpm.services.cdi.impl.ExcludeNonCDIImplExtension")
                 .addAsResource("jndi.properties","jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/support/CDISupportProcessTSInjectionDisabledTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/support/CDISupportProcessTSInjectionDisabledTest.java
@@ -92,7 +92,7 @@ public class CDISupportProcessTSInjectionDisabledTest extends SupportProcessBase
                  .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                  .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                  .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                  .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/support/CDISupportProcessTSInjectionSingletonTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/support/CDISupportProcessTSInjectionSingletonTest.java
@@ -92,7 +92,7 @@ public class CDISupportProcessTSInjectionSingletonTest extends SupportProcessBas
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/support/CDISupportProcessTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/support/CDISupportProcessTest.java
@@ -92,7 +92,7 @@ public class CDISupportProcessTest extends SupportProcessBaseTest {
                 .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
                 .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
                 .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
-                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener")
                 .addAsResource("jndi.properties", "jndi.properties")
                 .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
                 .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/util/CountDownDeploymentListenerCDIImpl.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/util/CountDownDeploymentListenerCDIImpl.java
@@ -19,7 +19,7 @@ package org.jbpm.services.cdi.test.util;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 
-import org.jbpm.kie.services.test.objects.CoundDownDeploymentListener;
+import org.jbpm.kie.services.test.objects.CountDownDeploymentListener;
 import org.jbpm.services.api.DeploymentEvent;
 import org.jbpm.services.cdi.Activate;
 import org.jbpm.services.cdi.Deactivate;
@@ -27,7 +27,7 @@ import org.jbpm.services.cdi.Deploy;
 import org.jbpm.services.cdi.Undeploy;
 
 @ApplicationScoped
-public class CountDownDeploymentListenerCDIImpl extends CoundDownDeploymentListener {
+public class CountDownDeploymentListenerCDIImpl extends CountDownDeploymentListener {
 
     public CountDownDeploymentListenerCDIImpl() {
         super();

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-impl/src/test/java/org/jbpm/services/ejb/test/DeploymentServiceEJBWithSyncIntegrationTest.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-impl/src/test/java/org/jbpm/services/ejb/test/DeploymentServiceEJBWithSyncIntegrationTest.java
@@ -30,7 +30,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jbpm.kie.services.impl.KModuleDeploymentUnit;
 import org.jbpm.kie.services.impl.store.DeploymentStore;
-import org.jbpm.kie.services.test.objects.CoundDownDeploymentListener;
+import org.jbpm.kie.services.test.objects.CountDownDeploymentListener;
 import org.jbpm.services.api.ListenerSupport;
 import org.jbpm.services.api.model.DeployedUnit;
 import org.jbpm.services.api.model.DeploymentUnit;
@@ -74,7 +74,7 @@ public class DeploymentServiceEJBWithSyncIntegrationTest extends AbstractTestSup
 		}
 		WebArchive war = ShrinkWrap.createFromZipFile(WebArchive.class, archive);
 		war.addPackage("org.jbpm.services.ejb.test");
-		war.addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener");// test cases
+		war.addClass("org.jbpm.kie.services.test.objects.CountDownDeploymentListener");// test cases
 
 		// deploy test kjar
 		deployKjar();
@@ -123,8 +123,8 @@ public class DeploymentServiceEJBWithSyncIntegrationTest extends AbstractTestSup
         repository.installArtifact(releaseIdSupport, kJar2, pom2);
 	}
 	
-    protected CoundDownDeploymentListener configureListener(int threads) {
-        CoundDownDeploymentListener countDownListener = new CoundDownDeploymentListener(threads);
+    protected CountDownDeploymentListener configureListener(int threads) {
+        CountDownDeploymentListener countDownListener = new CountDownDeploymentListener(threads);
         ((ListenerSupport)deploymentService).addListener(countDownListener);
         
         return countDownListener;
@@ -139,7 +139,7 @@ public class DeploymentServiceEJBWithSyncIntegrationTest extends AbstractTestSup
     @Test
     public void testDeploymentOfProcessesBySync() throws Exception {
         
-        CoundDownDeploymentListener countDownListener = configureListener(1);
+        CountDownDeploymentListener countDownListener = configureListener(1);
         
     	DeploymentStore store = new DeploymentStore();
 		store.setCommandService(commandService);
@@ -161,7 +161,7 @@ public class DeploymentServiceEJBWithSyncIntegrationTest extends AbstractTestSup
     
     @Test
     public void testUndeploymentOfProcessesBySync() throws Exception {
-        CoundDownDeploymentListener countDownListener = configureListener(2);
+        CountDownDeploymentListener countDownListener = configureListener(2);
         
     	DeploymentStore store = new DeploymentStore();
 		store.setCommandService(commandService);
@@ -190,7 +190,7 @@ public class DeploymentServiceEJBWithSyncIntegrationTest extends AbstractTestSup
     
     @Test
     public void testDeactivateAndActivateOfProcessesBySync() throws Exception {
-        CoundDownDeploymentListener countDownListener = configureListener(2);
+        CountDownDeploymentListener countDownListener = configureListener(2);
         
     	DeploymentStore store = new DeploymentStore();
 		store.setCommandService(commandService);


### PR DESCRIPTION
1. `forkMode` is deprecated
2. ~~We don't need it in 2 of 3 modules as it doesn't contain any Arquillian tests.~~