### PR TITLE
[RHPAM-2903] 255 characters limitation in ExecutionErrorInfo database table

### DIFF
--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/jpa/ExecutionErrorInfo.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/jpa/ExecutionErrorInfo.java
@@ -40,6 +40,8 @@ public class ExecutionErrorInfo extends ExecutionError implements Serializable {
 
 	private static final long serialVersionUID = 6669858787722894023L;
 	
+    private final int ERROR_LOG_LENGTH = Integer.parseInt(System.getProperty("org.kie.jbpm.error.log.length", "255"));
+
 	private Long id;
 
     public ExecutionErrorInfo() {
@@ -56,11 +58,11 @@ public class ExecutionErrorInfo extends ExecutionError implements Serializable {
         this.activityId = activityId;
         this.activityName = activityName;
         this.jobId = jobId;
-        this.errorMessage = errorMessage;
         this.error = error;
         this.errorDate = errorDate;
         this.acknowledged = new Short("0");
         this.initActivityId = initActivityId;
+        this.setErrorMessage(errorMessage);
     }
 
     @Id
@@ -101,6 +103,15 @@ public class ExecutionErrorInfo extends ExecutionError implements Serializable {
     @Override
     public Long getActivityId() {
         return super.getActivityId();
+    }
+
+    @Override
+    public void setErrorMessage(String errorMessage) {
+        String trimmedErrorMessage = errorMessage;
+        if (trimmedErrorMessage != null && trimmedErrorMessage.length() > ERROR_LOG_LENGTH) {
+            trimmedErrorMessage = trimmedErrorMessage.substring(0, ERROR_LOG_LENGTH);
+        }
+        super.setErrorMessage(trimmedErrorMessage);
     }
 
     @Column(name="ERROR_MSG")

--- a/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/error/ExecutionErrorInfoTest.java
+++ b/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/error/ExecutionErrorInfoTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.runtime.manager.impl.error;
+
+import java.util.Random;
+
+import org.assertj.core.api.Assertions;
+import org.jbpm.runtime.manager.impl.jpa.ExecutionErrorInfo;
+import org.junit.After;
+import org.junit.Test;
+
+public class ExecutionErrorInfoTest {
+
+    @After
+    public void tearUp() {
+        System.clearProperty("org.kie.jbpm.error.log.length");
+    }
+    @Test
+    public void testTrimmedErrorMessage() {
+        ExecutionErrorInfo info = new ExecutionErrorInfo();
+        String randomString = randomString(300);
+        info.setErrorMessage(randomString);
+        Assertions.assertThat(info.getErrorMessage().length()).isEqualTo(255);
+        Assertions.assertThat(info.getErrorMessage()).isEqualTo(randomString.substring(0, 255));
+    }
+
+    @Test
+    public void testTrimmedNotDefaultErrorMessage() {
+        System.setProperty("org.kie.jbpm.error.log.length", "5");
+        String randomString = randomString(100);
+        ExecutionErrorInfo info = new ExecutionErrorInfo();
+        info.setErrorMessage(randomString);
+        Assertions.assertThat(info.getErrorMessage().length()).isEqualTo(5);
+        Assertions.assertThat(info.getErrorMessage()).isEqualTo(randomString.substring(0, 5));
+    }
+
+    @Test
+    public void testDefaultErrorMessage() {
+        String randomString = randomString(100);
+        ExecutionErrorInfo info = new ExecutionErrorInfo();
+        info.setErrorMessage(randomString);
+        Assertions.assertThat(info.getErrorMessage().length()).isEqualTo(100);
+        Assertions.assertThat(info.getErrorMessage()).isEqualTo(randomString);
+    }
+
+    private String randomString(int size) {
+        char[] array = new char[size];
+        Random random = new Random();
+        for (int i = 0; i < array.length; i++) {
+            array[i] = (char) random.nextInt();
+        }
+        return String.valueOf(array);
+    }
+}


### PR DESCRIPTION
trim string in execution error info so it does truncate when info does not fit the column