### PR TITLE
Fix tests for postgresql ddl scripts

### DIFF
--- a/jbpm-installer/src/main/resources/db/ddl-scripts/postgresql/postgresql-jbpm-lo-trigger-clob.sql
+++ b/jbpm-installer/src/main/resources/db/ddl-scripts/postgresql/postgresql-jbpm-lo-trigger-clob.sql
@@ -1,3 +1,4 @@
+drop table if exists jbpm_active_clob;
 create table jbpm_active_clob ( loid oid );
 
 -- Triggers to protect CLOB from vacuumlo

--- a/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/util/TestsUtil.java
+++ b/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/util/TestsUtil.java
@@ -62,6 +62,11 @@ public final class TestsUtil {
                         return o1.getName().compareTo(o2.getName());
                     }
                 });
+                
+                if (databaseType.equals(DatabaseType.POSTGRESQL)) {
+                    //Returns first schema sql
+                    Arrays.sort(foundFiles, Comparator.<File, Boolean>comparing(s -> s.getName().contains("schema")).reversed());
+                }
             }
 
             return foundFiles;


### PR DESCRIPTION
Following issues during ddl script execution for postgresql have been sorted out:
- Delimiter semicolon has to be kept without splitting if found inside a dollar quoted block
- schema sql has to be executed prior to trigger sql
- missing drop table jbpm_active_clob