### PR TITLE
JBPM-9093 Alert panel and Process Definitions contain encoded names

### DIFF
--- a/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
+++ b/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
@@ -16,6 +16,8 @@
 
 package org.jbpm.bpmn2.xml;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -125,9 +127,8 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
 			            final Attributes attrs, final ExtensibleXmlParser parser)
 			throws SAXException {
 		parser.startElementBuilder(localName, attrs);
-
-		String id = attrs.getValue("id");
-		String name = attrs.getValue("name");
+		String id = getDecodedAttribute(attrs, "id");
+		String name = getDecodedAttribute(attrs, "name");
 		String packageName = attrs.getValue("http://www.jboss.org/drools", "packageName");
 		String dynamic = attrs.getValue("http://www.jboss.org/drools", "adHoc");
 		String version = attrs.getValue("http://www.jboss.org/drools", "version");
@@ -170,6 +171,16 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
 		parser.getMetaData().put("idGen", new AtomicInteger(1));
 		
 		return process;
+	}
+
+	private String getDecodedAttribute(final Attributes attrs, final String attrName) {
+		String value = attrs.getValue(attrName);
+		try {
+			return URLDecoder.decode(value, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			logger.warn("Attribute decoded with incorrect encoding.", e);
+			return value;
+		}
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Hi @romartin, @LuboTerifaj,

this is fixing [JBPM-9093](https://issues.redhat.com/browse/JBPM-9093) which is caused by https://github.com/kiegroup/kie-wb-common/pull/3172. I tested it with locally built of business central + kie server with this changes.

## BUT

When I tried to write a unit test for it I tried to use this test https://github.com/kiegroup/jbpm/blob/5f10ed713300019934edbfbcb35034c73d342a06/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/BPMN2XMLTest.java#L64 which uses this process https://github.com/kiegroup/jbpm/blob/5f10ed713300019934edbfbcb35034c73d342a06/jbpm-bpmn2/src/test/resources/BPMN2-SimpleXMLProcess.bpmn2#L14

The process under test already has encoded process name so I expected that it will be easy one, but when I started to check the test the process name was already decoded even before my changes.

**So, it looks like the code should work without my changes but it doesn't.** 

I checked stacktrace from business central and for this test and both of them looks identical to me (except calling point and other 3-rd part libraries like weld in Business Central and JUnit in unit test).

<details>
  <summary>Call stack when I run the test</summary>
  <pre>	at org.jbpm.bpmn2.xml.ProcessHandler.start(ProcessHandler.java:129)
	at org.drools.core.xml.ExtensibleXmlParser.startElement(ExtensibleXmlParser.java:408)
	at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.startElement(AbstractSAXParser.java:509)
	at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.startElement(XMLSchemaValidator.java:744)
	at com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.scanStartElement(XMLNSDocumentScannerImpl.java:374)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2784)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:602)
	at com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next(XMLNSDocumentScannerImpl.java:112)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:505)
	at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:842)
	at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:771)
	at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
	at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1213)
	at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:643)
	at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl.parse(SAXParserImpl.java:327)
	at org.drools.core.xml.ExtensibleXmlParser.read(ExtensibleXmlParser.java:317)
	at org.drools.core.xml.ExtensibleXmlParser.read(ExtensibleXmlParser.java:194)
	at org.jbpm.compiler.xml.XmlProcessReader.read(XmlProcessReader.java:93)
	at org.jbpm.bpmn2.BPMN2XMLTest.testXML(BPMN2XMLTest.java:71)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at junit.framework.TestCase.runTest(TestCase.java:176)
	at junit.framework.TestCase.runBare(TestCase.java:141)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:129)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:86)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)</pre>
</details>

<details>
  <summary>Call stack when in this class when we call during deploy on Business Central</summary>
  <pre>start:131, ProcessHandler (org.jbpm.bpmn2.xml)
startElement:408, ExtensibleXmlParser (org.drools.core.xml)
startElement:498, AbstractSAXParser (org.apache.xerces.parsers)
startElement:792, XMLSchemaValidator (org.apache.xerces.impl.xs)
scanStartElement:283, XMLNSDocumentScannerImpl (org.apache.xerces.impl)
dispatch:1653, XMLDocumentFragmentScannerImpl$FragmentContentDispatcher (org.apache.xerces.impl)
scanDocument:324, XMLDocumentFragmentScannerImpl (org.apache.xerces.impl)
parse:875, XML11Configuration (org.apache.xerces.parsers)
parse:798, XML11Configuration (org.apache.xerces.parsers)
parse:108, XMLParser (org.apache.xerces.parsers)
parse:1198, AbstractSAXParser (org.apache.xerces.parsers)
parse:564, SAXParserImpl$JAXPSAXParser (org.apache.xerces.jaxp)
parse:298, SAXParserImpl (org.apache.xerces.jaxp)
read:317, ExtensibleXmlParser (org.drools.core.xml)
read:180, ExtensibleXmlParser (org.drools.core.xml)
read:79, XmlProcessReader (org.jbpm.compiler.xml)
addProcessFromXml:293, ProcessBuilderImpl (org.jbpm.compiler)
addResource:47, AbstractProcessAssembler (org.jbpm.assembler)
addResource:46, KieAssemblersImpl (org.kie.internal.services)
addPackageForExternalType:772, KnowledgeBuilderImpl (org.drools.compiler.builder.impl)
addKnowledgeResource:757, KnowledgeBuilderImpl (org.drools.compiler.builder.impl)
lambda$static$6:306, CompositeKnowledgeBuilderImpl$ResourceBuilder (org.drools.compiler.builder.impl)
build:-1, 470063820 (org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl$ResourceBuilder$$Lambda$1532)
buildResourceType:140, CompositeKnowledgeBuilderImpl (org.drools.compiler.builder.impl)
buildProcesses:120, CompositeKnowledgeBuilderImpl (org.drools.compiler.builder.impl)
build:110, CompositeKnowledgeBuilderImpl (org.drools.compiler.builder.impl)
build:98, CompositeKnowledgeBuilderImpl (org.drools.compiler.builder.impl)
buildKnowledgePackages:261, AbstractKieProject (org.drools.compiler.kie.builder.impl)
verify:75, AbstractKieProject (org.drools.compiler.kie.builder.impl)
buildKieProject:279, KieBuilderImpl (org.drools.compiler.kie.builder.impl)
buildAll:247, KieBuilderImpl (org.drools.compiler.kie.builder.impl)
buildAll:216, KieBuilderImpl (org.drools.compiler.kie.builder.impl)
build:213, Builder (org.kie.workbench.common.services.backend.builder.core)
build:92, BuildHelper (org.kie.workbench.common.services.backend.builder.core)
doBuildAndDeploy:292, BuildHelper (org.kie.workbench.common.services.backend.builder.core)
buildAndDeploy:253, BuildHelper (org.kie.workbench.common.services.backend.builder.core)
buildAndDeploy:-1, BuildHelper$Proxy$_$$_WeldClientProxy (org.kie.workbench.common.services.backend.builder.core)
apply:85, LocalBuildExecConfigExecutor (org.kie.workbench.common.services.backend.builder.ala)
apply:32, LocalBuildExecConfigExecutor (org.kie.workbench.common.services.backend.builder.ala)
apply:-1, LocalBuildExecConfigExecutor$Proxy$_$$_WeldClientProxy (org.kie.workbench.common.services.backend.builder.ala)
lambda$continuePipeline$0:109, PipelineExecutor (org.guvnor.ala.pipeline.execution)
accept:-1, 1915762791 (org.guvnor.ala.pipeline.execution.PipelineExecutor$$Lambda$1519)
execute:38, StageUtil$1 (org.guvnor.ala.pipeline)
execute:33, StageUtil$1 (org.guvnor.ala.pipeline)
continuePipeline:94, PipelineExecutor (org.guvnor.ala.pipeline.execution)
execute:76, PipelineExecutor (org.guvnor.ala.pipeline.execution)
invokeLocalBuildPipeLine:88, BuildPipelineInvoker (org.kie.workbench.common.services.backend.builder.ala)
invokeLocalBuildPipeLine:-1, BuildPipelineInvoker$Proxy$_$$_WeldClientProxy (org.kie.workbench.common.services.backend.builder.ala)
invokeLocalBuildPipeLine:185, BuildServiceHelper (org.kie.workbench.common.services.backend.builder.service)
localBuildAndDeploy:140, BuildServiceHelper (org.kie.workbench.common.services.backend.builder.service)
localBuildAndDeploy:-1, BuildServiceHelper$Proxy$_$$_WeldClientProxy (org.kie.workbench.common.services.backend.builder.service)
buildAndDeploy:101, BuildServiceImpl (org.kie.workbench.common.services.backend.builder.service)
buildAndDeploy:84, BuildServiceImpl (org.kie.workbench.common.services.backend.builder.service)
buildAndDeploy:-1, BuildServiceImpl$Proxy$_$$_WeldClientProxy (org.kie.workbench.common.services.backend.builder.service)
invoke0:-1, NativeMethodAccessorImpl (sun.reflect)
invoke:62, NativeMethodAccessorImpl (sun.reflect)
invoke:43, DelegatingMethodAccessorImpl (sun.reflect)
invoke:498, Method (java.lang.reflect)
invokeMethodFromMessage:65, AbstractRPCMethodCallback (org.jboss.errai.bus.server.io)
callback:40, ValueReplyRPCEndpointCallback (org.jboss.errai.bus.server.io)
callback:54, RemoteServiceCallback (org.jboss.errai.bus.server.io)
callback:448, CDIExtensionPoints$2 (org.jboss.errai.cdi.server)
deliver:47, DeliveryPlan (org.jboss.errai.bus.server)
sendGlobal:297, ServerMessageBusImpl (org.jboss.errai.bus.server)
dispatchGlobal:46, SimpleDispatcher (org.jboss.errai.bus.server)
store:96, ErraiServiceImpl (org.jboss.errai.bus.server.service)
store:113, ErraiServiceImpl (org.jboss.errai.bus.server.service)
doPost:144, DefaultBlockingServlet (org.jboss.errai.bus.server.servlet)
service:706, HttpServlet (javax.servlet.http)
service:791, HttpServlet (javax.servlet.http)
handleRequest:74, ServletHandler (io.undertow.servlet.handlers)
doFilter:129, FilterHandler$FilterChainImpl (io.undertow.servlet.handlers)
doFilter:173, JsrWebSocketFilter (io.undertow.websockets.jsr)
doFilter:61, ManagedFilter (io.undertow.servlet.core)
doFilter:131, FilterHandler$FilterChainImpl (io.undertow.servlet.handlers)
doFilter:110, SecureHeadersFilter (org.uberfire.ext.security.server)
doFilter:61, ManagedFilter (io.undertow.servlet.core)
doFilter:131, FilterHandler$FilterChainImpl (io.undertow.servlet.handlers)
doFilter:70, SecurityIntegrationFilter (org.uberfire.ext.security.server)
doFilter:61, ManagedFilter (io.undertow.servlet.core)
doFilter:131, FilterHandler$FilterChainImpl (io.undertow.servlet.handlers)
doFilter:55, SpanFinishingFilter (io.opentracing.contrib.jaxrs2.server)
doFilter:61, ManagedFilter (io.undertow.servlet.core)
doFilter:131, FilterHandler$FilterChainImpl (io.undertow.servlet.handlers)
handleRequest:84, FilterHandler (io.undertow.servlet.handlers)
handleRequest:62, ServletSecurityRoleHandler (io.undertow.servlet.handlers.security)
handleRequest:68, ServletChain$1 (io.undertow.servlet.handlers)
handleRequest:36, ServletDispatchingHandler (io.undertow.servlet.handlers)
handleRequest:78, SecurityContextAssociationHandler (org.wildfly.extension.undertow.security)
handleRequest:43, PredicateHandler (io.undertow.server.handlers)
handleRequest:132, SSLInformationAssociationHandler (io.undertow.servlet.handlers.security)
handleRequest:57, ServletAuthenticationCallHandler (io.undertow.servlet.handlers.security)
handleRequest:33, DisableCacheHandler (io.undertow.server.handlers)
handleRequest:43, PredicateHandler (io.undertow.server.handlers)
handleRequest:53, AuthenticationConstraintHandler (io.undertow.security.handlers)
handleRequest:46, AbstractConfidentialityHandler (io.undertow.security.handlers)
handleRequest:64, ServletConfidentialityConstraintHandler (io.undertow.servlet.handlers.security)
handleRequest:59, ServletSecurityConstraintHandler (io.undertow.servlet.handlers.security)
handleRequest:60, AuthenticationMechanismsHandler (io.undertow.security.handlers)
handleRequest:77, CachedAuthenticatedSessionHandler (io.undertow.servlet.handlers.security)
handleRequest:50, NotificationReceiverHandler (io.undertow.security.handlers)
handleRequest:43, AbstractSecurityContextAssociationHandler (io.undertow.security.handlers)
handleRequest:43, PredicateHandler (io.undertow.server.handlers)
handleRequest:61, JACCContextIdHandler (org.wildfly.extension.undertow.security.jacc)
handleRequest:43, PredicateHandler (io.undertow.server.handlers)
handleRequest:68, GlobalRequestControllerHandler (org.wildfly.extension.undertow.deployment)
handleRequest:43, PredicateHandler (io.undertow.server.handlers)
handleFirstRequest:292, ServletInitialHandler (io.undertow.servlet.handlers)
access$100:81, ServletInitialHandler (io.undertow.servlet.handlers)
call:138, ServletInitialHandler$2 (io.undertow.servlet.handlers)
call:135, ServletInitialHandler$2 (io.undertow.servlet.handlers)
call:48, ServletRequestContextThreadSetupAction$1 (io.undertow.servlet.core)
call:43, ContextClassLoaderSetupAction$1 (io.undertow.servlet.core)
lambda$create$0:105, SecurityContextThreadSetupAction (org.wildfly.extension.undertow.security)
call:-1, 1990806827 (org.wildfly.extension.undertow.security.SecurityContextThreadSetupAction$$Lambda$775)
lambda$create$0:1502, UndertowDeploymentInfoService$UndertowThreadSetupAction (org.wildfly.extension.undertow.deployment)
call:-1, 1424730699 (org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction$$Lambda$776)
lambda$create$0:1502, UndertowDeploymentInfoService$UndertowThreadSetupAction (org.wildfly.extension.undertow.deployment)
call:-1, 1424730699 (org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction$$Lambda$776)
lambda$create$0:1502, UndertowDeploymentInfoService$UndertowThreadSetupAction (org.wildfly.extension.undertow.deployment)
call:-1, 1424730699 (org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction$$Lambda$776)
lambda$create$0:1502, UndertowDeploymentInfoService$UndertowThreadSetupAction (org.wildfly.extension.undertow.deployment)
call:-1, 1424730699 (org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction$$Lambda$776)
dispatchRequest:272, ServletInitialHandler (io.undertow.servlet.handlers)
access$000:81, ServletInitialHandler (io.undertow.servlet.handlers)
handleRequest:104, ServletInitialHandler$1 (io.undertow.servlet.handlers)
executeRootHandler:360, Connectors (io.undertow.server)
run:830, HttpServerExchange$1 (io.undertow.server)
run:35, ContextClassLoaderSavingRunnable (org.jboss.threads)
safeRun:1985, EnhancedQueueExecutor (org.jboss.threads)
doRunTask:1487, EnhancedQueueExecutor$ThreadBody (org.jboss.threads)
run:1378, EnhancedQueueExecutor$ThreadBody (org.jboss.threads)
run:748, Thread (java.lang)</pre>
</details>


So, I don't know should we fix [JBPM-9093](https://issues.redhat.com/browse/JBPM-9093) as I did or we need to change some XML parsing configurations in kie server.

CC @cristianonicolai, @MarianMacik, @manstis 