### PR TITLE
Missing dependency with jdk11 (com.sun.xml.bind:jaxb-impl) for CaseLogCleanupCommand (JBPM-8745) 

### DIFF
--- a/jbpm-test-coverage/pom.xml
+++ b/jbpm-test-coverage/pom.xml
@@ -125,6 +125,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- needed for jdk 11 -->
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
   </dependencies>
 
   <properties>


### PR DESCRIPTION
Missing this dependency for the new tests related to CaseLogCleanupCommand (JBPM-8745), which provokes ClassNotFoundException: com.sun.xml.internal.bind.v2.ContextFactory
