### PR TITLE
[JBPM-9259] Create a test to validate new springboot DDL scripts

### DIFF
--- a/jbpm-db-scripts/src/test/java/org/jbpm/persistence/scripts/DDLScriptsTest.java
+++ b/jbpm-db-scripts/src/test/java/org/jbpm/persistence/scripts/DDLScriptsTest.java
@@ -17,6 +17,7 @@
 package org.jbpm.persistence.scripts;
 
 import org.jbpm.test.persistence.scripts.ScriptsBase;
+import org.jbpm.test.persistence.scripts.util.ScriptFilter;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,13 +34,13 @@ public class DDLScriptsTest extends ScriptsBase {
      */
     @Test
     public void createAndDropSchemaUsingDDLs() throws Exception {
-        executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, true);
+        executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, ScriptFilter.init(false, true));
         validateAndPersistProcess();
         validateQuartz();
-        executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, false);
+        executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, ScriptFilter.init(false, false));
     }
 
-    private void validateAndPersistProcess() {
+    protected void validateAndPersistProcess() {
         final TestPersistenceContext dbTestingContext = createAndInitContext(DB_TESTING_VALIDATE);
         try {
             dbTestingContext.startAndPersistSomeProcess(TEST_PROCESS_ID);
@@ -49,7 +50,7 @@ public class DDLScriptsTest extends ScriptsBase {
         }
     }
 
-    private void validateQuartz() {
+    protected void validateQuartz() {
         final TestPersistenceContext dbquartzContext = createAndInitContext(DB_QUARTZ_VALIDATE);
         dbquartzContext.clean();
     }

--- a/jbpm-db-scripts/src/test/java/org/jbpm/persistence/scripts/GenerateDDLScriptsTests.java
+++ b/jbpm-db-scripts/src/test/java/org/jbpm/persistence/scripts/GenerateDDLScriptsTests.java
@@ -58,11 +58,11 @@ public class GenerateDDLScriptsTests {
         }
 
         public Path buildCreateFile(Path basePath) {
-            return basePath.resolve(alias).resolve(prefix + "-" + (this.newGenerator ? "new-" : "") + "jbpm-schema.sql");
+            return basePath.resolve(alias).resolve(prefix + "-" + (this.newGenerator ? "springboot-" : "") + "jbpm-schema.sql");
         }
 
         public Path buildDropFile(Path basePath) {
-            return basePath.resolve(alias).resolve(prefix + "-" + (this.newGenerator ? "new-" : "") + "jbpm-drop-schema.sql");
+            return basePath.resolve(alias).resolve(prefix + "-" + (this.newGenerator ? "springboot-" : "") + "jbpm-drop-schema.sql");
         }
 
         public String getNewGenerator() {

--- a/jbpm-db-scripts/src/test/java/org/jbpm/persistence/scripts/SpringbootDDLScriptsTest.java
+++ b/jbpm-db-scripts/src/test/java/org/jbpm/persistence/scripts/SpringbootDDLScriptsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.persistence.scripts;
+
+import org.jbpm.test.persistence.scripts.util.ScriptFilter;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.jbpm.test.persistence.scripts.DatabaseType.POSTGRESQL;
+import static org.jbpm.test.persistence.scripts.DatabaseType.ORACLE;
+import static org.junit.Assume.assumeTrue;
+
+import org.jbpm.test.persistence.scripts.DatabaseType;
+
+/**
+ * Contains tests that test springboot DDL scripts for postgresql and oracle only.
+ */
+public class SpringbootDDLScriptsTest extends DDLScriptsTest {
+    
+    @BeforeClass
+    public static void hasToBeTested() {
+        // execute these springboot tests only for postgresql and oracle
+        TestPersistenceContext ctx = new TestPersistenceContext();
+        DatabaseType dbType = ctx.getDatabaseType();
+        assumeTrue(dbType==POSTGRESQL || dbType==ORACLE);
+    }
+    
+    /**
+     * Tests that DB schema is created properly using Springboot DDL scripts.
+     */
+    @Test
+    @Override
+    public void createAndDropSchemaUsingDDLs() throws Exception {
+        executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, ScriptFilter.init(true, true));
+        validateAndPersistProcess();
+        executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, ScriptFilter.init(true, false));
+    }
+}

--- a/jbpm-db-scripts/src/test/java/org/jbpm/persistence/scripts/UpgradeScriptsTest.java
+++ b/jbpm-db-scripts/src/test/java/org/jbpm/persistence/scripts/UpgradeScriptsTest.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import org.jbpm.test.persistence.scripts.DatabaseType;
 import org.jbpm.test.persistence.scripts.PersistenceUnit;
 import org.jbpm.test.persistence.scripts.ScriptsBase;
+import org.jbpm.test.persistence.scripts.util.ScriptFilter;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -77,14 +78,14 @@ public class UpgradeScriptsTest extends ScriptsBase {
     
     private void createSchema60UsingDDLs() throws IOException, SQLException {
         //create 6.0 schema
-        executeScriptRunner(DB_60_SCRIPTS_RESOURCE_PATH, true);
+        executeScriptRunner(DB_60_SCRIPTS_RESOURCE_PATH, ScriptFilter.init(false, true));
     }
     
     private void dropFinalSchemaAfterUpgradingUsingDDLs() throws IOException, SQLException {
         //drop schema
         //need to drop constraints from 6.0 first
-        executeScriptRunner(DB_60_SCRIPTS_RESOURCE_PATH, false);
-        executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, false);
+        executeScriptRunner(DB_60_SCRIPTS_RESOURCE_PATH, ScriptFilter.init(false, false));
+        executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, ScriptFilter.init(false, false));
     }
     
     /**
@@ -96,7 +97,7 @@ public class UpgradeScriptsTest extends ScriptsBase {
         logger.info("entering testExecutingScripts with type: {} ", product);
         try {
             createSchema60UsingDDLs();
-            executeScriptRunner(DB_UPGRADE_SCRIPTS_RESOURCE_PATH, true, product);
+            executeScriptRunner(DB_UPGRADE_SCRIPTS_RESOURCE_PATH, ScriptFilter.init(false, true), product);
             startAndPersistSomeProcess();
         }finally {
             dropFinalSchemaAfterUpgradingUsingDDLs();
@@ -138,7 +139,8 @@ public class UpgradeScriptsTest extends ScriptsBase {
             scriptRunnerContext.persistOldProcessAndSession(TEST_SESSION_ID, TEST_PROCESS_ID, TEST_PROCESS_INSTANCE_ID);
             scriptRunnerContext.createSomeTask();
             // Execute upgrade scripts.
-            scriptRunnerContext.executeScripts(new File(getClass().getResource(DB_UPGRADE_SCRIPTS_RESOURCE_PATH).getFile()), true, type);
+            scriptRunnerContext.executeScripts(new File(getClass().getResource(DB_UPGRADE_SCRIPTS_RESOURCE_PATH).getFile()), 
+                                               ScriptFilter.init(false, true), type);
         } finally {
             scriptRunnerContext.clean();
         }

--- a/jbpm-test-util/src/main/java/org/jbpm/test/persistence/scripts/ScriptsBase.java
+++ b/jbpm-test-util/src/main/java/org/jbpm/test/persistence/scripts/ScriptsBase.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 
 import org.jbpm.test.persistence.scripts.util.TestsUtil;
+import org.jbpm.test.persistence.scripts.util.ScriptFilter;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
@@ -52,22 +53,22 @@ public class ScriptsBase {
     public static void cleanUp() throws IOException, SQLException {
         logger.info("Running with Hibernate " + org.hibernate.Version.getVersionString());
         TestsUtil.clearSchema();
-        executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, false);
+        executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, ScriptFilter.init(false, false));
     }
 
-    public static void executeScriptRunner(String resourcePath, boolean createFiles, String type) throws IOException, SQLException {
+    public static void executeScriptRunner(String resourcePath, ScriptFilter scriptFilter, String type) throws IOException, SQLException {
         final TestPersistenceContextBase scriptRunnerContext = createAndInitContext(PersistenceUnit.SCRIPT_RUNNER);
         try {
-            scriptRunnerContext.executeScripts(new File(ScriptsBase.class.getResource(resourcePath).getFile()), createFiles, type);
+            scriptRunnerContext.executeScripts(new File(ScriptsBase.class.getResource(resourcePath).getFile()), scriptFilter, type);
         } finally {
             scriptRunnerContext.clean();
         }
     }
 
-    public static void executeScriptRunner(String resourcePath, boolean createFiles) throws IOException, SQLException {
+    public static void executeScriptRunner(String resourcePath, ScriptFilter scriptFilter) throws IOException, SQLException {
         final TestPersistenceContextBase scriptRunnerContext = createAndInitContext(PersistenceUnit.SCRIPT_RUNNER);
         try {
-            scriptRunnerContext.executeScripts(new File(ScriptsBase.class.getResource(resourcePath).getFile()), createFiles);
+            scriptRunnerContext.executeScripts(new File(ScriptsBase.class.getResource(resourcePath).getFile()), scriptFilter);
         } finally {
             scriptRunnerContext.clean();
         }

--- a/jbpm-test-util/src/main/java/org/jbpm/test/persistence/scripts/util/ScriptFilter.java
+++ b/jbpm-test-util/src/main/java/org/jbpm/test/persistence/scripts/util/ScriptFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.test.persistence.scripts.util;
+
+public class ScriptFilter {
+
+    private boolean springboot;
+    private boolean create;
+    
+    public ScriptFilter(boolean springboot, boolean create) {
+        this.springboot = springboot;
+        this.create = create;
+    }
+    
+    public static ScriptFilter init(boolean springboot, boolean create) {
+        return new ScriptFilter(springboot, create);
+    }
+    
+    public boolean isSpringboot() {
+        return springboot;
+    }
+    
+    public boolean isCreate() {
+        return create;
+    }
+}


### PR DESCRIPTION
With [jbpm#1651](https://github.com/kiegroup/jbpm/pull/1651) new DDL scripts (named with prefix _springboot_) were added for postgresql and oracle, generated with the property _**hibernate.id.new_generator_mappings**_ set to _true_.

These scripts have to be validated against definition in order to keep them always updated.