### PR TITLE
[JBPM-9223] include case file details in case list.

### DIFF
--- a/jbpm-case-mgmt/jbpm-case-mgmt-api/src/main/java/org/jbpm/casemgmt/api/CaseRuntimeDataService.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-api/src/main/java/org/jbpm/casemgmt/api/CaseRuntimeDataService.java
@@ -184,6 +184,14 @@ public interface CaseRuntimeDataService {
      *
      */
     Collection<CaseInstance> getCaseInstances(QueryContext queryContext);
+    
+    /**
+     * Returns all available active case instances
+     * @param withData indicates if case file data should be included in the result
+     * @param queryContext control parameters for the result e.g. sorting, paging
+     *
+     */
+    Collection<CaseInstance> getCaseInstances(boolean withData, QueryContext queryContext);
 
     /**
      * Returns all first level children cases given an parent id case.
@@ -209,6 +217,15 @@ public interface CaseRuntimeDataService {
     Collection<CaseInstance> getCaseInstances(List<CaseStatus> statuses, QueryContext queryContext);
     
     /**
+     * Returns all available active case instances that match given statuses
+     * @param statuses list of statuses that case should be in to match
+     * @param withData indicates if case file information should be included in returned instances
+     * @param queryContext control parameters for the result e.g. sorting, paging
+     *
+     */
+    Collection<CaseInstance> getCaseInstances(List<CaseStatus> statuses, boolean withData, QueryContext queryContext);
+    
+    /**
      * Returns all available case instances;
      * @param deploymentId deployment identifier that case instance is part of
      * @param statuses list of statuses that case should be in to match
@@ -216,6 +233,16 @@ public interface CaseRuntimeDataService {
      *
      */
     Collection<CaseInstance> getCaseInstancesByDeployment(String deploymentId, List<CaseStatus> statuses, QueryContext queryContext);
+    
+    /**
+     * Returns all available case instances;
+     * @param deploymentId deployment identifier that case instance is part of
+     * @param statuses list of statuses that case should be in to match
+     * @param withData indicates if case file data should be included in the result 
+     * @param queryContext control parameters for the result e.g. sorting, paging
+     *
+     */
+    Collection<CaseInstance> getCaseInstancesByDeployment(String deploymentId, List<CaseStatus> statuses, boolean withData, QueryContext queryContext);
     
     /**
      * Returns all available case instances;
@@ -227,12 +254,32 @@ public interface CaseRuntimeDataService {
     Collection<CaseInstance> getCaseInstancesByDefinition(String caseDefinitionId, List<CaseStatus> statuses, QueryContext queryContext);
     
     /**
+     * Returns all available case instances;
+     * @param caseDefinitionId case definition id
+     * @param statuses list of statuses that case should be in to match
+     * @param withData indicates if case file data should be included in the result 
+     * @param queryContext control parameters for the result e.g. sorting, paging 
+     *
+     */
+    Collection<CaseInstance> getCaseInstancesByDefinition(String caseDefinitionId, List<CaseStatus> statuses, boolean withData, QueryContext queryContext);
+    
+    /**
      * Returns all case instances owned by given user
+     * @param owner user owning task
      * @param statuses list of statuses that case should be in to match
      * @param queryContext control parameters for the result e.g. sorting, paging
      *
      */
     Collection<CaseInstance> getCaseInstancesOwnedBy(String owner, List<CaseStatus> statuses, QueryContext queryContext);
+    
+    /**
+     * Returns all case instances owned by given user
+     * @param owner user owning task
+     * @param statuses list of statuses that case should be in to match
+     * @param queryContext control parameters for the result e.g. sorting, paging
+     * @param withData indicates if case file data should be included in the result
+     */
+    Collection<CaseInstance> getCaseInstancesOwnedBy(String owner, List<CaseStatus> statuses, boolean withData, QueryContext queryContext);
     
     /**
      * Returns cases instances that given user (via identity provider) has access to with given role.
@@ -243,11 +290,28 @@ public interface CaseRuntimeDataService {
     Collection<CaseInstance> getCaseInstancesByRole(String roleName, List<CaseStatus> statuses, QueryContext queryContext);
     
     /**
+     * Returns cases instances that given user (via identity provider) has access to with given role.
+     * @param roleName name of the role that user should be
+     * @param statuses statuses of the case instances
+     * @param withData indicates if case file data should be included in the result
+     * @param queryContext control parameters for the result e.g. sorting, paging
+     */
+    Collection<CaseInstance> getCaseInstancesByRole(String roleName, List<CaseStatus> statuses, boolean withData, QueryContext queryContext);
+    
+    /**
      * Returns case instances that given user (via identity provider) is involved in in any role.
      * @param statuses statuses of the case instances
      * @param queryContext control parameters for the result e.g. sorting, paging
      */
     Collection<CaseInstance> getCaseInstancesAnyRole(List<CaseStatus> statuses, QueryContext queryContext);
+    
+    /**
+     * Returns case instances that given user (via identity provider) is involved in in any role.
+     * @param statuses statuses of the case instances
+     * @param withData indicates if case file data should be included in the result
+     * @param queryContext control parameters for the result e.g. sorting, paging
+     */
+    Collection<CaseInstance> getCaseInstancesAnyRole(List<CaseStatus> statuses, boolean withData, QueryContext queryContext);
     
     /**
      * Returns all available active case instances that match given statuses and has case file data item with given name
@@ -258,6 +322,15 @@ public interface CaseRuntimeDataService {
     Collection<CaseInstance> getCaseInstancesByDataItem(String dataItemName, List<CaseStatus> statuses, QueryContext queryContext);
     
     /**
+     * Returns all available active case instances that match given statuses and has case file data item with given name
+     * @param dataItemName name of the case file data item
+     * @param statuses list of statuses that case should be in to match
+     * @param withData indicates if case file data should be included in the result
+     * @param queryContext control parameters for the result e.g. sorting, paging
+     */
+    Collection<CaseInstance> getCaseInstancesByDataItem(String dataItemName, List<CaseStatus> statuses, boolean withData, QueryContext queryContext);
+    
+    /**
      * Returns all available active case instances that match given statuses and has case file data item with given name and value
      * @param dataItemName name of the case file data item
      * @param dataItemValue expected value of the data item
@@ -265,6 +338,16 @@ public interface CaseRuntimeDataService {
      * @param queryContext control parameters for the result e.g. sorting, paging
      */
     Collection<CaseInstance> getCaseInstancesByDataItemAndValue(String dataItemName, String dataItemValue, List<CaseStatus> statuses, QueryContext queryContext);
+    
+    /**
+     * Returns all available active case instances that match given statuses and has case file data item with given name and value
+     * @param dataItemName name of the case file data item
+     * @param dataItemValue expected value of the data item
+     * @param statuses list of statuses that case should be in to match
+     * @param withData indicates if case file data should be included in the result
+     * @param queryContext control parameters for the result e.g. sorting, paging
+     */
+    Collection<CaseInstance> getCaseInstancesByDataItemAndValue(String dataItemName, String dataItemValue, List<CaseStatus> statuses, boolean withData, QueryContext queryContext);
     
     /**
      * Returns all tasks associated with given case id that are eligible for user to see.

--- a/jbpm-case-mgmt/jbpm-case-mgmt-api/src/main/java/org/jbpm/casemgmt/api/model/instance/CaseInstance.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-api/src/main/java/org/jbpm/casemgmt/api/model/instance/CaseInstance.java
@@ -19,8 +19,6 @@ package org.jbpm.casemgmt.api.model.instance;
 import java.util.Collection;
 import java.util.Date;
 
-import org.jbpm.casemgmt.api.CaseService;
-
 /**
  * Describes case structure and requirements.
  *
@@ -60,11 +58,17 @@ public interface CaseInstance {
     /**
      * Returns case file associated with this case.
      * <p>
-     *     Note: {@link CaseInstance#getCaseFile()} will always be empty.
-     *     Refer to using {@link CaseService#getCaseFileInstance(String)} when access to case file information is needed.
-     *  </p>
+     *     Note: {@link CaseInstance#getCaseFile()} will be empty unless <code>withData</code> flag is specified 
+     * </p>
      */
     CaseFileInstance getCaseFile();
+    
+    
+    /**
+     * Sets case file information to this instance 
+     * @param caseFileInstance caseFileInstance information
+     */
+    void setCaseFile (CaseFileInstance  caseFileInstance);
     
     /**
      * Returns status of the case

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/CaseServiceImpl.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/CaseServiceImpl.java
@@ -135,6 +135,7 @@ public class CaseServiceImpl implements CaseService {
     
     public void setCaseRuntimeDataService(CaseRuntimeDataService caseRuntimeDataService) {
         this.caseRuntimeDataService = caseRuntimeDataService;
+        ((CaseRuntimeDataServiceImpl)caseRuntimeDataService).setCaseService(this);
     }
     
     public void setCaseIdGenerator(CaseIdGenerator caseIdGenerator) {

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/model/instance/CaseInstanceImpl.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/model/instance/CaseInstanceImpl.java
@@ -211,7 +211,7 @@ public class CaseInstanceImpl implements CaseInstance, Serializable {
         this.caseRoles = caseRoles;
     }
 
-    
+    @Override
     public void setCaseFile(CaseFileInstance caseFile) {
         this.caseFile = caseFile;
     }

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/CaseRuntimeDataServiceImplTest.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/CaseRuntimeDataServiceImplTest.java
@@ -19,6 +19,7 @@ package org.jbpm.casemgmt.impl;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -88,21 +89,12 @@ public class CaseRuntimeDataServiceImplTest extends AbstractCaseServicesBaseTest
             assertEquals(FIRST_CASE_ID, cInstance.getCaseId());
             assertNotNull(cInstance.getCaseFile());
             assertEquals("my first case", cInstance.getCaseFile().getData("name"));
+            
+            List<CaseStatus> statuses = Collections.singletonList(CaseStatus.OPEN);
 
-            Collection<CaseInstance> instances = caseRuntimeDataService.getCaseInstances(new QueryContext());
-            assertNotNull(instances);
-
-            assertEquals(1, instances.size());
-            CaseInstance instance = instances.iterator().next();
-            assertNotNull(instance);
-
-            assertEquals(FIRST_CASE_ID, instance.getCaseId());
-            assertEquals(EMPTY_CASE_P_ID, instance.getCaseDefinitionId());
-            assertEquals("my first case", instance.getCaseDescription());
-            assertEquals(USER, instance.getOwner());
-            assertEquals(ProcessInstance.STATE_ACTIVE, instance.getStatus().intValue());
-            assertEquals(deploymentUnit.getIdentifier(), instance.getDeploymentId());
-            assertNotNull(instance.getStartedAt());
+            assertCaseInstance(caseRuntimeDataService.getCaseInstances(statuses, true, new QueryContext()));
+            assertCaseInstance(caseRuntimeDataService.getCaseInstancesByDefinition(EMPTY_CASE_P_ID, statuses, true, new QueryContext()));
+            assertCaseInstance(caseRuntimeDataService.getCaseInstancesByDeployment(deploymentUnit.getIdentifier(), statuses, true, new QueryContext()));
 
             // add dynamic user task to empty case instance - first by case id
             Map<String, Object> parameters = new HashMap<>();
@@ -130,6 +122,23 @@ public class CaseRuntimeDataServiceImplTest extends AbstractCaseServicesBaseTest
                 caseService.cancelCase(caseId);
             }
         }
+    }
+    
+    private void assertCaseInstance (Collection<CaseInstance> instances) {
+        assertNotNull(instances);
+
+        assertEquals(1, instances.size());
+        CaseInstance instance = instances.iterator().next();
+        assertNotNull(instance);
+
+        assertEquals(FIRST_CASE_ID, instance.getCaseId());
+        assertEquals(EMPTY_CASE_P_ID, instance.getCaseDefinitionId());
+        assertEquals("my first case", instance.getCaseDescription());
+        assertEquals(USER, instance.getOwner());
+        assertEquals(ProcessInstance.STATE_ACTIVE, instance.getStatus().intValue());
+        assertEquals(deploymentUnit.getIdentifier(), instance.getDeploymentId());
+        assertEquals("my first case", instance.getCaseFile().getData("name"));
+        assertNotNull(instance.getStartedAt());
     }
 
     @Test


### PR DESCRIPTION
Adding new overloaded getCaseInstances method to CaseRuntimeDataService that allows the possibility to include case file information if a flag is set

Merge with [droolsjbpm-integration:2151](https://github.com/kiegroup/droolsjbpm-integration/pull/2151)