### PR TITLE
BXMSPROD-702 jbpm-installer excluded from productized profile

### DIFF
--- a/jbpm-distribution/pom.xml
+++ b/jbpm-distribution/pom.xml
@@ -72,31 +72,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>zips</id>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <configuration>
-              <finalName>jbpm-${project.version}</finalName>
-              <descriptors>
-                <!-- basic zips -->
-                <descriptor>src/main/assembly/pre-bin.xml</descriptor>
-                <descriptor>src/main/assembly/bin.xml</descriptor>
-                <descriptor>src/main/assembly/src.xml</descriptor>
-                <descriptor>src/main/assembly/assembly-jbpm.xml</descriptor>
-                <!-- examples -->
-                <descriptor>src/main/assembly/examples.xml</descriptor>
-              </descriptors>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 
@@ -423,4 +398,83 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+      <profile>
+          <id>jbpm-installer-include</id>
+          <activation>
+              <property>
+                  <name>productized</name>
+                  <value>!true</value>
+              </property>
+          </activation>
+          <build>
+            <plugins>
+              <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                  <execution>
+                    <id>zips</id>
+                    <phase>package</phase>
+                    <goals>
+                      <goal>single</goal>
+                    </goals>
+                    <configuration>
+                      <finalName>jbpm-${project.version}</finalName>
+                      <descriptors>
+                        <!-- basic zips -->
+                        <descriptor>src/main/assembly/pre-bin.xml</descriptor>
+                        <descriptor>src/main/assembly/bin.xml</descriptor>
+                        <descriptor>src/main/assembly/assembly-jbpm.xml</descriptor>
+                        <descriptor>src/main/assembly/src.xml</descriptor>
+                        <!-- examples -->
+                        <descriptor>src/main/assembly/examples.xml</descriptor>
+                      </descriptors>
+                    </configuration>
+                  </execution>
+                </executions>
+              </plugin>
+            </plugins>
+          </build>
+      </profile>
+      <profile>
+          <id>jbpm-installer-exclude</id>
+          <activation>
+              <property>
+                  <name>productized</name>
+                  <value>true</value>
+              </property>
+          </activation>
+          <build>
+            <plugins>
+              <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                  <execution>
+                    <id>zips</id>
+                    <phase>package</phase>
+                    <goals>
+                      <goal>single</goal>
+                    </goals>
+                    <configuration>
+                      <finalName>jbpm-${project.version}</finalName>
+                      <descriptors>
+                          <!-- basic zips -->
+                          <descriptor>src/main/assembly/pre-bin.xml</descriptor>
+                          <descriptor>src/main/assembly/bin.xml</descriptor>
+                          <descriptor>src/main/assembly/assembly-jbpm.xml</descriptor>
+                          <descriptor>src/main/assembly/src-without-installer.xml</descriptor>
+                          <!-- examples -->
+                          <descriptor>src/main/assembly/examples.xml</descriptor>
+                        </descriptors>
+                      </configuration>
+                  </execution>
+                </executions>
+              </plugin>
+            </plugins>
+          </build>
+      </profile>
+  </profiles>
 </project>

--- a/jbpm-distribution/src/main/assembly/src-without-installer.xml
+++ b/jbpm-distribution/src/main/assembly/src-without-installer.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly>
+  <id>src</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>..</directory>
+      <outputDirectory/>
+      <includes>
+        <include>jbpm-audit/**</include>
+        <include>jbpm-bpmn2/**</include>
+        <include>jbpm-bpmn2-emfextmodel/**</include>
+        <include>jbpm-distribution/**</include>
+        <include>jbpm-document/**</include>
+        <include>jbpm-examples/**</include>
+        <include>jbpm-flow/**</include>
+        <include>jbpm-flow-builder/**</include>
+        <include>jbpm-human-task/**</include>
+        <include>jbpm-persistence-jpa/**</include>
+        <include>jbpm-runtime-manager/**</include>
+        <include>jbpm-services/**</include>
+        <include>jbpm-test/**</include>
+        <include>jbpm-workitems/**</include>
+        <include>*.xml</include>
+        <include>*.txt</include>
+      </includes>
+      <excludes>
+        <exclude>**/*.log/**</exclude>
+        <exclude>**/*.tlog/**</exclude>
+        <exclude>**/target/**</exclude>
+        <exclude>**/.git</exclude>
+        <exclude>**/.metadata/**</exclude>
+        <exclude>**/*.h2.db</exclude>
+        <exclude>**/*.trace.db</exclude>
+        <exclude>**/*.iml</exclude>
+      </excludes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@
         <module>jbpm-case-mgmt</module>
         <module>jbpm-test-coverage</module>
         <module>jbpm-examples</module>
-        <module>jbpm-installer</module>
         <module>jbpm-container-test</module>
         <module>jbpm-event-emitters</module>
         <module>jbpm-xes</module>
@@ -278,6 +277,18 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+        <profile>
+            <id>jbpm-installer-exclude-productized</id>
+            <activation>
+                <property>
+                    <name>productized</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <modules>
+                <module>jbpm-installer</module>
+            </modules>
         </profile>
     </profiles>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-702
My only concern is about the jbpm-installer sources remain in the jbpm-distribution assembly zip `jbpm-%version%-src-zip` file

