### PR TITLE
[RHPAM-3048] Consider empty string an invalid value for required

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/VariableTagsTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/VariableTagsTest.java
@@ -90,6 +90,17 @@ import static org.junit.Assert.assertTrue;
          
          assertThatExceptionOfType(VariableViolationException.class).isThrownBy(() -> ksession.startProcess("approvals", parameters));
      }
+     
+     @Test
+     public void testProcessWithEmptyRequiredVariable() throws Exception {
+         ksession = createSessionAndRegisterWorkItemHandler("variable-tags/approval-with-required-variable-tags.bpmn2");
+
+         Map<String, Object> parameters = new HashMap<>();
+         parameters.put("approver", "   ");
+         
+         assertThatExceptionOfType(VariableViolationException.class).isThrownBy(() -> ksession.startProcess("approvals", parameters));
+     }
+
 
      @Test
      public void testProcessWithRequiredVariable() throws Exception {

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/CaseServiceImplTest.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/CaseServiceImplTest.java
@@ -4011,6 +4011,24 @@ public class CaseServiceImplTest extends AbstractCaseServicesBaseTest {
     }
     
     @Test
+    public void testCaseWithMissingRequiredEmptyCaseFileItem() {
+        Map<String, OrganizationalEntity> roleAssignments = new HashMap<>();
+        roleAssignments.put("owner", new UserImpl("john"));
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("s", "");
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(), USER_TASK_REQUIRED_V_CASE_P_ID, data, roleAssignments);
+
+        assertThatExceptionOfType(VariableViolationException.class)
+            .isThrownBy(() -> caseService.startCase(deploymentUnit.getIdentifier(), USER_TASK_REQUIRED_V_CASE_P_ID, caseFile));
+      
+        
+        assertThatExceptionOfType(CaseNotFoundException.class)
+            .isThrownBy(() -> caseService.getCaseInstance(FIRST_CASE_ID));
+        
+    }
+    
+    @Test
     public void testCaseWithRestrictedCaseFileItem() {
         Map<String, OrganizationalEntity> roleAssignments = new HashMap<>();
         roleAssignments.put("owner", new UserImpl("john"));

--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeInstance.java
@@ -181,7 +181,7 @@ public class VariableScopeInstance extends AbstractContextInstance {
                         
                     }
                     // otherwise check variables                    
-                } else if (!variables.containsKey(name)) {
+                } else if (!hasData(variables.get(name))) {
                     throw new VariableViolationException(getProcessInstance().getId(), name, "Variable '" + name + "' is required but not set");
                 }
                 
@@ -197,12 +197,16 @@ public class VariableScopeInstance extends AbstractContextInstance {
         Collection<CaseData> caseFiles = (Collection<CaseData>) getProcessInstance().getKnowledgeRuntime().getObjects(new ClassObjectFilter(CaseData.class));
         if (caseFiles.size() == 1) {
             CaseData caseData = caseFiles.iterator().next();
-            if (caseData.getData(nameInCaseFile) != null) {
+            if (hasData(caseData.getData(nameInCaseFile))) {
                 found = true;
             }
         }
         
         return found;
+    }
+    
+    private boolean hasData(Object data) {
+        return data != null && (!(data instanceof CharSequence) || !data.toString().trim().isEmpty());
     }
 
 }


### PR DESCRIPTION
if the value is an empty string, the variable is not consider as
present.