### PR TITLE
[JBPM-8998] Missing SpringBoot support in NotificationListener

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/deadlines/notifications/impl/NotificationListenerManager.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/deadlines/notifications/impl/NotificationListenerManager.java
@@ -42,7 +42,13 @@ public class NotificationListenerManager {
     private NotificationListenerManager() {
         for (NotificationListener listener : listenersLoaded) {
             listeners.add(listener);
-        }        
+        }
+    }
+
+    public void registerAdditionalNotificationListener(List<NotificationListener> additionalNotificationListener) {
+        for (NotificationListener listener : additionalNotificationListener) {
+            listeners.add(listener);
+        }
     }
 
     /**


### PR DESCRIPTION
adding support for autodiscovering and registering new notification listeners