### PR TITLE
[BAQE-1454] Stabilize flaky test: AsyncMultisubprocessTest

### DIFF
--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/async/AsyncMultisubprocessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/async/AsyncMultisubprocessTest.java
@@ -86,7 +86,7 @@ public class AsyncMultisubprocessTest extends JbpmTestCase {
 
         Map<String, Object> properties = new HashMap<>();
         properties.put("number_reviews", 4);
-        properties.put("approvalsRequired", 2);
+        properties.put("approvalsRequired", 4);
         properties.put("employee", "egonzale");
 
         ProcessInstance processInstance = ksession.startProcess(PROCESS_AICS, properties);


### PR DESCRIPTION
Sometimes this test **AsyncMultisubprocessTest** fails, depending on the CPU processing time.

The issue is because 4 iterations (_number_reviews_ variable) for multisubprocess are asynchronously launched, and when two of them (_approvalsRequired_ variable) are completed, the outcome variable switches to true, so processes finishes and uncompleted tasks change to `Exited` status, which makes them fail if they are still trying to transition.

_org.jbpm.services.task.exception.PermissionDeniedException: User '[UserImpl:'rhpamAdmin']' was unable to execute operation 'Claim' on task id 3 due to a no 'current status' match_

I think the easier fix is to force that _approvalsRequired_ are the same as _number_reviews_, so completion condition cannot be achieved while transitioning other human tasks with claim/start/complete actions.