### PR TITLE
[DROOLS-4755] Support easy form url encoding on REST Requests

### DIFF
--- a/jbpm-workitems/jbpm-workitems-rest/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-rest/pom.xml
@@ -55,6 +55,33 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+        <groupId>com.github.exabrial</groupId>
+        <artifactId>form-binding</artifactId>
+        <!-- These are included with kie-server -->
+        <exclusions>
+            <exclusion>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.reflections</groupId>
+                <artifactId>reflections</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
     <!-- Replacement for above excluded 'commons-logging:commons-logging' -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/jbpm-workitems/jbpm-workitems-rest/src/main/java/org/jbpm/process/workitem/rest/RESTWorkItemHandler.java
+++ b/jbpm-workitems/jbpm-workitems-rest/src/main/java/org/jbpm/process/workitem/rest/RESTWorkItemHandler.java
@@ -85,6 +85,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.exabrial.formbinding.FormBindingReader;
+import com.github.exabrial.formbinding.FormBindingWriter;
+import com.github.exabrial.formbinding.spi.FormBinding;
 
 /**
  * WorkItemHandler that is capable of interacting with REST service. Supports both types of services
@@ -983,6 +986,9 @@ public class RESTWorkItemHandler extends AbstractLogOrThrowWorkItemHandler imple
                                                        stringRep);
 
                 return stringRep.toString();
+            } else if (contentType.toLowerCase().contains("application/x-www-form-urlencoded")) {
+            	FormBindingWriter writer = FormBinding.getWriter();
+            	return writer.write(data);
             }
         } catch (Exception e) {
             throw new RuntimeException("Unable to transform request to object",
@@ -1005,6 +1011,9 @@ public class RESTWorkItemHandler extends AbstractLogOrThrowWorkItemHandler imple
             JAXBContext jaxbContext = JAXBContext.newInstance(new Class[]{clazz});
 
             return jaxbContext.createUnmarshaller().unmarshal(result);
+        } else if (contentType.toLowerCase().contains("application/x-www-form-urlencoded")) {
+        	FormBindingReader reader = FormBinding.getReader();
+        	return reader.read(content, clazz);
         }
         logger.warn("Unable to find transformer for content type '{}' to handle for content '{}'",
                     contentType,

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.github.exabrial</groupId>
+                <artifactId>form-binding</artifactId>
+                <version>1.0.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jbpm</groupId>
                 <artifactId>jbpm-test-util</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
It's surprisingly difficult to send an object as a group of form url encoded parameters. This seems like a common use case (POST a bunch of key-value-pairs to a URL). 

This patch allows the use to set the `content-type` to `application/x-www-form-urlencoded` and the payload object will be automatically form url encoded.