### PR TITLE
JBPM-8952 - Stabilize jbpm-in-container test after AssertJ upgrade

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
@@ -568,7 +568,7 @@
                 <configuration>
                   <properties>
                     <cargo.jboss.configuration>standalone-full</cargo.jboss.configuration>
-                    <cargo.jvmargs>-Xmx1g</cargo.jvmargs>
+                    <cargo.jvmargs>-Xmx1536m</cargo.jvmargs>
                     <!-- Datasource -->
                     <cargo.datasource.datasource.jbpm>
                       cargo.datasource.driver=${org.jbpm.datasource.driver.class}|
@@ -650,7 +650,7 @@
                 <configuration>
                   <properties>
                     <cargo.jboss.configuration>standalone-full</cargo.jboss.configuration>
-                    <cargo.jvmargs>-Xmx1024m</cargo.jvmargs>
+                    <cargo.jvmargs>-Xmx1536m</cargo.jvmargs>
                     <!-- Datasource -->
                     <cargo.datasource.datasource.jbpm>
                       cargo.datasource.driver=${org.jbpm.datasource.driver.class}|

--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/archive/HelloWebService.java
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/archive/HelloWebService.java
@@ -20,7 +20,10 @@ import java.io.File;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenStrategyStage;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenWorkingSession;
 import org.jboss.shrinkwrap.resolver.api.maven.PomEquippedResolveStage;
+import org.jboss.shrinkwrap.resolver.impl.maven.MavenWorkingSessionContainer;
 import org.jbpm.test.container.tools.IntegrationMavenResolver;
 import org.kie.api.KieServices;
 import org.kie.api.io.Resource;
@@ -50,10 +53,18 @@ public class HelloWebService {
         System.out.println("### Building archive '" + ARCHIVE_NAME + ".war'");
 
         PomEquippedResolveStage resolver = IntegrationMavenResolver.get();
-        File[] dependencies = resolver.importCompileAndRuntimeDependencies().resolve().withTransitivity().asFile();
-        LOGGER.debug("Archive dependencies:");
-        for (File d : dependencies) {
-            LOGGER.debug(d.getName());
+        MavenStrategyStage strategyStage = resolver.importCompileAndRuntimeDependencies().resolve();
+        MavenWorkingSession workingSession = ((MavenWorkingSessionContainer) strategyStage).getMavenWorkingSession();
+
+        File[] dependencies = new File[0];
+
+        if (!workingSession.getDependenciesForResolution().isEmpty()) {
+            dependencies = strategyStage.withTransitivity().asFile();
+
+            LOGGER.debug("Archive dependencies:");
+            for (File d : dependencies) {
+                LOGGER.debug(d.getName());
+            }
         }
         
         war = ShrinkWrap

--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/archive/RegisterRestService.java
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/archive/RegisterRestService.java
@@ -18,6 +18,9 @@ package org.jbpm.test.container.archive;
 
 import java.io.File;
 
+import org.jboss.shrinkwrap.resolver.api.maven.MavenStrategyStage;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenWorkingSession;
+import org.jboss.shrinkwrap.resolver.impl.maven.MavenWorkingSessionContainer;
 import org.jbpm.test.container.tools.IntegrationMavenResolver;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePaths;
@@ -59,10 +62,18 @@ public class RegisterRestService {
         String webXmlFile = isTomcat() ? "web-non-ee.xml" : "web-ee.xml";
 
         PomEquippedResolveStage resolver = IntegrationMavenResolver.get(mvnProfiles);
-        File[] dependencies = resolver.importCompileAndRuntimeDependencies().resolve().withTransitivity().asFile();
-        LOGGER.debug("Archive dependencies:");
-        for (File d : dependencies) {
-            LOGGER.debug(d.getName());
+        MavenStrategyStage strategyStage = resolver.importCompileAndRuntimeDependencies().resolve();
+        MavenWorkingSession workingSession = ((MavenWorkingSessionContainer) strategyStage).getMavenWorkingSession();
+
+        File[] dependencies = new File[0];
+
+        if (!workingSession.getDependenciesForResolution().isEmpty()) {
+            dependencies = strategyStage.withTransitivity().asFile();
+
+            LOGGER.debug("Archive dependencies:");
+            for (File d : dependencies) {
+                LOGGER.debug(d.getName());
+            }
         }
 
         war = ShrinkWrap

--- a/jbpm-container-test/jbpm-in-container-test/shrinkwrap-war-profiles/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/shrinkwrap-war-profiles/pom.xml
@@ -28,14 +28,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <!--Default dependencies for all archives-->
-  <dependencies>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-    </dependency>
-  </dependencies>
-
   <!-- Configuration for specific integration modules -->
   <profiles>
     <profile>
@@ -71,6 +63,11 @@
               <artifactId>jboss-transaction-api_1.2_spec</artifactId>
             </exclusion>
           </exclusions>
+        </dependency>
+        <!-- AssertJ is only needed if we deploy tests (with jBPM engine) into a container -->
+        <dependency>
+          <groupId>org.assertj</groupId>
+          <artifactId>assertj-core</artifactId>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
After AssertJ upgrade from version 3.8.0 to 3.14.0, the uberjar is now 4.5 MB instead of 1.2 MB which means the deployed archives are bigger as well and sometimes there is an OutOfMemoryError when tests are run.

* Raised max heap size for WildFly/EAP from 1 GB to 1.5 GB
* Include AssertJ only in archives which need it