### PR TITLE
Add a drl to an empty kjar to avoid EmptyKnowledgeBuilder issue

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/FilteredKModuleDeploymentServiceTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/FilteredKModuleDeploymentServiceTest.java
@@ -456,6 +456,7 @@ public class FilteredKModuleDeploymentServiceTest extends AbstractKieServicesBas
             .setGroupId( groupId )
             .setArtifactId( projectArtifactId )
             .setVersion( version )
+            .addResourceFilePath("/example/simple.drl")
             .addDependencies( groupId + ":" + pojoArtifactId + ":" + version )
             .createKieJarAndDeployToMaven();
 

--- a/jbpm-services/jbpm-kie-services/src/test/resources/example/simple.drl
+++ b/jbpm-services/jbpm-kie-services/src/test/resources/example/simple.drl
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package example;
+
+rule "simple"
+when
+    $s : String()
+then
+end


### PR DESCRIPTION
Since https://github.com/kiegroup/drools/commit/f176109d4ff89c52a341b2a781ac616552efbc21 , this test fails because it uses an empty kjar. Added a drl.