### PR TITLE
[JBPM-9155] GROUPS is a reserved word since mysql 8.0.2

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/DBUserGroupCallbackImplTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/DBUserGroupCallbackImplTest.java
@@ -51,8 +51,8 @@ public class DBUserGroupCallbackImplTest {
         props = new Properties();
         props.setProperty(DBUserGroupCallbackImpl.DS_JNDI_NAME, "jdbc/jbpm-ds");
         props.setProperty(DBUserGroupCallbackImpl.PRINCIPAL_QUERY, "select userId from Users where userId = ?");
-        props.setProperty(DBUserGroupCallbackImpl.ROLES_QUERY, "select groupId from Groups where groupId = ?");
-        props.setProperty(DBUserGroupCallbackImpl.USER_ROLES_QUERY, "select groupId from Groups where userId = ?");
+        props.setProperty(DBUserGroupCallbackImpl.ROLES_QUERY, "select groupId from UserGroups where groupId = ?");
+        props.setProperty(DBUserGroupCallbackImpl.USER_ROLES_QUERY, "select groupId from UserGroups where userId = ?");
     }
 
     protected Properties loadDataSourceProperties() {
@@ -77,7 +77,7 @@ public class DBUserGroupCallbackImplTest {
             PreparedStatement st = conn.prepareStatement(createUserTableSql);
             st.execute();
 
-            String createGroupTableSql = "create table Groups (groupId varchar(255), userId varchar(255))";
+            String createGroupTableSql = "create table UserGroups (groupId varchar(255), userId varchar(255))";
             st = conn.prepareStatement(createGroupTableSql);
             st.execute();
 
@@ -88,7 +88,7 @@ public class DBUserGroupCallbackImplTest {
             st.execute();
 
             // insert group rows
-            String insertGroup = "insert into Groups (groupId, userId) values (?, ?)";
+            String insertGroup = "insert into UserGroups (groupId, userId) values (?, ?)";
             st = conn.prepareStatement(insertGroup);
             st.setString(1, "PM");
             st.setString(2, "john");
@@ -111,7 +111,7 @@ public class DBUserGroupCallbackImplTest {
             PreparedStatement st = conn.prepareStatement(dropUserTableSql);
             st.execute();
 
-            String dropGroupTableSql = "drop table Groups";
+            String dropGroupTableSql = "drop table UserGroups";
             st = conn.prepareStatement(dropGroupTableSql);
 
             st.execute();

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/DBUserInfoImplTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/DBUserInfoImplTest.java
@@ -55,8 +55,8 @@ public class DBUserInfoImplTest {
         props.setProperty(DBUserInfoImpl.NAME_QUERY, "select name from Users where userId = ?");
         props.setProperty(DBUserInfoImpl.EMAIL_QUERY, "select email from Users where userId = ?");
         props.setProperty(DBUserInfoImpl.LANG_QUERY, "select lang from Users where userId = ?");
-        props.setProperty(DBUserInfoImpl.HAS_EMAIL_QUERY, "select email from Groups where groupId = ?");
-        props.setProperty(DBUserInfoImpl.MEMBERS_QUERY, "select userId from Groups where groupId = ?");
+        props.setProperty(DBUserInfoImpl.HAS_EMAIL_QUERY, "select email from UserGroups where groupId = ?");
+        props.setProperty(DBUserInfoImpl.MEMBERS_QUERY, "select userId from UserGroups where groupId = ?");
         props.setProperty(DBUserInfoImpl.ID_QUERY, "select userId from Users where email = ?");
     }
 
@@ -82,7 +82,7 @@ public class DBUserInfoImplTest {
             PreparedStatement st = conn.prepareStatement(createUserTableSql);
             st.execute();
 
-            String createGroupTableSql = "create table Groups (groupId varchar(255), userId varchar(255), email varchar(255))";
+            String createGroupTableSql = "create table UserGroups (groupId varchar(255), userId varchar(255), email varchar(255))";
             st = conn.prepareStatement(createGroupTableSql);
             st.execute();
 
@@ -96,7 +96,7 @@ public class DBUserInfoImplTest {
             st.execute();
 
             // insert group rows
-            String insertGroup = "insert into Groups (groupId, userId, email) values (?, ?, ?)";
+            String insertGroup = "insert into UserGroups (groupId, userId, email) values (?, ?, ?)";
             st = conn.prepareStatement(insertGroup);
             st.setString(1, "PM");
             st.setString(2, "john");
@@ -120,7 +120,7 @@ public class DBUserInfoImplTest {
             PreparedStatement st = conn.prepareStatement(dropUserTableSql);
             st.execute();
 
-            String dropGroupTableSql = "drop table Groups";
+            String dropGroupTableSql = "drop table UserGroups";
             st = conn.prepareStatement(dropGroupTableSql);
 
             st.execute();


### PR DESCRIPTION
Table name uses a reserved word for mysql.
If quoted with backticks (`), then other dbs (mssql, db2) don't work (incorrect syntax).