### PR TITLE
[JBPM-9249] Process upgrade fails in RHPAM 7.7 if process instance ha…

### DIFF
--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/migration/MigrationManager.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/migration/MigrationManager.java
@@ -603,7 +603,7 @@ public class MigrationManager {
                                     TimerInstance timerInstance = timerManager.getTimerMap().get(timerId);
                                     if (timerInstance==null) {
                                         report.addEntry(Type.WARN, "Could not find timer instance with id "+timerId+" to cancel.");
-                                    	break;
+                                        continue;
                                     }
                                     timerManager.cancelTimer(timerInstance.getId());
                                     collected.add(timerInstance);


### PR DESCRIPTION
…s active timer and its migrated from BPMS 6.4 release

not migration when a timer instance is not up to date.