### PR TITLE
[JBPM-9195] Case traceability from a Task Instance

### DIFF
--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/resources/META-INF/CaseMgmtorm.xml
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/resources/META-INF/CaseMgmtorm.xml
@@ -444,12 +444,13 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            inner join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.businessAdministrators businessAdministrators
             where
-            t.taskData.processInstanceId in (select log.processInstanceId from ProcessInstanceLog log where log.correlationKey like :caseId) and 
+            plog.correlationKey like :caseId and 
             t.archived = 0 and
             ( businessAdministrators.id = :userId or businessAdministrators.id in (:groupIds) ) and 
             t.taskData.status in (:status) 
@@ -478,13 +479,14 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            inner join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             left join t.peopleAssignments.excludedOwners as excludedOwners
             where
-            t.taskData.processInstanceId in (select log.processInstanceId from ProcessInstanceLog log where log.correlationKey like :caseId) and
+            plog.correlationKey like :caseId and
             t.archived = 0 and            
             (t.taskData.actualOwner.id = :userId or t.taskData.actualOwner is null) and 
             t.taskData.status in (:status) and 
@@ -514,12 +516,13 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            inner join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.taskStakeholders taskStakeholders
             where
-            t.taskData.processInstanceId in (select log.processInstanceId from ProcessInstanceLog log where log.correlationKey like :caseId) and
+            plog.correlationKey like :caseId and
             t.archived = 0 and                        
             t.taskData.status in (:status) and 
             ( taskStakeholders.id = :userId or taskStakeholders.id in (:groupIds) )

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/db2/db2-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/db2/db2-jbpm-schema.sql
@@ -413,6 +413,8 @@
         userId varchar(255),
         OPTLOCK integer,
         workItemId bigint,
+        correlationKey varchar(255),
+        processType integer,
         primary key (id)
     );
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/derby/derby-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/derby/derby-jbpm-schema.sql
@@ -413,6 +413,8 @@
         userId varchar(255),
         OPTLOCK integer,
         workItemId bigint,
+        correlationKey varchar(255),
+        processType integer,
         primary key (id)
     );
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/h2/h2-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/h2/h2-jbpm-schema.sql
@@ -413,6 +413,8 @@
         userId varchar(255),
         OPTLOCK integer,
         workItemId bigint,
+        correlationKey varchar(255),
+        processType integer,
         primary key (id)
     );
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/hsqldb/hsqldb-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/hsqldb/hsqldb-jbpm-schema.sql
@@ -413,6 +413,8 @@
         userId varchar(255),
         OPTLOCK integer,
         workItemId bigint,
+        correlationKey varchar(255),
+        processType integer,
         primary key (id)
     );
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
@@ -438,6 +438,8 @@
         userId varchar(255),
         OPTLOCK integer,
         workItemId bigint,
+        correlationKey varchar(255),
+        processType integer,
         primary key (id)
     );
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysqlinnodb/mysql-innodb-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysqlinnodb/mysql-innodb-jbpm-schema.sql
@@ -441,6 +441,8 @@
         userId varchar(255),
         OPTLOCK integer,
         workItemId bigint,
+        correlationKey varchar(255),
+        processType integer,
         primary key (id)
     );
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/oracle/oracle-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/oracle/oracle-jbpm-schema.sql
@@ -413,6 +413,8 @@
         userId varchar2(255 char),
         OPTLOCK number(10,0),
         workItemId number(19,0),
+        correlationKey varchar(255),
+        processType number(1,0),
         primary key (id)
     );
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-jbpm-schema.sql
@@ -413,6 +413,8 @@
         userId varchar(255),
         OPTLOCK int4,
         workItemId int8,
+        correlationKey varchar(255),
+        processType int2,
         primary key (id)
     );
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver/sqlserver-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver/sqlserver-jbpm-schema.sql
@@ -413,6 +413,8 @@
         userId varchar(255),
         OPTLOCK int,
         workItemId numeric(19,0),
+        correlationKey varchar(255),
+        processType numeric(1,0),
         primary key (id)
     );
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver2008/sqlserver2008-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver2008/sqlserver2008-jbpm-schema.sql
@@ -413,6 +413,8 @@
         userId varchar(255),
         OPTLOCK int,
         workItemId bigint,
+        correlationKey varchar(255),
+        processType smallint,
         primary key (id)
     );
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sybase/sybase-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sybase/sybase-jbpm-schema.sql
@@ -448,9 +448,11 @@
         processInstanceId numeric(19,0) null,
         taskId numeric(19,0) null,
         type varchar(255) null,
-        userId varchar(255) null,
+        userId varchar(255) null,			
         OPTLOCK int null,
         workItemId numeric(19,0) null,
+        correlationKey varchar(255),	
+        processType numeric(1,0),
         primary key (id)
     ) lock datarows
     go

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/db2/bpms-7.8-to-7.9.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/db2/bpms-7.8-to-7.9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType integer;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/db2/jbpm-7.40-to-7.41.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/db2/jbpm-7.40-to-7.41.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType integer;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/bpms-7.8-to-7.9.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/bpms-7.8-to-7.9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType integer;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/jbpm-7.40-to-7.41.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/jbpm-7.40-to-7.41.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType integer;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/bpms-7.8-to-7.9.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/bpms-7.8-to-7.9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType integer;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/jbpm-7.40-to-7.41.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/jbpm-7.40-to-7.41.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType integer;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/bpms-7.8-to-7.9.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/bpms-7.8-to-7.9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType integer;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/jbpm-7.40-to-7.41.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/jbpm-7.40-to-7.41.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType integer;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/bpms-7.8-to-7.9.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/bpms-7.8-to-7.9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType integer;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/jbpm-7.40-to-7.41.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/jbpm-7.40-to-7.41.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType integer;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/bpms-7.8-to-7.9.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/bpms-7.8-to-7.9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType integer;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/jbpm-7.40-to-7.41.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/jbpm-7.40-to-7.41.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType integer;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/bpms-7.8-to-7.9.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/bpms-7.8-to-7.9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType number(1,0);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/jbpm-7.40-to-7.41.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/jbpm-7.40-to-7.41.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType number(1,0);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/bpms-7.8-to-7.9.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/bpms-7.8-to-7.9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType int2;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/jbpm-7.40-to-7.41.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/jbpm-7.40-to-7.41.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType int2;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/bpms-7.8-to-7.9.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/bpms-7.8-to-7.9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType numeric(1,0);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/jbpm-7.40-to-7.41.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/jbpm-7.40-to-7.41.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType numeric(1,0);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/bpms-7.8-to-7.9.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/bpms-7.8-to-7.9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType smallint;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/jbpm-7.40-to-7.41.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/jbpm-7.40-to-7.41.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType smallint;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/bpms-7.8-to-7.9.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/bpms-7.8-to-7.9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType numeric(1,0);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/jbpm-7.40-to-7.41.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/jbpm-7.40-to-7.41.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TaskEvent ADD COLUMN correlationKey varchar(255);
+ALTER TABLE TaskEvent ADD COLUMN processType numeric(1,0);

--- a/jbpm-human-task/jbpm-human-task-audit/src/main/java/org/jbpm/services/task/audit/impl/model/TaskEventImpl.java
+++ b/jbpm-human-task/jbpm-human-task-audit/src/main/java/org/jbpm/services/task/audit/impl/model/TaskEventImpl.java
@@ -70,6 +70,10 @@ public class TaskEventImpl implements TaskEvent, Serializable {
 
   private String message;
 
+  private String correlationKey;
+
+  private Integer processType;
+
   @Temporal(javax.persistence.TemporalType.TIMESTAMP)
   private Date logTime;
 
@@ -146,6 +150,26 @@ public class TaskEventImpl implements TaskEvent, Serializable {
 
   public String getMessage() {
     return message;
+  }
+
+  @Override
+  public String getCorrelationKey() {
+    return correlationKey;
+}
+
+  @Override
+  public Integer getProcessType() {
+    return processType;
+  }
+
+  @Override
+  public void setCorrelationKey(String correlationKey) {
+    this.correlationKey = correlationKey;
+  }
+
+  @Override
+  public void setProcessType(Integer processType) {
+    this.processType = processType;
   }
 
   public void setMessage(String message) {

--- a/jbpm-human-task/jbpm-human-task-core/pom.xml
+++ b/jbpm-human-task/jbpm-human-task-core/pom.xml
@@ -157,6 +157,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-audit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
       <scope>test</scope>

--- a/jbpm-human-task/jbpm-human-task-core/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/filtered-resources/META-INF/persistence.xml
@@ -27,11 +27,9 @@
     <class>org.jbpm.services.task.impl.model.TaskImpl</class>
     <class>org.jbpm.services.task.impl.model.TaskDataImpl</class>
     <class>org.jbpm.services.task.impl.model.UserImpl</class>
-       
-    <!--BAM for task service 
-    <class>org.jbpm.services.task.impl.model.BAMTaskSummaryImpl</class>-->
     
-   
+    <class>org.jbpm.process.audit.ProcessInstanceLog</class>
+    
     <properties>
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}" />
       <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/query/TaskSummaryImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/query/TaskSummaryImpl.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import org.kie.api.task.model.Status;
 import org.kie.api.task.model.User;
-import org.kie.internal.task.api.TaskModelFactory;
 import org.kie.internal.task.api.TaskModelProvider;
 import org.kie.internal.task.api.model.InternalTaskSummary;
 import org.kie.internal.task.api.model.SubTasksStrategy;
@@ -52,6 +51,8 @@ public class TaskSummaryImpl implements InternalTaskSummary {
     private SubTasksStrategy subTaskStrategy;
     private long parentId;
     private boolean quickTaskSummary;
+    private String correlationKey;
+    private Integer processType;
 
     // JPQL does not accept collections in constructor arguments
     // In short, this means that this field will never be filled
@@ -150,6 +151,28 @@ public class TaskSummaryImpl implements InternalTaskSummary {
 
         this.quickTaskSummary = false;
     }
+    
+    /*
+     * Construct a QuickTaskSummary
+     */
+    public TaskSummaryImpl(long id,
+                           String name,
+                           String subject, 
+                           String description,
+                           Status status,
+                           int priority,
+                           String actualOwner,
+                           String createdBy,
+                           Date createdOn,
+                           Date activationTime,
+                           Date expirationTime,
+                           String processId,
+                           long processInstanceId,
+                           long parentId,
+                           String deploymentId,
+                           boolean skipable) {
+        this(id,name,subject,description,status,priority,actualOwner,createdBy,createdOn,activationTime,expirationTime,processId,processInstanceId,parentId,deploymentId,skipable,null,null);
+    }
 
     /*
      * Construct a QuickTaskSummary
@@ -169,7 +192,9 @@ public class TaskSummaryImpl implements InternalTaskSummary {
             long processInstanceId,
             long parentId,
             String deploymentId,
-            boolean skipable) {
+            boolean skipable,
+            String correlationKey,
+            Integer processType) {
         this.id = id;
         this.processInstanceId = processInstanceId;
         this.name = name;
@@ -189,6 +214,8 @@ public class TaskSummaryImpl implements InternalTaskSummary {
         this.parentId = parentId;
         this.deploymentId = deploymentId;
         this.skipable = skipable;
+        this.correlationKey = correlationKey;
+        this.processType = processType;
         this.quickTaskSummary = true;
     }
 
@@ -688,8 +715,18 @@ public class TaskSummaryImpl implements InternalTaskSummary {
     }
 
     @Override
+    public String getCorrelationKey() {
+        return correlationKey;
+    }
+
+    @Override
+    public Integer getProcessType() {
+        return processType;
+    }
+
+    @Override
     public String toString() {
-        return "TaskSummaryImpl{" + "id=" + id + ", name=" + name + ", subject=" + subject + ", description=" + description + ", statusId=" + statusId + ", priority=" + priority + ", skipable=" + skipable + ", actualOwnerId=" + actualOwnerId + ", createdById=" + createdById + ", createdOn=" + createdOn + ", activationTime=" + activationTime + ", expirationTime=" + expirationTime + ", processInstanceId=" + processInstanceId + ", processId=" + processId + ", processSessionId=" + processSessionId + ", deploymentId=" + deploymentId + ", parentId=" + parentId + ", potentialOwners=" + potentialOwners + ", quickTaskSummary=" + quickTaskSummary + '}';
+        return "TaskSummaryImpl{" + "id=" + id + ", name=" + name + ", subject=" + subject + ", description=" + description + ", statusId=" + statusId + ", priority=" + priority + ", skipable=" + skipable + ", actualOwnerId=" + actualOwnerId + ", createdById=" + createdById + ", createdOn=" + createdOn + ", activationTime=" + activationTime + ", expirationTime=" + expirationTime + ", processInstanceId=" + processInstanceId + ", processId=" + processId + ", processSessionId=" + processSessionId + ", deploymentId=" + deploymentId + ", parentId=" + parentId + ", potentialOwners=" + potentialOwners + ", quickTaskSummary=" + quickTaskSummary +", correlationKey="+correlationKey+",processType="+processType+'}';
     }
 
 

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/resources/META-INF/Taskorm.xml
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/resources/META-INF/Taskorm.xml
@@ -23,9 +23,12 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable,
+                plog.correlationKey,
+                plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.businessAdministrators businessAdministrators
             where
             t.archived = 0 and
@@ -53,9 +56,12 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable,
+                plog.correlationKey,
+                plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.businessAdministrators businessAdministrators
             where
             t.archived = 0 and
@@ -85,9 +91,12 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable,
+                plog.correlationKey,
+                plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.excludedOwners excludedOwners
             where
             t.archived = 0 and
@@ -115,9 +124,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and
@@ -148,9 +158,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and
@@ -181,9 +192,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
@@ -214,9 +226,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
@@ -247,9 +260,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
@@ -280,9 +294,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners 
             where
             t.archived = 0 and
@@ -334,9 +349,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
@@ -369,9 +385,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners 
             where
             t.archived = 0 and            
@@ -470,9 +487,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and
@@ -505,9 +523,9 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
-            TaskImpl t,
+            TaskImpl t left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId,
             OrganizationalEntityImpl potentialOwners
             where
             t.archived = 0 and
@@ -538,9 +556,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.recipients recipients
             where
             t.archived = 0 and
@@ -568,9 +587,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.taskInitiator taskInitiators
             where
             t.archived = 0 and
@@ -598,9 +618,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.taskStakeholders taskStakeholders
             where
             t.archived = 0 and
@@ -629,10 +650,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
-    
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 0 and
             t.taskData.actualOwner.id = :userId 
@@ -662,9 +683,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             left join t.peopleAssignments.potentialOwners potOwners
             where
             t.archived = 0 and          
@@ -696,10 +718,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
-    
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             left join t.peopleAssignments.potentialOwners potOwners
             where
             t.archived = 0 and
@@ -731,9 +753,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             left join t.peopleAssignments.potentialOwners potOwners
             where
             t.archived = 0 and          
@@ -770,9 +793,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
                 TaskImpl t 
+                left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             
             where
             t.archived = 0 and
@@ -800,10 +824,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
-            
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 0 and
             t.taskData.status = :status and
@@ -834,9 +858,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 1
 
@@ -864,10 +889,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
-    
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 0 and          
             t.taskData.actualOwner.id = :userId and
@@ -899,10 +924,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
-    
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.id in (:taskIds)  
             order by t.id DESC
@@ -1084,10 +1109,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
-            
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 0 and
             t.taskData.processInstanceId = :processInstanceId and
@@ -1116,10 +1141,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
-            
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 0 and
             t.taskData.processInstanceId = :processInstanceId and
@@ -1179,9 +1204,10 @@
             t.taskData.processInstanceId,
             t.taskData.parentId,
             t.taskData.deploymentId,
-            t.taskData.skipable              )
+            t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and
@@ -1217,9 +1243,10 @@
             t.taskData.processInstanceId,
             t.taskData.parentId,
             t.taskData.deploymentId,
-            t.taskData.skipable              )
+            t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
@@ -1252,9 +1279,10 @@
             t.taskData.processInstanceId,
             t.taskData.parentId,
             t.taskData.deploymentId,
-            t.taskData.skipable              )
+            t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
@@ -1287,9 +1315,10 @@
                     t.taskData.processInstanceId,
                     t.taskData.parentId,
                     t.taskData.deploymentId,
-                    t.taskData.skipable               )
+                    t.taskData.skipable, plog.correlationKey, plog.processType )
             from
                 TaskImpl t
+                left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
                 join t.peopleAssignments.potentialOwners potentialOwners
             where
                 t.archived = 0 and
@@ -1321,9 +1350,10 @@
                     t.taskData.processInstanceId,
                     t.taskData.parentId,
                     t.taskData.deploymentId,
-                    t.taskData.skipable              )
+                    t.taskData.skipable, plog.correlationKey, plog.processType)
             from
                 TaskImpl t
+                left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
                 join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
@@ -1355,9 +1385,10 @@
                     t.taskData.processInstanceId,
                     t.taskData.parentId,
                     t.taskData.deploymentId,
-                    t.taskData.skipable              )
+                    t.taskData.skipable, plog.correlationKey, plog.processType)
             from
                 TaskImpl t
+                left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
                 join t.peopleAssignments.potentialOwners potentialOwners
             where
                 t.archived = 0 and
@@ -1389,9 +1420,10 @@
                     t.taskData.processInstanceId,
                     t.taskData.parentId,
                     t.taskData.deploymentId,
-                    t.taskData.skipable              )
+                    t.taskData.skipable, plog.correlationKey, plog.processType)
             from
                 TaskImpl t
+                left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
                 t.archived = 0 and
                 t.taskData.actualOwner.id = :userId and

--- a/jbpm-human-task/jbpm-human-task-workitems/pom.xml
+++ b/jbpm-human-task/jbpm-human-task-workitems/pom.xml
@@ -64,6 +64,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-audit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
       <scope>test</scope>

--- a/jbpm-human-task/jbpm-human-task-workitems/src/test/resources/META-INF/persistence.xml
+++ b/jbpm-human-task/jbpm-human-task-workitems/src/test/resources/META-INF/persistence.xml
@@ -28,6 +28,8 @@
     <class>org.jbpm.services.task.impl.model.TaskDataImpl</class>
     <class>org.jbpm.services.task.impl.model.UserImpl</class>
     
+    <class>org.jbpm.process.audit.ProcessInstanceLog</class>
+    
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
 

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/model/UserTaskInstanceDesc.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/model/UserTaskInstanceDesc.java
@@ -42,6 +42,8 @@ public class UserTaskInstanceDesc implements org.jbpm.services.api.model.UserTas
 	private Date slaDueDate;
 	private Integer slaCompliance;
     private String subject;
+    private String correlationKey;
+    private Integer processType;
 
 
     public UserTaskInstanceDesc(Long taskId, String status,
@@ -57,20 +59,22 @@ public class UserTaskInstanceDesc implements org.jbpm.services.api.model.UserTas
 								Integer priority, String actualOwner, String createdBy, String deploymentId,
 								String processId, Long processInstanceId, Date createdOn, Date dueDate, Long workItemId) {
 		this(taskId, status, activationTime, name, description, priority, actualOwner, createdBy, deploymentId,
-             processId, processInstanceId, createdOn, dueDate, workItemId, null, null);
+             processId, processInstanceId, createdOn, dueDate, workItemId,null, null, null, null);
 	}
+	
 	
 	public UserTaskInstanceDesc(Long taskId, String status, Date activationTime, String name, String description,
                                 Integer priority, String actualOwner, String createdBy, String deploymentId,
-                                String processId, Long processInstanceId, Date createdOn, Date dueDate, Long workItemId, String formName, String subject) {
+                                String processId, Long processInstanceId, Date createdOn, Date dueDate, Long workItemId, String formName, String subject, String correlationKey, Integer processType) {
         this(taskId, status, activationTime, name, description, priority, actualOwner, createdBy, deploymentId,
-             processId, processInstanceId, createdOn, dueDate, workItemId, formName, subject, null, null);
+             processId, processInstanceId, createdOn, dueDate, workItemId, formName, subject, correlationKey, processType, null, null);
     }
-
+	
+	
     public UserTaskInstanceDesc(Long taskId, String status, Date activationTime, String name,
                                 String description,
                                 Integer priority, String actualOwner, String createdBy, String deploymentId,
-                                String processId, Long processInstanceId, Date createdOn, Date dueDate, Long workItemId, String formName, String subject,
+                                String processId, Long processInstanceId, Date createdOn, Date dueDate, Long workItemId, String formName, String subject, String correlationKey, Integer processType,
                                 Date slaDueDate, Integer slaCompliance) {
         this.taskId = taskId;
         this.status = status;
@@ -88,6 +92,8 @@ public class UserTaskInstanceDesc implements org.jbpm.services.api.model.UserTas
         this.workItemId = workItemId;
         this.formName = formName;
         this.subject = subject;
+        this.correlationKey = correlationKey;
+        this.processType = processType;
         this.slaDueDate = slaDueDate;
         this.slaCompliance = slaCompliance;
     }
@@ -246,22 +252,41 @@ public class UserTaskInstanceDesc implements org.jbpm.services.api.model.UserTas
 		this.slaCompliance = slaCompliance;
 	}
 
-
-    public String getSubject() {
-        return subject;
-    }
-
-    public void setSubject(String subject) {
+	@Override
+	public String getSubject() {
+	    return subject;
+	}
+	
+	@Override
+	public void setSubject(String subject) {
         this.subject = subject;
+	}
+
+	@Override
+	public String getCorrelationKey() {
+	    return correlationKey;
+	}
+
+	@Override
+	public void setCorrelationKey(String correlationKey) {
+	    this.correlationKey = correlationKey;
+	}
+
+	@Override
+	public Integer getProcessType() {
+	    return processType;
     }
 
 	@Override
-	public String toString() {
-		return "UserTaskInstanceDesc [taskId=" + taskId + ", name=" + name
-				+ ", deploymentId=" + deploymentId + ", processInstanceId="
-               + processInstanceId + ", workItemId=" + workItemId + ", subject=" + subject
-				+ ", slaCompliance=" + slaCompliance + ", slaDueDate=" + slaDueDate +"]";
+	public void setProcessType(Integer processType) {
+	    this.processType = processType;
 	}
 
-
+	@Override
+	public String toString() {
+	    return "UserTaskInstanceDesc [taskId=" + taskId + ", status=" + status + ", activationTime=" + activationTime + ", name=" + name + ", description=" + description + ", priority=" + priority + ", actualOwner=" +
+	            actualOwner + ", createdBy=" + createdBy + ", deploymentId=" + deploymentId + ", processId=" + processId + ", processInstanceId=" + processInstanceId + ", createdOn=" + createdOn + ", dueDate=" + dueDate +
+	            ", formName=" + formName + ", workItemId=" + workItemId + ", slaDueDate=" + slaDueDate + ", slaCompliance=" + slaCompliance + ", subject=" + subject + ", correlationKey=" + correlationKey +
+	            ", processType=" + processType + "]";
+	}
 }

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/mapper/TaskSummaryQueryMapper.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/mapper/TaskSummaryQueryMapper.java
@@ -82,7 +82,9 @@ public class TaskSummaryQueryMapper extends AbstractQueryMapper<TaskSummary> imp
                 getColumnLongValue(dataSetResult, COLUMN_TASK_PROCESSINSTANCEID, index),//processInstanceId,                                
                 -1l,
                 getColumnStringValue(dataSetResult, COLUMN_DEPLOYMENTID, index),//deploymentId,
-                false                
+                false,
+                getColumnStringValue(dataSetResult, COLUMN_CORRELATIONKEY, index),
+                getColumnIntValue(dataSetResult, COLUMN_PROCESSTYPE, index)
                 );
         
         return userTask;

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/mapper/UserTaskInstanceQueryMapper.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/mapper/UserTaskInstanceQueryMapper.java
@@ -80,7 +80,11 @@ public class UserTaskInstanceQueryMapper extends AbstractQueryMapper<UserTaskIns
                 getColumnDateValue(dataSetResult, COLUMN_DUEDATE, index),//dueDate
                 getColumnLongValue(dataSetResult, COLUMN_WORKITEMID, index), //workItemId
                 getColumnStringValue(dataSetResult, COLUMN_FORM_NAME, index),
-                getColumnStringValue(dataSetResult, COLUMN_SUBJECT, index)
+                getColumnStringValue(dataSetResult, COLUMN_SUBJECT, index),
+                getColumnStringValue(dataSetResult, COLUMN_CORRELATIONKEY, index), 
+                getColumnIntValue(dataSetResult, COLUMN_PROCESSTYPE, index),
+                getColumnDateValue(dataSetResult, COLUMN_TASK_SLA_DUE_DATE, index), 
+                getColumnIntValue(dataSetResult, COLUMN_TASK_SLA_COMPLIANCE, index)
                 );
         return userTask;
     }

--- a/jbpm-services/jbpm-kie-services/src/main/resources/META-INF/Servicesorm.xml
+++ b/jbpm-services/jbpm-kie-services/src/main/resources/META-INF/Servicesorm.xml
@@ -715,15 +715,18 @@
 	      a.processInstanceId,
 	      a.createdOn,
 	      a.dueDate,
-          a.workItemId,
-    	  t.formName,
-    	  t.subject
+	      a.workItemId,
+	      t.formName,
+	      t.subject,
+	      plog.correlationKey,
+	      plog.processType
 	      )
         from 
-        	AuditTaskImpl a
-        	left join TaskImpl t on t.id = a.taskId
+          AuditTaskImpl a
+          inner join ProcessInstanceLog plog ON a.processInstanceId = plog.processInstanceId
+          left join TaskImpl t on t.id = a.taskId
         where 
-        	a.taskId = :taskId
+          a.taskId = :taskId
     </query>
     <!-- hint name="org.hibernate.timeout" value="200"/ -->
   </named-query>
@@ -747,14 +750,16 @@
 	      a.dueDate,
 	      a.workItemId,
 	      t.formName,
-	      t.subject
+	      t.subject,
+	      plog.correlationKey,
+	      plog.processType
 	      )
         from 
-        	AuditTaskImpl a
-        left join TaskImpl t on t.id = a.taskId
-        where 
-        	a.workItemId = :workItemId 
-        	
+          AuditTaskImpl a
+          inner join ProcessInstanceLog plog ON a.processInstanceId = plog.processInstanceId
+          left join TaskImpl t on t.id = a.taskId
+        where
+          a.workItemId = :workItemId 
     </query>
     <!-- hint name="org.hibernate.timeout" value="200"/ -->
   </named-query>
@@ -778,11 +783,14 @@
         a.dueDate,
         a.workItemId,
         t.formName,
-        t.subject
+        t.subject,
+        plog.correlationKey,
+        plog.processType
         )
         from 
           AuditTaskImpl a 
-        left join TaskImpl t on t.id = a.taskId
+          inner join ProcessInstanceLog plog ON a.processInstanceId = plog.processInstanceId
+          left join TaskImpl t on t.id = a.taskId
         where 
           a.processInstanceId = :processInstanceId
           and a.status in ( :statuses) 

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/UserTaskServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/UserTaskServiceImplTest.java
@@ -929,5 +929,6 @@ private static final Logger logger = LoggerFactory.getLogger(KModuleDeploymentSe
         UserTaskInstanceDesc task = runtimeDataService.getTaskById(taskId);
         assertNotNull(task);
         assertEquals(Status.Ready.toString(), task.getStatus());
+        assertCorrelationAndProcess(task, processInstanceId);
     }
 }

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/test/util/AbstractKieServicesBaseTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/test/util/AbstractKieServicesBaseTest.java
@@ -16,8 +16,6 @@
 
 package org.jbpm.kie.test.util;
 
-import static org.junit.Assert.fail;
-
 import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
@@ -26,7 +24,9 @@ import org.dashbuilder.DataSetCore;
 import org.jbpm.kie.services.impl.FormManagerService;
 import org.jbpm.kie.services.impl.utils.DefaultKieServiceConfigurator;
 import org.jbpm.services.api.model.DeploymentUnit;
+import org.jbpm.services.api.model.UserTaskInstanceDesc;
 import org.jbpm.test.services.AbstractKieServicesTest;
+import org.jbpm.workflow.core.WorkflowProcess;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieFileSystem;
 import org.kie.api.builder.model.KieBaseModel;
@@ -35,7 +35,12 @@ import org.kie.api.builder.model.KieSessionModel;
 import org.kie.api.conf.EqualityBehaviorOption;
 import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.runtime.conf.ClockTypeOption;
+import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.io.ResourceFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 public abstract class AbstractKieServicesBaseTest extends AbstractKieServicesTest {
 
@@ -110,4 +115,33 @@ public abstract class AbstractKieServicesBaseTest extends AbstractKieServicesTes
         return kfs;
     }
 
+    protected void assertCorrelationAndProcess(UserTaskInstanceDesc userTask, long processInstanceId) {
+        assertCorrelationAndProcess(userTask, Long.toString(processInstanceId));
+    }
+
+    protected void assertCorrelationAndProcess(UserTaskInstanceDesc userTask, String correlationKey) {
+        assertEquals(correlationKey, userTask.getCorrelationKey());
+        assertEquals(Integer.valueOf(WorkflowProcess.PROCESS_TYPE), userTask.getProcessType());
+    }
+
+    protected void assertTasksDesc(List<UserTaskInstanceDesc> tasks, int expectedSize, long processInstanceId) {
+        assertNotNull(tasks);
+        assertEquals(expectedSize, tasks.size());
+        for (UserTaskInstanceDesc task : tasks) {
+            assertCorrelationAndProcess(task, processInstanceId);
+        }
+    }
+
+    protected void assertCorrelationAndProcess(TaskSummary userTask, long processInstanceId) {
+        assertEquals(Long.toString(processInstanceId), userTask.getCorrelationKey());
+        assertEquals(Integer.valueOf(WorkflowProcess.PROCESS_TYPE), userTask.getProcessType());
+    }
+
+    protected void assertTasksSummary(List<TaskSummary> userTasks, int expectedSize, long processInstanceId) {
+        assertNotNull(userTasks);
+        assertEquals(expectedSize, userTasks.size());
+        for (TaskSummary task : userTasks) {
+            assertCorrelationAndProcess(task, processInstanceId);
+        }
+    }
 }

--- a/jbpm-services/jbpm-services-api/src/build/revapi-config.json
+++ b/jbpm-services/jbpm-services-api/src/build/revapi-config.json
@@ -89,26 +89,61 @@
                     "methodName": "startProcessFromNodeIds",
                     "elementKind": "method",
                     "justification": "start nodes from an arbitray node"
-                }
-                ,
+                },
                 {
-				   "code": "java.method.addedToInterface",
-  					"new": "method java.lang.String org.jbpm.services.api.model.UserTaskInstanceDesc::getSubject()",
-   					"package": "org.jbpm.services.api.model",
-   					"classSimpleName": "UserTaskInstanceDesc",
-   					"methodName": "getSubject",
-   					"elementKind": "method",
-   					"justification": "subject should be returned by REST service"
- 				},
- 				{
-   					"code": "java.method.addedToInterface",
-   					"new": "method void org.jbpm.services.api.model.UserTaskInstanceDesc::setSubject(java.lang.String)",
-   					"package": "org.jbpm.services.api.model",
-   					"classSimpleName": "UserTaskInstanceDesc",
-   					"methodName": "setSubject",
-   					"elementKind": "method",
-   					"justification": "subject should be returned by REST service"
-				}
+                    "code": "java.method.addedToInterface",
+                    "new": "method java.lang.String org.jbpm.services.api.model.UserTaskInstanceDesc::getSubject()",
+                    "package": "org.jbpm.services.api.model",
+                    "classSimpleName": "UserTaskInstanceDesc",
+                    "methodName": "getSubject",
+                    "elementKind": "method",
+                    "justification": "subject should be returned by REST service"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method void org.jbpm.services.api.model.UserTaskInstanceDesc::setSubject(java.lang.String)",
+                    "package": "org.jbpm.services.api.model",
+                    "classSimpleName": "UserTaskInstanceDesc",
+                    "methodName": "setSubject",
+                    "elementKind": "method",
+                    "justification": "subject should be returned by REST service"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method java.lang.String org.jbpm.services.api.model.UserTaskInstanceDesc::getCorrelationKey()",
+                    "package": "org.jbpm.services.api.model",
+                    "classSimpleName": "UserTaskInstanceDesc",
+                    "methodName": "getCorrelationKey",
+                    "elementKind": "method",
+                    "justification": "https://issues.redhat.com/browse/BAPL-1623"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method void org.jbpm.services.api.model.UserTaskInstanceDesc::setCorrelationKey(java.lang.String)",
+                    "package": "org.jbpm.services.api.model",
+                    "classSimpleName": "UserTaskInstanceDesc",
+                    "methodName": "setCorrelationKey",
+                    "elementKind": "method",
+                    "justification": "https://issues.redhat.com/browse/BAPL-1623"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method java.lang.Integer org.jbpm.services.api.model.UserTaskInstanceDesc::getProcessType()",
+                    "package": "org.jbpm.services.api.model",
+                    "classSimpleName": "UserTaskInstanceDesc",
+                    "methodName": "getProcessType",
+                    "elementKind": "method",
+                    "justification": "https://issues.redhat.com/browse/BAPL-1623"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method void org.jbpm.services.api.model.UserTaskInstanceDesc::setProcessType(java.lang.Integer)",
+                    "package": "org.jbpm.services.api.model",
+                    "classSimpleName": "UserTaskInstanceDesc",
+                    "methodName": "setProcessType",
+                    "elementKind": "method",
+                    "justification": "https://issues.redhat.com/browse/BAPL-1623"
+                }
             ]
         }
     }

--- a/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/model/UserTaskInstanceDesc.java
+++ b/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/model/UserTaskInstanceDesc.java
@@ -134,15 +134,39 @@ public interface UserTaskInstanceDesc {
 	 */
 	void setSlaDueDate(Date slaDueDate);
 
-    /**
-       * Returns task subject 
-       * @return task subject
-       */
-    String getSubject();
+	/**
+	 * * Returns task subject 
+	 * @return task subject
+	 */
+	String getSubject();
 
-    /**
-     * Set task subject 
-     * @param subject task subject
-     */
-    void setSubject(String subject);
+	/**
+	 * Set task subject 
+	 * @param subject task subject
+	 */
+	void setSubject(String subject);
+
+	/**
+	 * Returns correlation key
+	 * @return correlation key
+	 */
+	String getCorrelationKey();
+
+	/**
+	 * Sets correlation key
+	 * @param correlationKey
+	 */
+	void setCorrelationKey(String correlationKey);
+
+	/**
+	 * Returns process type
+	 * @return 1 if process, 2 if case
+	 */
+	Integer getProcessType();
+
+	/**
+	 * Set process type
+	 * @param process type (1 for process, 2 for case)
+	 */
+	void setProcessType(Integer processType);
 }

--- a/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/query/QueryResultMapper.java
+++ b/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/query/QueryResultMapper.java
@@ -70,6 +70,7 @@ public interface QueryResultMapper<T> extends Serializable {
     public static final String COLUMN_IDENTITY = "USER_IDENTITY";
     public static final String COLUMN_PROCESSVERSION = "PROCESSVERSION";
     public static final String COLUMN_PROCESSNAME = "PROCESSNAME";
+    public static final String COLUMN_PROCESSTYPE = "PROCESSTYPE";
     public static final String COLUMN_CORRELATIONKEY = "CORRELATIONKEY";
     public static final String COLUMN_EXTERNALID = "EXTERNALID";
     public static final String COLUMN_PROCESSINSTANCEDESCRIPTION = "PROCESSINSTANCEDESCRIPTION";
@@ -98,6 +99,8 @@ public interface QueryResultMapper<T> extends Serializable {
     public static final String COLUMN_TASK_PROCESSINSTANCEID = "PROCESSINSTANCEID";
     public static final String COLUMN_TASK_STATUS = "STATUS";
     public static final String COLUMN_TASKID = "TASKID";
+    public static final String COLUMN_TASK_SLA_DUE_DATE = "SLA_DUE_DATE";
+    public static final String COLUMN_TASK_SLA_COMPLIANCE = "SLACOMPLIANCE";
     public static final String COLUMN_WORKITEMID = "WORKITEMID";
     public static final String COLUMN_ORGANIZATIONAL_ENTITY = "ID";
     public static final String COLUMN_EXCLUDED_OWNER = "ENTITY_ID";

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/RuntimeDataServiceTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/RuntimeDataServiceTest.java
@@ -15,9 +15,6 @@
  */
 package org.jbpm.services.cdi.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -59,6 +56,9 @@ import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.query.QueryFilter;
 import org.kie.internal.runtime.manager.context.EmptyContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 
 @RunWith(Arquillian.class)
@@ -266,7 +266,8 @@ public class RuntimeDataServiceTest extends AbstractKieServicesBaseTest {
         List<TaskSummary> tasks = runtimeDataService.getTasksAssignedAsPotentialOwnerByStatus("katy", statuses, new QueryFilter());
         assertNotNull(tasks);
         assertEquals(1, tasks.size());
-        
+        TaskSummary task = tasks.get(0);
+        assertCorrelationAndProcess(task, processInstance.getId());
         ksession.abortProcessInstance(processInstance.getId());
         
     }

--- a/jbpm-test-coverage/pom.xml
+++ b/jbpm-test-coverage/pom.xml
@@ -57,6 +57,11 @@
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-audit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
       <artifactId>jbpm-persistence-jpa</artifactId>
       <type>test-jar</type>
       <scope>test</scope>

--- a/jbpm-test-coverage/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-test-coverage/src/test/filtered-resources/META-INF/persistence.xml
@@ -135,6 +135,8 @@
       <class>org.jbpm.services.task.impl.model.TaskImpl</class>
       <class>org.jbpm.services.task.impl.model.TaskDataImpl</class>
       <class>org.jbpm.services.task.impl.model.UserImpl</class>
+      
+      <class>org.jbpm.process.audit.ProcessInstanceLog</class>
     
       <!--BAM for task service -->
       <class>org.jbpm.services.task.audit.impl.model.BAMTaskSummaryImpl</class>


### PR DESCRIPTION
CorrelationKey and ProcessType added to UserTaskDescription.

Depends on [droolsjbpm-knowledge:447](https://github.com/kiegroup/droolsjbpm-knowledge/pull/447) and merge together with https://github.com/kiegroup/droolsjbpm-integration/pull/2136

Existing APIs(getTaskById, getTaskByWorkItem and getTaskByProcess) are
reused, since I believe is preferable to assume the performance cost of
an extra join rather than having to maintain a new API for every
attribute combination (specially when there is already a join because of
the introduction of subject attribute)