### PR TITLE
[JBPM-9200] Tests for DB UserGroupCallback with declarative config

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/test/resources/jbpm.usergroup.callback.db.properties
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/resources/jbpm.usergroup.callback.db.properties
@@ -1,0 +1,4 @@
+db.ds.jndi.name = jdbc/jbpm-ds
+db.user.query = select userId from Users where userId = ?
+db.roles.query = select groupId from UserGroups where groupId = ?
+db.user.roles.query = select groupId from UserGroups where userId = ?


### PR DESCRIPTION
Refactoring this test class to parameterize it with the 2 possible configurations: programmatically and declaratively, as DOC team was asking about some examples of declaratively configuration to be properly documented.