### PR TITLE
Fixing a column name error in the SQL

### DIFF
--- a/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/commands/ExecutionErrorCleanupCommand.java
+++ b/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/commands/ExecutionErrorCleanupCommand.java
@@ -115,7 +115,7 @@ public class ExecutionErrorCleanupCommand implements Command, Reoccurring {
 		Map<String, Object> parameters = new HashMap<>();
         StringBuilder cleanUpErrorsQuery = new StringBuilder();
         
-        cleanUpErrorsQuery.append("delete from ExecutionErrorInfo where processInstanceId in "
+        cleanUpErrorsQuery.append("delete from ExecutionErrorInfo where PROCESS_INST_ID in "
                 + "(select processInstanceId from ProcessInstanceLog where status in (2,3))");
         if (olderThan != null && !olderThan.isEmpty()) {            
             cleanUpErrorsQuery.append(" and errorDate < :olderThan");


### PR DESCRIPTION
Looking at https://github.com/kiegroup/jbpm/blob/cb8c01be15c79524c0e3218db0f082e67506d404/jbpm-installer/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql#L190, the column name for process instance id in ExecutionErrorInfo is PROCESS_INST_ID