### PR TITLE
fixed last http left overs and URLs

### DIFF
--- a/jbpm-installer/src/main/resources/build.properties
+++ b/jbpm-installer/src/main/resources/build.properties
@@ -18,57 +18,57 @@ release.version=7.33.0-SNAPSHOT
 #   jBPM.version=${snapshot.version}
 #   jBPM.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=droolsjbpm-bpms-distribution&v=${jBPM.version}&e=zip&c=bin
 jBPM.version=${snapshot.version}
-jBPM.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=droolsjbpm-bpms-distribution&v=${jBPM.version}&e=zip&c=bin
+jBPM.url=https://origin-repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=droolsjbpm-bpms-distribution&v=${jBPM.version}&e=zip&c=bin
 
 # the version of jBPM Console you want to use
 # and the associated URL you want to get it from
 # for example: 
 #<RELEASE>
 # for EAP7:
-#   jBPM.console.url=http://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central/${jBPM.version}/business-central-${jBPM.version}-eap7.war
+#   jBPM.console.url=https://origin-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central/${jBPM.version}/business-central-${jBPM.version}-eap7.war
 # for WildFly14:
-#   jBPM.console.url=https://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central/${jBPM.version}/business-central-${jBPM.version}-wildfly14.war
+#   jBPM.console.url=https://origin-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central/${jBPM.version}/business-central-${jBPM.version}-wildfly14.war
 # or:
 #<SNAPSHOT>
-#   jBPM.console.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=business-central&v=${jBPM.version}&e=war&c=wildfly14
-jBPM.console.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=business-central&v=${jBPM.version}&e=war&c=wildfly14
+#   jBPM.console.url=https://origin-repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=business-central&v=${jBPM.version}&e=war&c=wildfly14
+jBPM.console.url=https://origin-repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=business-central&v=${jBPM.version}&e=war&c=wildfly14
 
 # the version of jBPM case mgmt Console you want to use
 # and the associated URL you want to get it from
 # for example: 
 #<RELEASE>
 # for EAP7:
-#   jBPM.casemgmt.url=https://repository.jboss.org/nexus/content/groups/public-jboss/org/jbpm/jbpm-wb-case-mgmt-showcase/${jBPM.version}/jbpm-wb-case-mgmt-showcase-${jBPM.version}-eap7.war
+#   jBPM.casemgmt.url=https://origin-repository.jboss.org/nexus/content/groups/public-jboss/org/jbpm/jbpm-wb-case-mgmt-showcase/${jBPM.version}/jbpm-wb-case-mgmt-showcase-${jBPM.version}-eap7.war
 # for WildFly14:
-#   jBPM.casemgmt.url=https://repository.jboss.org/nexus/content/groups/public-jboss/org/jbpm/jbpm-wb-case-mgmt-showcase/${jBPM.version}/jbpm-wb-case-mgmt-showcase-${jBPM.version}-wildfly14.war
+#   jBPM.casemgmt.url=https://origin-repository.jboss.org/nexus/content/groups/public-jboss/org/jbpm/jbpm-wb-case-mgmt-showcase/${jBPM.version}/jbpm-wb-case-mgmt-showcase-${jBPM.version}-wildfly14.war
 # or:
 #<SNAPSHOT>
-#   jBPM.casemgmt.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-wb-case-mgmt-showcase&v=${jBPM.version}&e=war&c=wildfly14
-jBPM.casemgmt.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-wb-case-mgmt-showcase&v=${jBPM.version}&e=war&c=wildfly14
+#   jBPM.casemgmt.url=https://origin-repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-wb-case-mgmt-showcase&v=${jBPM.version}&e=war&c=wildfly14
+jBPM.casemgmt.url=https://origin-repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-wb-case-mgmt-showcase&v=${jBPM.version}&e=war&c=wildfly14
 
 # the version of KIE Server you want to use
 # and the associated URL you want to get it from
 # for example: 
 #<RELEASE>
 # for Wildfly14 and EAP7:
-#   kie.server.url=http://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/server/kie-server/${jBPM.version}/kie-server-${jBPM.version}-ee7.war
+#   kie.server.url=https://origin-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/server/kie-server/${jBPM.version}/kie-server-${jBPM.version}-ee7.war
 # or:
 #<SNAPSHOT>
-#   kie.server.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=${jBPM.version}&e=war&c=ee7
-kie.server.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=${jBPM.version}&e=war&c=ee7
+#   kie.server.url=https://origin-repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=${jBPM.version}&e=war&c=ee7
+kie.server.url=https://origin-repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=${jBPM.version}&e=war&c=ee7
 
 # the version of jBPM and Drools Eclipse plugin you want to use
 # and the associated URL you want to get the dependencies from
 # for example: 
 #<RELEASE>
 #   droolsjbpm.eclipse.version=${release.version}
-#   droolsjbpm.eclipse.url=https://repository.jboss.org/nexus/content/groups/public-jboss/org/drools/org.drools.updatesite/${droolsjbpm.eclipse.version}/org.drools.updatesite-${droolsjbpm.eclipse.version}.zip
+#   droolsjbpm.eclipse.url=https://origin-repository.jboss.org/nexus/content/groups/public-jboss/org/drools/org.drools.updatesite/${droolsjbpm.eclipse.version}/org.drools.updatesite-${droolsjbpm.eclipse.version}.zip
 # or:
 #<SNAPSHOT>
 #   droolsjbpm.eclipse.version=${snapshot.version}
-#   droolsjbpm.eclipse.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=org.drools.updatesite&v=${droolsjbpm.eclipse.version}&e=zip
+#   droolsjbpm.eclipse.url=https://origin-repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=org.drools.updatesite&v=${droolsjbpm.eclipse.version}&e=zip
 droolsjbpm.eclipse.version=${snapshot.version}
-droolsjbpm.eclipse.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=org.drools.updatesite&v=${droolsjbpm.eclipse.version}&e=zip
+droolsjbpm.eclipse.url=https://origin-repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.drools&a=org.drools.updatesite&v=${droolsjbpm.eclipse.version}&e=zip
 
 # the home of your eclipse installation
 # will be used to deploy the Eclipse plugin to
@@ -88,7 +88,7 @@ eclipse.clean.workspace=true
 #   jboss.server.wildfly.version=14.0.1.Final
 #   jboss.server.version=wildfly-${jboss.server.wildfly.version}
 #   jboss.home=./${jboss.server.version}
-#   jboss.download.url=http://download.jboss.org/wildfly/${jboss.server.wildfly.version}/${jboss.server.version}.zip
+#   jboss.download.url=https://download.jboss.org/wildfly/${jboss.server.wildfly.version}/${jboss.server.version}.zip
 #   jboss.server.conf.dir=${jboss.home}/standalone/configuration
 #   jboss.server.deploy.dir=${jboss.home}/standalone/deployments
 #   jboss.server.data.dir=${jboss.home}/standalone/data
@@ -96,7 +96,7 @@ eclipse.clean.workspace=true
 jboss.server.wildfly.version=14.0.1.Final
 jboss.server.version=wildfly-${jboss.server.wildfly.version}
 jboss.home=./${jboss.server.version}
-jboss.download.url=http://download.jboss.org/wildfly/${jboss.server.wildfly.version}/${jboss.server.version}.zip
+jboss.download.url=https://download.jboss.org/wildfly/${jboss.server.wildfly.version}/${jboss.server.version}.zip
 jboss.server.conf.dir=${jboss.home}/standalone/configuration
 jboss.server.deploy.dir=${jboss.home}/standalone/deployments
 jboss.server.data.dir=${jboss.home}/standalone/data
@@ -114,17 +114,17 @@ db.driver.module.dir=${jboss.home}/modules/${db.driver.module.prefix}/main/
 H2.version=1.3.168
 db.name=h2
 db.driver.jar.name=h2-${H2.version}.jar
-db.driver.download.url=http://repo1.maven.org/maven2/com/h2database/h2/${H2.version}/h2-${H2.version}.jar
+db.driver.download.url=https://repo1.maven.org/maven2/com/h2database/h2/${H2.version}/h2-${H2.version}.jar
 #other options are:
 #mysql
 #  db.name=mysql
 #  db.driver.module.prefix=com/mysql
 #  db.driver.jar.name=mysql-connector-java-5.1.18.jar
-#  db.driver.download.url=https://repository.jboss.org/nexus/service/local/repositories/central/content/mysql/mysql-connector-java/5.1.18/mysql-connector-java-5.1.18.jar
+#  db.driver.download.url=https://origin-repository.jboss.org/nexus/service/local/repositories/central/content/mysql/mysql-connector-java/5.1.18/mysql-connector-java-5.1.18.jar
 #  org.kie.server.persistence.dialect=org.hibernate.dialect.MySQLDialect
 #postgresql
 #  db.name=postgresql
 #  db.driver.module.prefix=org/postgresql
 #  db.driver.jar.name=postgresql-9.1-902.jdbc4.jar
-#  db.driver.download.url=https://repository.jboss.org/nexus/content/repositories/thirdparty-uploads/postgresql/postgresql/9.1-902.jdbc4/postgresql-9.1-902.jdbc4.jar
+#  db.driver.download.url=https://origin-repository.jboss.org/nexus/content/repositories/thirdparty-uploads/postgresql/postgresql/9.1-902.jdbc4/postgresql-9.1-902.jdbc4.jar
 #  org.kie.server.persistence.dialect=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
from this version it seems that some URLs are not accessible any more.
Changed all left over http to https.
Changed https://repository.jboss.org/ to https://origin-repository.jboss.org/ since the origin-repository gets updated immediately.
Script was tested now and it works properly again.