### PR TITLE
[BAPL-1623] Case traceability from a Task Instance

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/model/UserTaskInstanceDesc.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/model/UserTaskInstanceDesc.java
@@ -42,6 +42,8 @@ public class UserTaskInstanceDesc implements org.jbpm.services.api.model.UserTas
 	private Date slaDueDate;
 	private Integer slaCompliance;
     private String subject;
+    private String correlationKey;
+    private Integer processType;
 
 
     public UserTaskInstanceDesc(Long taskId, String status,
@@ -57,20 +59,22 @@ public class UserTaskInstanceDesc implements org.jbpm.services.api.model.UserTas
 								Integer priority, String actualOwner, String createdBy, String deploymentId,
 								String processId, Long processInstanceId, Date createdOn, Date dueDate, Long workItemId) {
 		this(taskId, status, activationTime, name, description, priority, actualOwner, createdBy, deploymentId,
-             processId, processInstanceId, createdOn, dueDate, workItemId, null, null);
+             processId, processInstanceId, createdOn, dueDate, workItemId,null, null, null, null);
 	}
+	
 	
 	public UserTaskInstanceDesc(Long taskId, String status, Date activationTime, String name, String description,
                                 Integer priority, String actualOwner, String createdBy, String deploymentId,
-                                String processId, Long processInstanceId, Date createdOn, Date dueDate, Long workItemId, String formName, String subject) {
+                                String processId, Long processInstanceId, Date createdOn, Date dueDate, Long workItemId, String formName, String subject, String correlationKey, Integer processType) {
         this(taskId, status, activationTime, name, description, priority, actualOwner, createdBy, deploymentId,
-             processId, processInstanceId, createdOn, dueDate, workItemId, formName, subject, null, null);
+             processId, processInstanceId, createdOn, dueDate, workItemId, formName, subject, correlationKey, processType, null, null);
     }
-
+	
+	
     public UserTaskInstanceDesc(Long taskId, String status, Date activationTime, String name,
                                 String description,
                                 Integer priority, String actualOwner, String createdBy, String deploymentId,
-                                String processId, Long processInstanceId, Date createdOn, Date dueDate, Long workItemId, String formName, String subject,
+                                String processId, Long processInstanceId, Date createdOn, Date dueDate, Long workItemId, String formName, String subject, String correlationKey, Integer processType,
                                 Date slaDueDate, Integer slaCompliance) {
         this.taskId = taskId;
         this.status = status;
@@ -88,6 +92,8 @@ public class UserTaskInstanceDesc implements org.jbpm.services.api.model.UserTas
         this.workItemId = workItemId;
         this.formName = formName;
         this.subject = subject;
+        this.correlationKey = correlationKey;
+        this.processType = processType;
         this.slaDueDate = slaDueDate;
         this.slaCompliance = slaCompliance;
     }
@@ -246,22 +252,41 @@ public class UserTaskInstanceDesc implements org.jbpm.services.api.model.UserTas
 		this.slaCompliance = slaCompliance;
 	}
 
-
-    public String getSubject() {
-        return subject;
-    }
-
-    public void setSubject(String subject) {
+	@Override
+	public String getSubject() {
+	    return subject;
+	}
+	
+	@Override
+	public void setSubject(String subject) {
         this.subject = subject;
+	}
+
+	@Override
+	public String getCorrelationKey() {
+	    return correlationKey;
+	}
+
+	@Override
+	public void setCorrelationKey(String correlationKey) {
+	    this.correlationKey = correlationKey;
+	}
+
+	@Override
+	public Integer getProcessType() {
+	    return processType;
     }
 
 	@Override
-	public String toString() {
-		return "UserTaskInstanceDesc [taskId=" + taskId + ", name=" + name
-				+ ", deploymentId=" + deploymentId + ", processInstanceId="
-               + processInstanceId + ", workItemId=" + workItemId + ", subject=" + subject
-				+ ", slaCompliance=" + slaCompliance + ", slaDueDate=" + slaDueDate +"]";
+	public void setProcessType(Integer processType) {
+	    this.processType = processType;
 	}
 
-
+	@Override
+	public String toString() {
+	    return "UserTaskInstanceDesc [taskId=" + taskId + ", status=" + status + ", activationTime=" + activationTime + ", name=" + name + ", description=" + description + ", priority=" + priority + ", actualOwner=" +
+	            actualOwner + ", createdBy=" + createdBy + ", deploymentId=" + deploymentId + ", processId=" + processId + ", processInstanceId=" + processInstanceId + ", createdOn=" + createdOn + ", dueDate=" + dueDate +
+	            ", formName=" + formName + ", workItemId=" + workItemId + ", slaDueDate=" + slaDueDate + ", slaCompliance=" + slaCompliance + ", subject=" + subject + ", correlationKey=" + correlationKey +
+	            ", processType=" + processType + "]";
+	}
 }

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/mapper/UserTaskInstanceQueryMapper.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/mapper/UserTaskInstanceQueryMapper.java
@@ -80,7 +80,11 @@ public class UserTaskInstanceQueryMapper extends AbstractQueryMapper<UserTaskIns
                 getColumnDateValue(dataSetResult, COLUMN_DUEDATE, index),//dueDate
                 getColumnLongValue(dataSetResult, COLUMN_WORKITEMID, index), //workItemId
                 getColumnStringValue(dataSetResult, COLUMN_FORM_NAME, index),
-                getColumnStringValue(dataSetResult, COLUMN_SUBJECT, index)
+                getColumnStringValue(dataSetResult, COLUMN_SUBJECT, index),
+                getColumnStringValue(dataSetResult, COLUMN_CORRELATIONKEY, index), 
+                getColumnIntValue(dataSetResult, COLUMN_PROCESSTYPE, index),
+                getColumnDateValue(dataSetResult, COLUMN_SLA_DUE_DATE, index), 
+                getColumnIntValue(dataSetResult, COLUMN_SLA_COMPLIANCE, index)
                 );
         return userTask;
     }

--- a/jbpm-services/jbpm-kie-services/src/main/resources/META-INF/Servicesorm.xml
+++ b/jbpm-services/jbpm-kie-services/src/main/resources/META-INF/Servicesorm.xml
@@ -715,15 +715,18 @@
 	      a.processInstanceId,
 	      a.createdOn,
 	      a.dueDate,
-          a.workItemId,
-    	  t.formName,
-    	  t.subject
+	      a.workItemId,
+	      t.formName,
+	      t.subject,
+	      plog.correlationKey,
+	      plog.processType
 	      )
         from 
-        	AuditTaskImpl a
-        	left join TaskImpl t on t.id = a.taskId
+          AuditTaskImpl a
+          inner join ProcessInstanceLog plog ON a.processInstanceId = plog.processInstanceId
+          left join TaskImpl t on t.id = a.taskId
         where 
-        	a.taskId = :taskId
+          a.taskId = :taskId
     </query>
     <!-- hint name="org.hibernate.timeout" value="200"/ -->
   </named-query>
@@ -747,14 +750,16 @@
 	      a.dueDate,
 	      a.workItemId,
 	      t.formName,
-	      t.subject
+	      t.subject,
+	      plog.correlationKey,
+	      plog.processType
 	      )
         from 
-        	AuditTaskImpl a
-        left join TaskImpl t on t.id = a.taskId
-        where 
-        	a.workItemId = :workItemId 
-        	
+          AuditTaskImpl a
+          inner join ProcessInstanceLog plog ON a.processInstanceId = plog.processInstanceId
+          left join TaskImpl t on t.id = a.taskId
+        where
+          a.workItemId = :workItemId 
     </query>
     <!-- hint name="org.hibernate.timeout" value="200"/ -->
   </named-query>
@@ -778,11 +783,14 @@
         a.dueDate,
         a.workItemId,
         t.formName,
-        t.subject
+        t.subject,
+        plog.correlationKey,
+        plog.processType
         )
         from 
           AuditTaskImpl a 
-        left join TaskImpl t on t.id = a.taskId
+          inner join ProcessInstanceLog plog ON a.processInstanceId = plog.processInstanceId
+          left join TaskImpl t on t.id = a.taskId
         where 
           a.processInstanceId = :processInstanceId
           and a.status in ( :statuses) 

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/RuntimeDataServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/RuntimeDataServiceImplTest.java
@@ -39,6 +39,7 @@ import org.jbpm.services.api.model.ProcessDefinition;
 import org.jbpm.services.api.model.ProcessInstanceDesc;
 import org.jbpm.services.api.model.UserTaskInstanceDesc;
 import org.jbpm.services.api.model.VariableDesc;
+import org.jbpm.workflow.core.WorkflowProcess;
 import org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl;
 import org.jbpm.workflow.instance.node.WorkItemNodeInstance;
 import org.junit.After;
@@ -1039,19 +1040,23 @@ public class RuntimeDataServiceImplTest extends AbstractKieServicesBaseTest {
     	assertEquals("Write a Document", userTask.getName());
 
     	NodeInstanceDesc nodeInstanceDesc = runtimeDataService.getNodeInstanceForWorkItem(userTask.getWorkItemId());
-		assertNull(userTask.getSlaCompliance());
-		assertNull(userTask.getSlaDueDate());
+    	assertNull(userTask.getSlaCompliance());
+    	assertNull(userTask.getSlaDueDate());
 
-		userTask = runtimeDataService.getTaskById(taskId,true);
-		assertNotNull(userTask);
+    	userTask = runtimeDataService.getTaskById(taskId, true);
+    	assertNotNull(userTask);
+    	assertEquals(nodeInstanceDesc.getSlaCompliance(), userTask.getSlaCompliance());
+    	assertEquals(nodeInstanceDesc.getSlaDueDate(), userTask.getSlaDueDate());
+    	
+    	assertNotNull(userTask.getCorrelationKey());
+    	assertNotNull(userTask.getProcessType());
+    	assertEquals((int) WorkflowProcess.PROCESS_TYPE, (int) userTask.getProcessType());
+    	assertEquals(processInstanceId, userTask.getProcessInstanceId());
 
-		assertEquals(nodeInstanceDesc.getSlaCompliance(), userTask.getSlaCompliance());
-		assertEquals(nodeInstanceDesc.getSlaDueDate(), userTask.getSlaDueDate());
-
-		userTask = runtimeDataService.getTaskById(taskId,false);
-		assertNotNull(userTask);
-		assertNull(userTask.getSlaCompliance());
-		assertNull(userTask.getSlaDueDate());
+    	userTask = runtimeDataService.getTaskById(taskId,false);
+    	assertNotNull(userTask);
+    	assertNull(userTask.getSlaCompliance());
+    	assertNull(userTask.getSlaDueDate());
     }
 
     @Test

--- a/jbpm-services/jbpm-services-api/src/build/revapi-config.json
+++ b/jbpm-services/jbpm-services-api/src/build/revapi-config.json
@@ -89,26 +89,61 @@
                     "methodName": "startProcessFromNodeIds",
                     "elementKind": "method",
                     "justification": "start nodes from an arbitray node"
-                }
-                ,
+                },
                 {
-				   "code": "java.method.addedToInterface",
-  					"new": "method java.lang.String org.jbpm.services.api.model.UserTaskInstanceDesc::getSubject()",
-   					"package": "org.jbpm.services.api.model",
-   					"classSimpleName": "UserTaskInstanceDesc",
-   					"methodName": "getSubject",
-   					"elementKind": "method",
-   					"justification": "subject should be returned by REST service"
- 				},
- 				{
-   					"code": "java.method.addedToInterface",
-   					"new": "method void org.jbpm.services.api.model.UserTaskInstanceDesc::setSubject(java.lang.String)",
-   					"package": "org.jbpm.services.api.model",
-   					"classSimpleName": "UserTaskInstanceDesc",
-   					"methodName": "setSubject",
-   					"elementKind": "method",
-   					"justification": "subject should be returned by REST service"
-				}
+                    "code": "java.method.addedToInterface",
+                    "new": "method java.lang.String org.jbpm.services.api.model.UserTaskInstanceDesc::getSubject()",
+                    "package": "org.jbpm.services.api.model",
+                    "classSimpleName": "UserTaskInstanceDesc",
+                    "methodName": "getSubject",
+                    "elementKind": "method",
+                    "justification": "subject should be returned by REST service"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method void org.jbpm.services.api.model.UserTaskInstanceDesc::setSubject(java.lang.String)",
+                    "package": "org.jbpm.services.api.model",
+                    "classSimpleName": "UserTaskInstanceDesc",
+                    "methodName": "setSubject",
+                    "elementKind": "method",
+                    "justification": "subject should be returned by REST service"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method java.lang.String org.jbpm.services.api.model.UserTaskInstanceDesc::getCorrelationKey()",
+                    "package": "org.jbpm.services.api.model",
+                    "classSimpleName": "UserTaskInstanceDesc",
+                    "methodName": "getCorrelationKey",
+                    "elementKind": "method",
+                    "justification": "https://issues.redhat.com/browse/BAPL-1623"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method void org.jbpm.services.api.model.UserTaskInstanceDesc::setCorrelationKey(java.lang.String)",
+                    "package": "org.jbpm.services.api.model",
+                    "classSimpleName": "UserTaskInstanceDesc",
+                    "methodName": "setCorrelationKey",
+                    "elementKind": "method",
+                    "justification": "https://issues.redhat.com/browse/BAPL-1623"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method java.lang.Integer org.jbpm.services.api.model.UserTaskInstanceDesc::getProcessType()",
+                    "package": "org.jbpm.services.api.model",
+                    "classSimpleName": "UserTaskInstanceDesc",
+                    "methodName": "getProcessType",
+                    "elementKind": "method",
+                    "justification": "https://issues.redhat.com/browse/BAPL-1623"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method void org.jbpm.services.api.model.UserTaskInstanceDesc::setProcessType(java.lang.Integer)",
+                    "package": "org.jbpm.services.api.model",
+                    "classSimpleName": "UserTaskInstanceDesc",
+                    "methodName": "setProcessType",
+                    "elementKind": "method",
+                    "justification": "https://issues.redhat.com/browse/BAPL-1623"
+                }
             ]
         }
     }

--- a/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/model/UserTaskInstanceDesc.java
+++ b/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/model/UserTaskInstanceDesc.java
@@ -134,15 +134,39 @@ public interface UserTaskInstanceDesc {
 	 */
 	void setSlaDueDate(Date slaDueDate);
 
-    /**
-       * Returns task subject 
-       * @return task subject
-       */
-    String getSubject();
+	/**
+	 * * Returns task subject 
+	 * @return task subject
+	 */
+	String getSubject();
 
-    /**
-     * Set task subject 
-     * @param subject task subject
-     */
-    void setSubject(String subject);
+	/**
+	 * Set task subject 
+	 * @param subject task subject
+	 */
+	void setSubject(String subject);
+
+	/**
+	 * Returns correlation key
+	 * @return correlation key
+	 */
+	String getCorrelationKey();
+
+	/**
+	 * Sets correlation key
+	 * @param correlationKey
+	 */
+	void setCorrelationKey(String correlationKey);
+
+	/**
+	 * Returns process type
+	 * @return 1 if process, 2 if case
+	 */
+	Integer getProcessType();
+
+	/**
+	 * Set process type
+	 * @param process type (1 for process, 2 for case)
+	 */
+	void setProcessType(Integer processType);
 }

--- a/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/query/QueryResultMapper.java
+++ b/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/query/QueryResultMapper.java
@@ -70,6 +70,7 @@ public interface QueryResultMapper<T> extends Serializable {
     public static final String COLUMN_IDENTITY = "USER_IDENTITY";
     public static final String COLUMN_PROCESSVERSION = "PROCESSVERSION";
     public static final String COLUMN_PROCESSNAME = "PROCESSNAME";
+    public static final String COLUMN_PROCESSTYPE = "PROCESSTYPE";
     public static final String COLUMN_CORRELATIONKEY = "CORRELATIONKEY";
     public static final String COLUMN_EXTERNALID = "EXTERNALID";
     public static final String COLUMN_PROCESSINSTANCEDESCRIPTION = "PROCESSINSTANCEDESCRIPTION";


### PR DESCRIPTION
CorrelationKey and ProcessType added to UserTaskDescription.

Existing APIs(getTaskById, getTaskByWorkItem and getTaskByProcess) are
reused, since I believe is preferable to assume the performance cost of
an extra join rather than having to maintain a new API for every
attribute combination (specially when there is already a join because of
the introduction of subject attribute)