### PR TITLE
[JBPM-8991] Allow for process initiator to be set using 'initiator' value from process data

### DIFF
--- a/jbpm-services/jbpm-kie-services/pom.xml
+++ b/jbpm-services/jbpm-kie-services/pom.xml
@@ -107,11 +107,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kie.server</groupId>
-      <artifactId>kie-server-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
     </dependency>

--- a/jbpm-services/jbpm-kie-services/pom.xml
+++ b/jbpm-services/jbpm-kie-services/pom.xml
@@ -107,6 +107,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
     </dependency>

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/audit/ServicesAwareAuditEventBuilder.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/audit/ServicesAwareAuditEventBuilder.java
@@ -31,7 +31,6 @@ import org.kie.api.event.process.ProcessNodeTriggeredEvent;
 import org.kie.api.event.process.ProcessStartedEvent;
 import org.kie.api.event.process.ProcessVariableChangedEvent;
 import org.kie.internal.identity.IdentityProvider;
-import org.kie.server.api.KieServerConstants;
 
 public class ServicesAwareAuditEventBuilder extends DefaultAuditEventBuilderImpl {
 
@@ -39,7 +38,7 @@ public class ServicesAwareAuditEventBuilder extends DefaultAuditEventBuilderImpl
 
     private String deploymentUnitId;
 
-    private final Boolean allowSetInitiator = Boolean.parseBoolean(System.getProperty(KieServerConstants.CFG_BYPASS_AUTH_USER, "false"));
+    private final Boolean allowSetInitiator = Boolean.parseBoolean(System.getProperty("org.kie.server.bypass.auth.user", "false"));
 
     public IdentityProvider getIdentityProvider() {
         return identityProvider;

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/audit/ServicesAwareAuditEventBuilder.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/audit/ServicesAwareAuditEventBuilder.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jbpm.kie.services.impl.audit;
 
 import java.util.Map;
@@ -34,14 +33,13 @@ import org.kie.api.event.process.ProcessVariableChangedEvent;
 import org.kie.internal.identity.IdentityProvider;
 import org.kie.server.api.KieServerConstants;
 
-
 public class ServicesAwareAuditEventBuilder extends DefaultAuditEventBuilderImpl {
 
-    private IdentityProvider identityProvider;    
-    
+    private IdentityProvider identityProvider;
+
     private String deploymentUnitId;
 
-    private final Boolean allowSetInitiator =  Boolean.parseBoolean(System.getProperty(KieServerConstants.CFG_BYPASS_AUTH_USER, "false"));
+    private final Boolean allowSetInitiator = Boolean.parseBoolean(System.getProperty(KieServerConstants.CFG_BYPASS_AUTH_USER, "false"));
 
     public IdentityProvider getIdentityProvider() {
         return identityProvider;
@@ -50,10 +48,10 @@ public class ServicesAwareAuditEventBuilder extends DefaultAuditEventBuilderImpl
     public void setIdentityProvider(IdentityProvider identityProvider) {
         this.identityProvider = identityProvider;
     }
-    
+
     @Override
     public AuditEvent buildEvent(ProcessStartedEvent pse) {
-        
+
         ProcessInstanceLog log = (ProcessInstanceLog) super.buildEvent(pse);
         log.setIdentity(getIdentity(pse));
         log.setExternalId(deploymentUnitId);
@@ -62,31 +60,30 @@ public class ServicesAwareAuditEventBuilder extends DefaultAuditEventBuilderImpl
 
     @Override
     public AuditEvent buildEvent(ProcessCompletedEvent pce, Object log) {
-        ProcessInstanceLog instanceLog = (ProcessInstanceLog) super.buildEvent(pce, log); 
+        ProcessInstanceLog instanceLog = (ProcessInstanceLog) super.buildEvent(pce, log);
         instanceLog.setExternalId(deploymentUnitId);
         return instanceLog;
-        
+
     }
 
     @Override
     public AuditEvent buildEvent(ProcessNodeTriggeredEvent pnte) {
-        NodeInstanceLog nodeInstanceLog = (NodeInstanceLog)super.buildEvent(pnte); 
+        NodeInstanceLog nodeInstanceLog = (NodeInstanceLog) super.buildEvent(pnte);
         nodeInstanceLog.setExternalId(deploymentUnitId);
         return nodeInstanceLog;
-        
-        
+
     }
 
     @Override
     public AuditEvent buildEvent(ProcessNodeLeftEvent pnle, Object log) {
-        NodeInstanceLog nodeInstanceLog = (NodeInstanceLog) super.buildEvent(pnle, log); 
+        NodeInstanceLog nodeInstanceLog = (NodeInstanceLog) super.buildEvent(pnle, log);
         nodeInstanceLog.setExternalId(deploymentUnitId);
         return nodeInstanceLog;
     }
 
     @Override
     public AuditEvent buildEvent(ProcessVariableChangedEvent pvce) {
-        VariableInstanceLog variableLog = (VariableInstanceLog)super.buildEvent(pvce); 
+        VariableInstanceLog variableLog = (VariableInstanceLog) super.buildEvent(pvce);
         variableLog.setExternalId(deploymentUnitId);
         return variableLog;
     }
@@ -100,8 +97,8 @@ public class ServicesAwareAuditEventBuilder extends DefaultAuditEventBuilderImpl
     }
 
     /**
-     * Utilitary method to get the identity to save on ProcessInstanceLog.
-     * It checks if bypass user authentication is set and if set, checks if the
+     * Utilitary method to get the identity to save on ProcessInstanceLog. It
+     * checks if bypass user authentication is set and if set, checks if the
      * value of initiator in process variables is set and uses it. Otherwise
      * will use the value from the identity provider.
      *

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/audit/ServicesAwareAuditEventBuilderTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/audit/ServicesAwareAuditEventBuilderTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.kie.services.impl.audit;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import org.drools.core.event.ProcessStartedEventImpl;
+import org.jbpm.kie.services.test.ProcessServiceImplTest;
+import org.jbpm.kie.test.util.AbstractKieServicesBaseTest;
+import org.jbpm.process.audit.ProcessInstanceLog;
+import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.process.instance.context.variable.VariableScopeInstance;
+import org.jbpm.process.instance.impl.ProcessInstanceImpl;
+import org.jbpm.workflow.core.WorkflowProcess;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.runner.RunWith;
+import org.kie.api.event.process.ProcessStartedEvent;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.process.CorrelationKey;
+import org.mockito.Mock;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServicesAwareAuditEventBuilderTest extends AbstractKieServicesBaseTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProcessServiceImplTest.class);
+
+    private Map<String, Object> processMetadata = new HashMap<>();
+
+    @Mock
+    ProcessInstanceImpl processInstance;
+
+    @Mock
+    KieSession kieRuntime;
+
+    @Mock
+    WorkflowProcess process;
+
+    @Mock
+    CorrelationKey correlationKey;
+
+    @Mock
+    VariableScopeInstance variableScope;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        processMetadata.put("CorrelationKey", correlationKey);
+
+        setUpMocks();
+    }
+
+    private void setUpMocks() {
+        when(kieRuntime.getIdentifier()).thenReturn(2L);
+
+        when(processInstance.getId()).thenReturn(1L);
+        when(processInstance.getDescription()).thenReturn("Some test Process");
+        when(processInstance.getSlaCompliance()).thenReturn(0);
+        when(processInstance.getSlaDueDate()).thenReturn(null);
+        when(processInstance.getMetaData()).thenReturn(processMetadata);
+
+        when(processInstance.getProcess()).thenReturn(process);
+        when(process.getProcessType()).thenReturn(WorkflowProcess.PROCESS_TYPE);
+        when(process.getName()).thenReturn("test-process");
+        when(process.getVersion()).thenReturn(VERSION);
+
+        when(processInstance.getContextInstance(eq(VariableScope.VARIABLE_SCOPE))).thenReturn(variableScope);
+        when(variableScope.getVariables()).thenReturn(processMetadata);
+
+        when(correlationKey.toExternalForm()).thenReturn("1");
+    }
+
+    /**
+     * Test build the ProcessInstanceLog for a regular process start
+     */
+    @Test
+    public void testBuildProcessStartedEvent() {
+        ServicesAwareAuditEventBuilder builder = new ServicesAwareAuditEventBuilder();
+        builder.setIdentityProvider(identityProvider);
+
+        ProcessStartedEvent pse = new ProcessStartedEventImpl(processInstance, kieRuntime);
+        ProcessInstanceLog log = (ProcessInstanceLog) builder.buildEvent(pse);
+
+        assertEquals("testUser", log.getIdentity());
+    }
+
+    /**
+     * Test build the ProcessInstanceLog for a process with initiator metadata
+     * and user auth bypasss not enabled
+     */
+    @Test
+    public void testBuildProcessStartedEventWithInitiatorAndNoUserAuthBypass() {
+
+        processMetadata.put("initiator", "john");
+
+        ServicesAwareAuditEventBuilder builder = new ServicesAwareAuditEventBuilder();
+        builder.setIdentityProvider(identityProvider);
+
+        ProcessStartedEvent pse = new ProcessStartedEventImpl(processInstance, kieRuntime);
+        ProcessInstanceLog log = (ProcessInstanceLog) builder.buildEvent(pse);
+
+        assertEquals("testUser", log.getIdentity());
+    }
+
+    /**
+     * Test build the ProcessInstanceLog for a process with initiator metadata
+     * and user auth bypasss enabled
+     */
+    @Test
+    public void testBuildProcessStartedEventWithInitiatorAndUserAuthBypassEnabled() {
+
+        processMetadata.put("initiator", "john");
+
+        ServicesAwareAuditEventBuilder builder = new ServicesAwareAuditEventBuilder();
+        builder.setIdentityProvider(identityProvider);
+
+        enableSetInitiator(builder);
+
+        ProcessStartedEvent pse = new ProcessStartedEventImpl(processInstance, kieRuntime);
+        ProcessInstanceLog log = (ProcessInstanceLog) builder.buildEvent(pse);
+
+        assertEquals("john", log.getIdentity());
+    }
+
+    private void enableSetInitiator(ServicesAwareAuditEventBuilder builder) {
+        try {
+            Field allowSetInitiatorField = builder.getClass().getDeclaredField("allowSetInitiator");
+            allowSetInitiatorField.setAccessible(true);
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(allowSetInitiatorField, allowSetInitiatorField.getModifiers() & ~Modifier.FINAL);
+            allowSetInitiatorField.set(builder, Boolean.TRUE);
+        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ex) {
+            // Tests will misbehave
+            throw new RuntimeException(ex);
+        }
+    }
+}


### PR DESCRIPTION
When bypassing user auth, ProcessEvent can now use 'initiator' from process data if set, when creating ProcessInstanceLog for ProcessStartedEvent.