### PR TITLE
Register dialect for validating Quartz-mariaDB

### DIFF
--- a/jbpm-test-util/src/main/java/org/jbpm/test/persistence/scripts/quartzdialects/QuartzDialectResolver.java
+++ b/jbpm-test-util/src/main/java/org/jbpm/test/persistence/scripts/quartzdialects/QuartzDialectResolver.java
@@ -30,7 +30,7 @@ public class QuartzDialectResolver implements DialectResolver {
     private static Map<String, Dialect> DIALECT_BY_NAME = new HashMap<>();
 
     {
-        registerDialect(new MySQLCustomDialect(), "MySQL");
+        registerDialect(new MySQLCustomDialect(), "MySQL", "MariaDB");
         registerDialect(new DB2CustomDialect(), "DB2/LINUXX8664");
         registerDialect(new OracleCustomDialect(), "Oracle");
         registerDialect(new PostgreSQLCustomDialect(), "PostgreSQL", "EnterpriseDB");


### PR DESCRIPTION
Previously, dbAllocator was instantiating MariaDB instances with "MySQL" db name, but now Quartz schema validation is failing because the database name was missing.