### PR TITLE
[JBPM-9258] Sybase: GetSubTasksByParentTaskId query syntax fails

### DIFF
--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/resources/META-INF/Taskorm.xml
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/resources/META-INF/Taskorm.xml
@@ -525,8 +525,7 @@
                 t.taskData.deploymentId,
                 t.taskData.skipable, plog.correlationKey, plog.processType)
             from
-            TaskImpl t left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId,
-            OrganizationalEntityImpl potentialOwners
+            TaskImpl t left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 0 and
             t.taskData.parentId = :parentId and


### PR DESCRIPTION
After [jbpm#1680](https://github.com/kiegroup/jbpm/pull/1680), when the join clause was added to this query an exception has come out only for sybase.

Removed `OrganizationalEntityImpl potentialOwners` from the query, as it was useless, will solve it. 