### PR TITLE
[JBPM-9269] ibm jdk: Missing sun.security classes for mock-server tests

### DIFF
--- a/jbpm-workitems/jbpm-workitems-rest/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-rest/pom.xml
@@ -106,6 +106,26 @@
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-netty</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta.validation</groupId>
+          <artifactId>jakarta.validation-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/jbpm-workitems/jbpm-workitems-rest/src/test/java/org/jbpm/process/workitem/rest/RESTWorkItemHandlerProxyTest.java
+++ b/jbpm-workitems/jbpm-workitems-rest/src/test/java/org/jbpm/process/workitem/rest/RESTWorkItemHandlerProxyTest.java
@@ -23,6 +23,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockserver.configuration.ConfigurationProperties;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
 
@@ -45,6 +46,9 @@ public class RESTWorkItemHandlerProxyTest {
 
     @BeforeClass
     public static void startProxy() {
+        //needed mainly for ibm jdk 1.8
+        ConfigurationProperties.useBouncyCastleForKeyAndCertificateGeneration(true);
+
         proxy = ClientAndServer.startClientAndServer();
         System.setProperty("http.proxyHost", "127.0.0.1");
         System.setProperty("http.proxyPort", Integer.toString(proxy.getLocalPort()));


### PR DESCRIPTION
Depends on [droolsjbpm-build-bootstrap#1423](https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1423)