### PR TITLE
[RHPAM-2840] issue with afterTaskActivatedEvent method of TaskLifeCycleEventListener

### DIFF
--- a/jbpm-human-task/jbpm-human-task-audit/src/test/java/org/jbpm/services/task/audit/service/TaskAuditBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-audit/src/test/java/org/jbpm/services/task/audit/service/TaskAuditBaseTest.java
@@ -16,10 +16,6 @@
 
 package org.jbpm.services.task.audit.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -54,6 +50,10 @@ import org.kie.internal.task.api.TaskVariable.VariableType;
 import org.kie.internal.task.api.model.InternalTaskData;
 import org.kie.internal.task.api.model.TaskEvent;
 import org.kie.internal.task.api.model.TaskEvent.TaskEventType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public abstract class TaskAuditBaseTest extends HumanTaskServicesBaseTest {
 
@@ -117,7 +117,7 @@ public abstract class TaskAuditBaseTest extends HumanTaskServicesBaseTest {
         assertEquals("Darth Vader", task2.getTaskData().getActualOwner().getId());
 
         List<TaskEvent> allTaskEvents = taskService.execute(new GetAuditEventsCommand(taskId, new QueryFilter(0, 0)));
-        assertEquals(6, allTaskEvents.size());
+        assertEquals(7, allTaskEvents.size());
 
         // test DeleteAuditEventsCommand
         int numFirstTaskEvents = allTaskEvents.size();
@@ -138,7 +138,8 @@ public abstract class TaskAuditBaseTest extends HumanTaskServicesBaseTest {
 
         taskService.execute(new DeleteAuditEventsCommand(taskId));
         allTaskEvents = taskService.execute(new GetAuditEventsCommand());
-        assertEquals(numTaskEvents - numFirstTaskEvents, allTaskEvents.size());
+        // +2 activate events.
+        assertEquals(numTaskEvents - numFirstTaskEvents + 2, allTaskEvents.size());
 
         taskService.execute(new DeleteAuditEventsCommand());
         allTaskEvents = taskService.execute(new GetAuditEventsCommand());
@@ -1145,31 +1146,34 @@ public abstract class TaskAuditBaseTest extends HumanTaskServicesBaseTest {
 
         List<TaskEvent> taskEvents = taskAuditService.getAllTaskEvents(taskId, new QueryFilter());
 
-        Assertions.assertThat(taskEvents).hasSize(8);
+        Assertions.assertThat(taskEvents).hasSize(9);
 
         Assertions.assertThat(taskEvents.get(0).getType()).isEqualTo(TaskEventType.ADDED);
         Assertions.assertThat(taskEvents.get(0).getUserId()).isNull();
 
-        Assertions.assertThat(taskEvents.get(1).getType()).isEqualTo(TaskEventType.CLAIMED);
-        Assertions.assertThat(taskEvents.get(1).getUserId()).isEqualTo("Darth Vader");
+        Assertions.assertThat(taskEvents.get(1).getType()).isEqualTo(TaskEventType.ACTIVATED);
+        Assertions.assertThat(taskEvents.get(1).getUserId()).isNull();
 
-        Assertions.assertThat(taskEvents.get(2).getType()).isEqualTo(TaskEventType.RELEASED);
+        Assertions.assertThat(taskEvents.get(2).getType()).isEqualTo(TaskEventType.CLAIMED);
         Assertions.assertThat(taskEvents.get(2).getUserId()).isEqualTo("Darth Vader");
 
-        Assertions.assertThat(taskEvents.get(3).getType()).isEqualTo(TaskEventType.CLAIMED);
+        Assertions.assertThat(taskEvents.get(3).getType()).isEqualTo(TaskEventType.RELEASED);
         Assertions.assertThat(taskEvents.get(3).getUserId()).isEqualTo("Darth Vader");
 
-        Assertions.assertThat(taskEvents.get(4).getType()).isEqualTo(TaskEventType.STARTED);
+        Assertions.assertThat(taskEvents.get(4).getType()).isEqualTo(TaskEventType.CLAIMED);
         Assertions.assertThat(taskEvents.get(4).getUserId()).isEqualTo("Darth Vader");
 
-        Assertions.assertThat(taskEvents.get(5).getType()).isEqualTo(TaskEventType.STOPPED);
+        Assertions.assertThat(taskEvents.get(5).getType()).isEqualTo(TaskEventType.STARTED);
         Assertions.assertThat(taskEvents.get(5).getUserId()).isEqualTo("Darth Vader");
 
-        Assertions.assertThat(taskEvents.get(6).getType()).isEqualTo(TaskEventType.STARTED);
+        Assertions.assertThat(taskEvents.get(6).getType()).isEqualTo(TaskEventType.STOPPED);
         Assertions.assertThat(taskEvents.get(6).getUserId()).isEqualTo("Darth Vader");
 
-        Assertions.assertThat(taskEvents.get(7).getType()).isEqualTo(TaskEventType.COMPLETED);
+        Assertions.assertThat(taskEvents.get(7).getType()).isEqualTo(TaskEventType.STARTED);
         Assertions.assertThat(taskEvents.get(7).getUserId()).isEqualTo("Darth Vader");
+
+        Assertions.assertThat(taskEvents.get(8).getType()).isEqualTo(TaskEventType.COMPLETED);
+        Assertions.assertThat(taskEvents.get(8).getUserId()).isEqualTo("Darth Vader");
     }
 
     @Test
@@ -1366,25 +1370,28 @@ public abstract class TaskAuditBaseTest extends HumanTaskServicesBaseTest {
 
         List<TaskEvent> taskEvents = taskAuditService.getAllTaskEvents(taskId, new QueryFilter());
 
-        Assertions.assertThat(taskEvents).hasSize(6);
+        Assertions.assertThat(taskEvents).hasSize(7);
 
         Assertions.assertThat(taskEvents.get(0).getType()).isEqualTo(TaskEventType.ADDED);
         Assertions.assertThat(taskEvents.get(0).getUserId()).isNull();
 
-        Assertions.assertThat(taskEvents.get(1).getType()).isEqualTo(TaskEventType.CLAIMED);
-        Assertions.assertThat(taskEvents.get(1).getUserId()).isEqualTo("Darth Vader");
+        Assertions.assertThat(taskEvents.get(1).getType()).isEqualTo(TaskEventType.ACTIVATED);
+        Assertions.assertThat(taskEvents.get(1).getUserId()).isNull();
 
-        Assertions.assertThat(taskEvents.get(2).getType()).isEqualTo(TaskEventType.STARTED);
+        Assertions.assertThat(taskEvents.get(2).getType()).isEqualTo(TaskEventType.CLAIMED);
         Assertions.assertThat(taskEvents.get(2).getUserId()).isEqualTo("Darth Vader");
-        // first update of data explicitly
-        Assertions.assertThat(taskEvents.get(3).getType()).isEqualTo(TaskEventType.UPDATED);
+
+        Assertions.assertThat(taskEvents.get(3).getType()).isEqualTo(TaskEventType.STARTED);
         Assertions.assertThat(taskEvents.get(3).getUserId()).isEqualTo("Darth Vader");
-        // next update of data through complete
+        // first update of data explicitly
         Assertions.assertThat(taskEvents.get(4).getType()).isEqualTo(TaskEventType.UPDATED);
         Assertions.assertThat(taskEvents.get(4).getUserId()).isEqualTo("Darth Vader");
-
-        Assertions.assertThat(taskEvents.get(5).getType()).isEqualTo(TaskEventType.COMPLETED);
+        // next update of data through complete
+        Assertions.assertThat(taskEvents.get(5).getType()).isEqualTo(TaskEventType.UPDATED);
         Assertions.assertThat(taskEvents.get(5).getUserId()).isEqualTo("Darth Vader");
+
+        Assertions.assertThat(taskEvents.get(6).getType()).isEqualTo(TaskEventType.COMPLETED);
+        Assertions.assertThat(taskEvents.get(6).getUserId()).isEqualTo("Darth Vader");
     }
 
     @Test
@@ -1406,18 +1413,21 @@ public abstract class TaskAuditBaseTest extends HumanTaskServicesBaseTest {
 
         List<TaskEvent> taskEvents = taskAuditService.getAllTaskEvents(taskId, new QueryFilter());
 
-        Assertions.assertThat(taskEvents).hasSize(3);
+        Assertions.assertThat(taskEvents).hasSize(4);
 
         Assertions.assertThat(taskEvents.get(0).getType()).isEqualTo(TaskEventType.ADDED);
         Assertions.assertThat(taskEvents.get(0).getUserId()).isNull();
 
-        Assertions.assertThat(taskEvents.get(1).getType()).isEqualTo(TaskEventType.CLAIMED);
-        Assertions.assertThat(taskEvents.get(1).getUserId()).isEqualTo("Administrator");
+        Assertions.assertThat(taskEvents.get(1).getType()).isEqualTo(TaskEventType.ACTIVATED);
+        Assertions.assertThat(taskEvents.get(1).getUserId()).isNull();
 
-        Assertions.assertThat(taskEvents.get(2).getType()).isEqualTo(TaskEventType.FORWARDED);
+        Assertions.assertThat(taskEvents.get(2).getType()).isEqualTo(TaskEventType.CLAIMED);
         Assertions.assertThat(taskEvents.get(2).getUserId()).isEqualTo("Administrator");
-        Assertions.assertThat(taskEvents.get(2).getMessage()).isNotNull();
-        Assertions.assertThat(taskEvents.get(2).getMessage()).contains("Darth Vader");
+
+        Assertions.assertThat(taskEvents.get(3).getType()).isEqualTo(TaskEventType.FORWARDED);
+        Assertions.assertThat(taskEvents.get(3).getUserId()).isEqualTo("Administrator");
+        Assertions.assertThat(taskEvents.get(3).getMessage()).isNotNull();
+        Assertions.assertThat(taskEvents.get(3).getMessage()).contains("Darth Vader");
     }
 
     @Test
@@ -1431,7 +1441,7 @@ public abstract class TaskAuditBaseTest extends HumanTaskServicesBaseTest {
         long taskId = task.getId();
 
         List<TaskEvent> taskEvents = taskAuditService.getAllTaskEvents(taskId, new QueryFilter());
-        Assertions.assertThat(taskEvents).hasSize(1);
+        Assertions.assertThat(taskEvents).hasSize(2);
         Assertions.assertThat(taskEvents.get(0).getType()).isEqualTo(TaskEventType.ADDED);
         Assertions.assertThat(taskEvents.get(0).getUserId()).isNull();
 

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/commands/AddTaskCommand.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/commands/AddTaskCommand.java
@@ -15,7 +15,6 @@
  */
 package org.jbpm.services.task.commands;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -38,14 +37,12 @@ import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.Status;
 import org.kie.api.task.model.Task;
 import org.kie.api.task.model.User;
-import org.kie.internal.task.api.TaskDeadlinesService;
 import org.kie.internal.task.api.TaskDeadlinesService.DeadlineType;
 import org.kie.internal.task.api.model.ContentData;
-import org.kie.internal.task.api.model.Deadline;
-import org.kie.internal.task.api.model.Deadlines;
 import org.kie.internal.task.api.model.InternalPeopleAssignments;
 import org.kie.internal.task.api.model.InternalTask;
 import org.kie.internal.task.api.model.InternalTaskData;
+import org.kie.internal.task.api.model.Operation;
 
 /**
  * Operation.Start : [ new OperationCommand().{ status = [ Status.Ready ],
@@ -118,6 +115,11 @@ public class AddTaskCommand extends UserGroupCallbackTaskCommand<Long> {
         } else {
             
         	taskId = context.getTaskInstanceService().addTask(taskImpl, params);
+        }
+
+        // if the status is different from created it means it has been activated in the middle
+        if (!Status.Created.equals(taskImpl.getTaskData().getStatus())) {
+            context.getTaskInstanceService().fireEvent(Operation.Activate, task.getId());
         }
 
         DeadlineSchedulerHelper.scheduleDeadlinesForTask((InternalTask) taskImpl, context, DeadlineType.values());

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/TaskInstanceServiceImpl.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/TaskInstanceServiceImpl.java
@@ -497,6 +497,17 @@ public class TaskInstanceServiceImpl implements TaskInstanceService {
         ((InternalTask)task).setFormName((String) replacements.get("formName"));
     }
 
-
+    @Override
+    public void fireEvent(Operation operation, long taskId) {
+        Task task = context.getPersistenceContext().findTask(taskId);
+        switch (operation) {
+            case Activate:
+                this.taskEventSupport.fireBeforeTaskActivated(task, context);
+                this.taskEventSupport.fireAfterTaskActivated(task, context);
+                break;
+            default:
+                break;
+        }
+    }
 
 }

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/admin/UserTaskAdminServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/admin/UserTaskAdminServiceImplTest.java
@@ -16,12 +16,6 @@
 
 package org.jbpm.kie.services.impl.admin;
 
-import static org.jbpm.services.api.query.QueryResultMapper.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.kie.scanner.KieMavenRepository.getKieMavenRepository;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
@@ -50,8 +44,8 @@ import org.jbpm.services.api.admin.UserTaskAdminService;
 import org.jbpm.services.api.model.DeploymentUnit;
 import org.jbpm.services.api.model.UserTaskInstanceDesc;
 import org.jbpm.services.api.query.model.QueryDefinition;
-import org.jbpm.services.api.query.model.QueryParam;
 import org.jbpm.services.api.query.model.QueryDefinition.Target;
+import org.jbpm.services.api.query.model.QueryParam;
 import org.jbpm.shared.services.impl.TransactionalCommandService;
 import org.junit.After;
 import org.junit.Before;
@@ -74,6 +68,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.jbpm.services.api.query.QueryResultMapper.COLUMN_NAME;
+import static org.jbpm.services.api.query.QueryResultMapper.COLUMN_TASKID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.kie.scanner.KieMavenRepository.getKieMavenRepository;
 
 public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
 
@@ -235,8 +235,8 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         userTaskAdminService.addPotentialOwners(task.getId(), false, factory.newUser("john"));
         
         List<TaskEvent> events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
-        Assertions.assertThat(events).hasSize(3);
-        TaskEvent updatedEvent = events.get(2);
+        Assertions.assertThat(events).hasSize(4);
+        TaskEvent updatedEvent = events.get(3);
         Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Potential owners [john] have been added");
         
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("salaboy", new QueryFilter());
@@ -283,8 +283,8 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         
         userTaskAdminService.addExcludedOwners(task.getId(), false, factory.newUser("salaboy"));
         List<TaskEvent> events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
-        Assertions.assertThat(events).hasSize(3);
-        TaskEvent updatedEvent = events.get(2);
+        Assertions.assertThat(events).hasSize(4);
+        TaskEvent updatedEvent = events.get(3);
         Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Excluded owners [salaboy] have been added");
         
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("salaboy", new QueryFilter());
@@ -315,8 +315,8 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         
         userTaskAdminService.addBusinessAdmins(task.getId(), false, factory.newUser("salaboy"));
         List<TaskEvent> events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
-        Assertions.assertThat(events).hasSize(3);
-        TaskEvent updatedEvent = events.get(2);
+        Assertions.assertThat(events).hasSize(4);
+        TaskEvent updatedEvent = events.get(3);
         Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Business administrators [salaboy] have been added");
         
         tasks = runtimeDataService.getTasksAssignedAsBusinessAdministrator("salaboy", new QueryFilter());
@@ -344,8 +344,8 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         
         userTaskAdminService.removePotentialOwners(task.getId(), factory.newUser("salaboy"));
         List<TaskEvent> events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
-        Assertions.assertThat(events).hasSize(3);
-        TaskEvent updatedEvent = events.get(2);
+        Assertions.assertThat(events).hasSize(4);
+        TaskEvent updatedEvent = events.get(3);
         Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Potential owners [salaboy] have been removed");
         
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("salaboy", new QueryFilter());
@@ -365,8 +365,8 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         
         userTaskAdminService.addExcludedOwners(task.getId(), false, factory.newUser("salaboy"));
         List<TaskEvent> events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
-        Assertions.assertThat(events).hasSize(3);
-        TaskEvent updatedEvent = events.get(2);
+        Assertions.assertThat(events).hasSize(4);
+        TaskEvent updatedEvent = events.get(3);
         Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Excluded owners [salaboy] have been added");
         
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("salaboy", new QueryFilter());
@@ -374,8 +374,8 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         
         userTaskAdminService.removeExcludedOwners(task.getId(), factory.newUser("salaboy"));
         events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
-        Assertions.assertThat(events).hasSize(4);
-        updatedEvent = events.get(3);
+        Assertions.assertThat(events).hasSize(5);
+        updatedEvent = events.get(4);
         Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Excluded owners [salaboy] have been removed");
         
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("salaboy", new QueryFilter());
@@ -393,8 +393,8 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         
         userTaskAdminService.removeBusinessAdmins(task.getId(), factory.newUser("Administrator"));
         List<TaskEvent> events = runtimeDataService.getTaskEvents(task.getId(), new QueryFilter());
-        Assertions.assertThat(events).hasSize(2);
-        TaskEvent updatedEvent = events.get(1);
+        Assertions.assertThat(events).hasSize(3);
+        TaskEvent updatedEvent = events.get(2);
         Assertions.assertThat(updatedEvent.getMessage()).isEqualTo("Business administrators [Administrator] have been removed");
 
         List<Status> readyStatuses = Arrays.asList(new Status[]{

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/RuntimeDataServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/RuntimeDataServiceImplTest.java
@@ -1333,16 +1333,17 @@ public class RuntimeDataServiceImplTest extends AbstractKieServicesBaseTest {
 
     	List<TaskEvent> auditTasks = runtimeDataService.getTaskEvents(userTask.getTaskId(), new QueryFilter());
     	assertNotNull(auditTasks);
-    	assertEquals(1, auditTasks.size());
+        assertEquals(2, auditTasks.size());
     	assertEquals(TaskEvent.TaskEventType.ADDED, auditTasks.get(0).getType());
 
     	userTaskService.start(userTask.getTaskId(), "salaboy");
 
     	auditTasks = runtimeDataService.getTaskEvents(userTask.getTaskId(), new QueryFilter());
     	assertNotNull(auditTasks);
-    	assertEquals(2, auditTasks.size());
+        assertEquals(3, auditTasks.size());
     	assertEquals(TaskEvent.TaskEventType.ADDED, auditTasks.get(0).getType());
-    	assertEquals(TaskEvent.TaskEventType.STARTED, auditTasks.get(1).getType());
+        assertEquals(TaskEvent.TaskEventType.ACTIVATED, auditTasks.get(1).getType());
+        assertEquals(TaskEvent.TaskEventType.STARTED, auditTasks.get(2).getType());
     	
     	QueryFilter filter = new QueryFilter();
     	filter.setFilterParams("t.type = :type ");

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/UserTaskInstanceWithPotOwnerTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/UserTaskInstanceWithPotOwnerTest.java
@@ -271,16 +271,16 @@ public class UserTaskInstanceWithPotOwnerTest extends AbstractKieServicesBaseTes
     public void testSearchTaskWithModifVarsMapper() {
         query = new SqlQueryDefinition("jbpmGetTaskWithPO", dataSourceJNDIname);
         query.setExpression("select t.id as TASKID, t.name as NAME,  t.FORMNAME AS FORMNAME, t.subject as SUBJECT, " +
-                "t.actualowner_id as ACTUALOWNER, po.entity_id as POTOWNER, p.processinstancedescription as PROCESSINSTANCEDESCRIPTION, t.CREATEDON as CREATEDON, " +
-                "t.CREATEDBY_ID as CREATEDBY, t.EXPIRATIONTIME as EXPIRATIONTIME, " +
-                "(select max(logtime) from taskevent where processinstanceid = t.processinstanceid and taskid = t.id) as lastmodificationdate, " +
-                "(select userid from taskevent where logtime = (select max(logtime) from taskevent where processinstanceid = t.processinstanceid and taskid = t.id)) as lastmodificationuser, " +
-                "t.priority as PRIORITY, t.STATUS as STATUS, t.PROCESSINSTANCEID as PROCESSINSTANCEID, t.PROCESSID as PROCESSID, " +
-                "t.deploymentid as DEPLOYMENTID, d.name as TVNAME, d.type as TVTYPE, d.value as TVVALUE " +
-                "from TASK t " +
-                "inner join PEOPLEASSIGNMENTS_POTOWNERS po on t.id=po.task_id " +
-                "inner join PROCESSINSTANCELOG p on t.processinstanceid = p.processinstanceid " +
-                "inner join TASKVARIABLEIMPL d on t.id=d.taskid");
+                            "t.actualowner_id as ACTUALOWNER, po.entity_id as POTOWNER, p.processinstancedescription as PROCESSINSTANCEDESCRIPTION, t.CREATEDON as CREATEDON, " +
+                            "t.CREATEDBY_ID as CREATEDBY, t.EXPIRATIONTIME as EXPIRATIONTIME, " +
+                            "(select max(logtime) from taskevent where processinstanceid = t.processinstanceid and taskid = t.id) as lastmodificationdate, " +
+                            "(select a.userid from taskevent a left join taskevent b on a.id < b.id where b.id IS NULL) as lastmodificationuser, " +
+                            "t.priority as PRIORITY, t.STATUS as STATUS, t.PROCESSINSTANCEID as PROCESSINSTANCEID, t.PROCESSID as PROCESSID, " +
+                            "t.deploymentid as DEPLOYMENTID, d.name as TVNAME, d.type as TVTYPE, d.value as TVVALUE " +
+                            "from TASK t " +
+                            "inner join PEOPLEASSIGNMENTS_POTOWNERS po on t.id=po.task_id " +
+                            "inner join PROCESSINSTANCELOG p on t.processinstanceid = p.processinstanceid " +
+                            "inner join TASKVARIABLEIMPL d on t.id=d.taskid");
 
         queryService.registerQuery(query);
 

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/UserTaskServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/UserTaskServiceImplTest.java
@@ -857,23 +857,25 @@ private static final Logger logger = LoggerFactory.getLogger(KModuleDeploymentSe
     
         List<TaskEvent> auditTasks = runtimeDataService.getTaskEvents(taskId, new QueryFilter());
         assertNotNull(auditTasks);
-        assertEquals(2, auditTasks.size());
+        assertEquals(3, auditTasks.size());
         assertEquals(TaskEvent.TaskEventType.ADDED, auditTasks.get(0).getType());
         assertEquals("org.jbpm.writedocument", auditTasks.get(0).getUserId());
-        assertEquals(TaskEvent.TaskEventType.STARTED, auditTasks.get(1).getType());
-        assertEquals("salaboy", auditTasks.get(1).getUserId());
+        assertEquals(TaskEvent.TaskEventType.ACTIVATED, auditTasks.get(1).getType());
+        assertEquals(TaskEvent.TaskEventType.STARTED, auditTasks.get(2).getType());
+        assertEquals("salaboy", auditTasks.get(2).getUserId());
         
         identityProvider.setName("salaboy");
         userTaskService.stop(taskId, null);
         
         auditTasks = runtimeDataService.getTaskEvents(taskId, new QueryFilter());
         assertNotNull(auditTasks);
-        assertEquals(3, auditTasks.size());
+        assertEquals(4, auditTasks.size());
         assertEquals(TaskEvent.TaskEventType.ADDED, auditTasks.get(0).getType());
         assertEquals("org.jbpm.writedocument", auditTasks.get(0).getUserId());
-        assertEquals(TaskEvent.TaskEventType.STARTED, auditTasks.get(1).getType());
-        assertEquals("salaboy", auditTasks.get(1).getUserId());
-        assertEquals(TaskEvent.TaskEventType.STOPPED, auditTasks.get(2).getType());
+        assertEquals(TaskEvent.TaskEventType.ACTIVATED, auditTasks.get(1).getType());
+        assertEquals(TaskEvent.TaskEventType.STARTED, auditTasks.get(2).getType());
+        assertEquals("salaboy", auditTasks.get(2).getUserId());
+        assertEquals(TaskEvent.TaskEventType.STOPPED, auditTasks.get(3).getType());
         assertEquals("salaboy", auditTasks.get(2).getUserId());
         
         Map<String, Object> params = new HashMap<>();
@@ -882,15 +884,16 @@ private static final Logger logger = LoggerFactory.getLogger(KModuleDeploymentSe
         
         auditTasks = runtimeDataService.getTaskEvents(taskId, new QueryFilter());
         assertNotNull(auditTasks);
-        assertEquals(4, auditTasks.size());
+        assertEquals(5, auditTasks.size());
         assertEquals(TaskEvent.TaskEventType.ADDED, auditTasks.get(0).getType());
         assertEquals("org.jbpm.writedocument", auditTasks.get(0).getUserId());
-        assertEquals(TaskEvent.TaskEventType.STARTED, auditTasks.get(1).getType());
-        assertEquals("salaboy", auditTasks.get(1).getUserId());
-        assertEquals(TaskEvent.TaskEventType.STOPPED, auditTasks.get(2).getType());
+        assertEquals(TaskEvent.TaskEventType.ACTIVATED, auditTasks.get(1).getType());
+        assertEquals(TaskEvent.TaskEventType.STARTED, auditTasks.get(2).getType());
         assertEquals("salaboy", auditTasks.get(2).getUserId());
-        assertEquals(TaskEvent.TaskEventType.UPDATED, auditTasks.get(3).getType());
+        assertEquals(TaskEvent.TaskEventType.STOPPED, auditTasks.get(3).getType());
         assertEquals("salaboy", auditTasks.get(3).getUserId());
+        assertEquals(TaskEvent.TaskEventType.UPDATED, auditTasks.get(4).getType());
+        assertEquals("salaboy", auditTasks.get(4).getUserId());
     
         identityProvider.setName("testUser");
         processService.abortProcessInstance(processInstanceId);

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/support/SupportProcessBaseTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/support/SupportProcessBaseTest.java
@@ -129,7 +129,7 @@ public abstract class SupportProcessBaseTest extends AbstractKieServicesBaseTest
         TaskService taskService = engine.getTaskService();
         
         currentNumberOfEvents = DebugTaskLifeCycleEventListener.getEventCounter();
-        assertEquals(2, currentNumberOfEvents);
+        assertEquals(4, currentNumberOfEvents);
         
         // Configure Release
         List<TaskSummary> tasksAssignedToSalaboy = taskService.getTasksAssignedAsPotentialOwner("salaboy", "en-UK");
@@ -143,7 +143,7 @@ public abstract class SupportProcessBaseTest extends AbstractKieServicesBaseTest
         taskService.start(createSupportTask.getId(), "salaboy");
         
         currentNumberOfEvents = DebugTaskLifeCycleEventListener.getEventCounter();
-        assertEquals(4, currentNumberOfEvents);
+        assertEquals(6, currentNumberOfEvents);
 
 
         Map<String, Object> taskContent = ((InternalTaskService) taskService).getTaskContent(createSupportTask.getId());
@@ -164,7 +164,7 @@ public abstract class SupportProcessBaseTest extends AbstractKieServicesBaseTest
         taskService.complete(createSupportTask.getId(), "salaboy", output);
         
         currentNumberOfEvents = DebugTaskLifeCycleEventListener.getEventCounter();
-        assertEquals(8, currentNumberOfEvents);
+        assertEquals(12, currentNumberOfEvents);
 
         tasksAssignedToSalaboy = taskService.getTasksAssignedAsPotentialOwner("salaboy", "en-UK");
         assertEquals(1, tasksAssignedToSalaboy.size());
@@ -176,12 +176,12 @@ public abstract class SupportProcessBaseTest extends AbstractKieServicesBaseTest
         taskService.start(resolveSupportTask.getId(), "salaboy");
         
         currentNumberOfEvents = DebugTaskLifeCycleEventListener.getEventCounter();
-        assertEquals(10, currentNumberOfEvents);
+        assertEquals(14, currentNumberOfEvents);
 
         taskService.complete(resolveSupportTask.getId(), "salaboy", null);
         
         currentNumberOfEvents = DebugTaskLifeCycleEventListener.getEventCounter();
-        assertEquals(14, currentNumberOfEvents);
+        assertEquals(20, currentNumberOfEvents);
 
 
         tasksAssignedToSalaboy = taskService.getTasksAssignedAsPotentialOwner("salaboy", "en-UK");
@@ -194,14 +194,14 @@ public abstract class SupportProcessBaseTest extends AbstractKieServicesBaseTest
         taskService.start(notifySupportTask.getId(), "salaboy");
         
         currentNumberOfEvents = DebugTaskLifeCycleEventListener.getEventCounter();
-        assertEquals(16, currentNumberOfEvents);
+        assertEquals(22, currentNumberOfEvents);
         
         output = new HashMap<String, Object>();
         output.put("output_solution", "solved today");
         taskService.complete(notifySupportTask.getId(), "salaboy", output);
         
         currentNumberOfEvents = DebugTaskLifeCycleEventListener.getEventCounter();
-        assertEquals(18, currentNumberOfEvents);
+        assertEquals(24, currentNumberOfEvents);
 
 
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/TaskLogCleanTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/TaskLogCleanTest.java
@@ -37,7 +37,6 @@ import org.kie.api.task.model.Status;
 import org.kie.api.task.model.Task;
 import org.kie.internal.task.api.AuditTask;
 import org.kie.internal.task.api.TaskVariable;
-
 import qa.tools.ikeeper.annotation.BZ;
 
 /**
@@ -232,11 +231,12 @@ public class TaskLogCleanTest extends JbpmTestCase {
                 .build()
                 .execute();
         // Changes are as follows (see https://docs.jboss.org/jbpm/v6.1/userguide/jBPMTaskService.html#jBPMTaskLifecycle):
-        // 1) Created -> Ready (automatic change because there are multiple actors)
-        // 2) Ready -> Reserved (by claim)
-        // 3) Reserved -> In Progress (by start)
-        // 4) In Progress -> Completed (by complete)
-        Assertions.assertThat(resultCount).isEqualTo(4);
+        // 1) Created -> Activated (virtual)
+        // 2) Activated ->  Ready (automatic change because there are multiple actors)
+        // 3) Ready -> Reserved (by claim)
+        // 4) Reserved -> In Progress (by start)
+        // 5) In Progress -> Completed (by complete)
+        Assertions.assertThat(resultCount).isEqualTo(5);
     }
     
     @Test

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/task/HumanTaskTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/task/HumanTaskTest.java
@@ -16,29 +16,35 @@
 
 package org.jbpm.test.regression.task;
 
-import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggered;
-import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggeredAndLeft;
-import static org.junit.Assert.*;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import javax.persistence.EntityManagerFactory;
 
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.assertj.core.api.Assertions;
+import org.jbpm.services.task.events.DefaultTaskEventListener;
 import org.jbpm.test.JbpmTestCase;
 import org.jbpm.test.listener.TrackingProcessEventListener;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.api.task.TaskEvent;
+import org.kie.api.task.TaskLifeCycleEventListener;
 import org.kie.api.task.TaskService;
 import org.kie.api.task.model.Status;
 import org.kie.api.task.model.Task;
 import org.kie.api.task.model.TaskSummary;
-
+import org.kie.internal.task.api.EventService;
 import qa.tools.ikeeper.annotation.BZ;
+
+import static java.util.Collections.emptyMap;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggered;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggeredAndLeft;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class HumanTaskTest extends JbpmTestCase {
 
@@ -62,6 +68,9 @@ public class HumanTaskTest extends JbpmTestCase {
 
     private static final String INPUT_TRANSFORMATION = "org/jbpm/test/regression/task/HumanTask-inputTransformation.bpmn2";
     private static final String INPUT_TRANSFORMATION_ID = "org.jbpm.test.regression.task.HumanTask-inputTransformation";
+
+    private static final String HUMAN_TASK_LISTENER = "org/jbpm/test/regression/task/HumanTask-Listener.bpmn2";
+    private static final String HUMAN_TASK_LISTENER_ID = "org.jbpm.test.regression.task.HumanTask-Listener";
 
     @Test
     @BZ("958397")
@@ -230,4 +239,31 @@ public class HumanTaskTest extends JbpmTestCase {
         assertProcessInstanceCompleted(pi.getId());
     }
 
+    @Test
+    public void testHumanTaskListener() {
+        KieSession ksession = createKSession(HUMAN_TASK_LISTENER);
+        MutableInt triggered = new MutableInt(0);
+        TaskLifeCycleEventListener listener = new DefaultTaskEventListener() {
+            @Override
+            public void afterTaskActivatedEvent(TaskEvent event) {
+                triggered.increment();
+            }
+
+        };
+        RuntimeEngine engine = getRuntimeEngine();
+        TaskService taskService = engine.getTaskService();
+        ((EventService<TaskLifeCycleEventListener>) taskService).registerTaskEventListener(listener);
+        ProcessInstance pi = ksession.startProcess(HUMAN_TASK_LISTENER_ID);
+        long processInstanceId = pi.getId();
+
+        List<Long> idList = taskService.getTasksByProcessInstanceId(processInstanceId);
+        for (long taskId : idList) {
+            taskService.start(taskId, "john");
+            taskService.complete(taskId, "john", emptyMap());
+        }
+        assertEquals((int) 2, (int) triggered.getValue());
+
+        ksession.abortProcessInstance(processInstanceId);
+        assertProcessInstanceAborted(processInstanceId);
+    }
 }

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/regression/task/HumanTask-Listener.bpmn2
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/regression/task/HumanTask-Listener.bpmn2
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_eq_ZkGhiEeqRIbB9YdC0SQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_appIdItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_tpItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_stageItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_subStageItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_jurisdictionWithItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_allocationStatusItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_allocationTypeItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_PriorityInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_CommentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_DescriptionInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_CreatedByInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_TaskNameInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_GroupIdInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_ContentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_NotStartedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_NotCompletedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_NotStartedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_NotCompletedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_appIdInputXItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_tpInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__4696E1F0-0A95-4C51-B601-FBF49A899D11_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__4696E1F0-0A95-4C51-B601-FBF49A899D11_PriorityInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__4696E1F0-0A95-4C51-B601-FBF49A899D11_CommentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__4696E1F0-0A95-4C51-B601-FBF49A899D11_DescriptionInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__4696E1F0-0A95-4C51-B601-FBF49A899D11_CreatedByInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__4696E1F0-0A95-4C51-B601-FBF49A899D11_TaskNameInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__4696E1F0-0A95-4C51-B601-FBF49A899D11_GroupIdInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__4696E1F0-0A95-4C51-B601-FBF49A899D11_ContentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__4696E1F0-0A95-4C51-B601-FBF49A899D11_NotStartedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__4696E1F0-0A95-4C51-B601-FBF49A899D11_NotCompletedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__4696E1F0-0A95-4C51-B601-FBF49A899D11_NotStartedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__4696E1F0-0A95-4C51-B601-FBF49A899D11_NotCompletedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:process id="org.jbpm.test.regression.task.HumanTask-Listener" drools:packageName="org.jbpm.test.regression.task" drools:version="1.0" drools:adHoc="false" name="TestProcess" isExecutable="true">
+    <bpmn2:sequenceFlow id="_99C505A7-2B8C-4A30-A845-A87BC62986B6" sourceRef="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA" targetRef="_4696E1F0-0A95-4C51-B601-FBF49A899D11">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_99027D7C-CB12-4BD7-AB46-E0BD6651AC33" sourceRef="_782F2FFB-4A45-4957-BA1F-C1920469443D" targetRef="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_9FCB7855-B5AA-4A1B-B133-A7B4EB0A48AB" sourceRef="_4696E1F0-0A95-4C51-B601-FBF49A899D11" targetRef="_E158C414-E636-4D22-A59E-35694EC0CEB7">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:userTask id="_4696E1F0-0A95-4C51-B601-FBF49A899D11" name="Task 2">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task 2]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_99C505A7-2B8C-4A30-A845-A87BC62986B6</bpmn2:incoming>
+      <bpmn2:outgoing>_9FCB7855-B5AA-4A1B-B133-A7B4EB0A48AB</bpmn2:outgoing>
+      <bpmn2:potentialOwner id="_ea6fadb5-b5f6-4dff-ac40-500ef5f58150">
+        <bpmn2:resourceAssignmentExpression id="_eq_ZpGhiEeqRIbB9YdC0SQ">
+          <bpmn2:formalExpression id="_eq_ZpWhiEeqRIbB9YdC0SQ">john</bpmn2:formalExpression>
+        </bpmn2:resourceAssignmentExpression>
+      </bpmn2:potentialOwner>
+    </bpmn2:userTask>
+    <bpmn2:startEvent id="_782F2FFB-4A45-4957-BA1F-C1920469443D">
+      <bpmn2:outgoing>_99027D7C-CB12-4BD7-AB46-E0BD6651AC33</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:userTask id="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA" name="Task">
+      <bpmn2:documentation id="_eq_ZpmhiEeqRIbB9YdC0SQ"><![CDATA[Abc]]></bpmn2:documentation>
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_99027D7C-CB12-4BD7-AB46-E0BD6651AC33</bpmn2:incoming>
+      <bpmn2:outgoing>_99C505A7-2B8C-4A30-A845-A87BC62986B6</bpmn2:outgoing>
+      <bpmn2:potentialOwner id="_1e5e4421-0243-40da-851f-ac290e782fa3">
+        <bpmn2:resourceAssignmentExpression id="_eq_ZxGhiEeqRIbB9YdC0SQ">
+          <bpmn2:formalExpression id="_eq_ZxWhiEeqRIbB9YdC0SQ">john</bpmn2:formalExpression>
+        </bpmn2:resourceAssignmentExpression>
+      </bpmn2:potentialOwner>
+    </bpmn2:userTask>
+    <bpmn2:endEvent id="_E158C414-E636-4D22-A59E-35694EC0CEB7">
+      <bpmn2:incoming>_9FCB7855-B5AA-4A1B-B133-A7B4EB0A48AB</bpmn2:incoming>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_eq_ZxmhiEeqRIbB9YdC0SQ">
+    <bpmndi:BPMNPlane id="_eq_Zx2hiEeqRIbB9YdC0SQ" bpmnElement="abc.TestProcess">
+      <bpmndi:BPMNShape id="shape__E158C414-E636-4D22-A59E-35694EC0CEB7" bpmnElement="_E158C414-E636-4D22-A59E-35694EC0CEB7">
+        <dc:Bounds height="56.0" width="56.0" x="904.0" y="120.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__9E72D077-F2EE-4F00-A987-6A88DD09F5EA" bpmnElement="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA">
+        <dc:Bounds height="102.0" width="154.0" x="416.0" y="97.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__782F2FFB-4A45-4957-BA1F-C1920469443D" bpmnElement="_782F2FFB-4A45-4957-BA1F-C1920469443D">
+        <dc:Bounds height="56.0" width="56.0" x="280.0" y="120.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__4696E1F0-0A95-4C51-B601-FBF49A899D11" bpmnElement="_4696E1F0-0A95-4C51-B601-FBF49A899D11">
+        <dc:Bounds height="102.0" width="154.0" x="670.0" y="97.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__4696E1F0-0A95-4C51-B601-FBF49A899D11_to_shape__E158C414-E636-4D22-A59E-35694EC0CEB7" bpmnElement="_9FCB7855-B5AA-4A1B-B133-A7B4EB0A48AB">
+        <di:waypoint xsi:type="dc:Point" x="824.0" y="148.0"/>
+        <di:waypoint xsi:type="dc:Point" x="904.0" y="148.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__782F2FFB-4A45-4957-BA1F-C1920469443D_to_shape__9E72D077-F2EE-4F00-A987-6A88DD09F5EA" bpmnElement="_99027D7C-CB12-4BD7-AB46-E0BD6651AC33">
+        <di:waypoint xsi:type="dc:Point" x="336.0" y="148.0"/>
+        <di:waypoint xsi:type="dc:Point" x="416.0" y="148.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_to_shape__4696E1F0-0A95-4C51-B601-FBF49A899D11" bpmnElement="_99C505A7-2B8C-4A30-A845-A87BC62986B6">
+        <di:waypoint xsi:type="dc:Point" x="570.0" y="148.0"/>
+        <di:waypoint xsi:type="dc:Point" x="670.0" y="148.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_erAAoGhiEeqRIbB9YdC0SQ" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA" id="_erAAoWhiEeqRIbB9YdC0SQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_782F2FFB-4A45-4957-BA1F-C1920469443D" id="_erAAomhiEeqRIbB9YdC0SQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_4696E1F0-0A95-4C51-B601-FBF49A899D11" id="_erH8cGhiEeqRIbB9YdC0SQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_eq_ZkGhiEeqRIbB9YdC0SQ</bpmn2:source>
+    <bpmn2:target>_eq_ZkGhiEeqRIbB9YdC0SQ</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION

transitions between task status are not being captured.
It is needed to trigger the events in the lifecycle of the task.