### PR TITLE
[JBPM-9272] Failing test due to startDate processInstance/processInstanceInfo precision

### DIFF
--- a/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/map/impl/MapPersistenceTest.java
+++ b/jbpm-persistence/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/map/impl/MapPersistenceTest.java
@@ -281,7 +281,7 @@ public abstract class MapPersistenceTest extends AbstractBaseTest {
         processInstance = (RuleFlowProcessInstance) processInstanceInfo.getProcessInstance(kruntime, crmPersistentSession.getEnvironment());
 
         Assert.assertNotNull(processInstance.getStartDate());
-        Assert.assertEquals(processInstance.getStartDate(), processInstanceInfo.getStartDate());
+        Assert.assertTrue("Dates aren't close enough", (processInstance.getStartDate().getTime() - processInstanceInfo.getStartDate().getTime()) < 1000);
     }
     
     protected abstract StatefulKnowledgeSession createSession(KieBase kbase);


### PR DESCRIPTION
Fix JpaBasedPersistenceTest.processWithNotNullStartDateTest after [jbpm#1705](https://github.com/kiegroup/jbpm/pull/1705)