### PR TITLE
JBPM-9205 - Make jbpm-workitems-webservice to compile to JDK 8 target…

### DIFF
--- a/jbpm-workitems/jbpm-workitems-webservice/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-webservice/pom.xml
@@ -235,47 +235,5 @@
       </plugin>
     </plugins>
   </build>
-  
-  <profiles>
-    <profile>
-      <id>jdk-11-compile</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <release>11</release>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-    <profile>
-      <id>jdk-8-compile</id>
-      <activation>
-        <jdk>(,9)</jdk>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <source>8</source>
-                <target>8</target>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-  </profiles>
 
 </project>

--- a/jbpm-workitems/jbpm-workitems-webservice/src/main/java/org/jbpm/process/workitem/webservice/WebServiceWorkItemHandler.java
+++ b/jbpm-workitems/jbpm-workitems-webservice/src/main/java/org/jbpm/process/workitem/webservice/WebServiceWorkItemHandler.java
@@ -40,6 +40,7 @@ import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.WidResult;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 import org.jbpm.workflow.core.impl.WorkflowProcessImpl;
 import org.kie.api.runtime.KieSession;
@@ -82,7 +83,8 @@ import org.slf4j.LoggerFactory;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "webservice,call",
-                action = @WidAction(title = "Perform a WebService call")
+                action = @WidAction(title = "Perform a WebService call"),
+                authinfo = @WidAuth
         ))
 public class WebServiceWorkItemHandler extends AbstractLogOrThrowWorkItemHandler implements Cacheable {
 


### PR DESCRIPTION
… with JDK 11

@gmunozfe Finally found a way how to run these annotation processors with JDK 11 and target of JDK 8. I already have a reproducer to fiel a bug in maven-compiler-plugin/java compiler so stay tuned for more.