### PR TITLE
[JBPM-9306] Raising exception when user is not defined

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/commands/UserGroupCallbackTaskCommand.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/commands/UserGroupCallbackTaskCommand.java
@@ -413,7 +413,6 @@ public class UserGroupCallbackTaskCommand<T> extends TaskCommand<T> {
             if (escalations != null) {
                 for (Escalation escalation : escalations) {
                     List<? extends Notification> notifications = escalation.getNotifications();
-                    List<? extends Reassignment> ressignments = escalation.getReassignments();
                     if (notifications != null) {
                         for (Notification notification : notifications) {
                             List<? extends OrganizationalEntity> recipients = notification.getRecipients();
@@ -441,13 +440,14 @@ public class UserGroupCallbackTaskCommand<T> extends TaskCommand<T> {
                             }
                         }
                     }
-                    if (ressignments != null) {
-                        for (Reassignment reassignment : ressignments) {
+                    List<? extends Reassignment> reassignments = escalation.getReassignments();
+                    if (reassignments != null) {
+                        for (Reassignment reassignment : reassignments) {
                             List<? extends OrganizationalEntity> potentialOwners = reassignment.getPotentialOwners();
                             if (potentialOwners != null) {
                                 for (OrganizationalEntity potentialOwner : potentialOwners) {
                                     if (potentialOwner instanceof User) {
-                                        doCallbackUserOperation(potentialOwner.getId(), context);
+                                        doCallbackUserOperation(potentialOwner.getId(), context, true);
                                     }
                                     if (potentialOwner instanceof Group) {
                                         doCallbackGroupOperation(potentialOwner.getId(), context);

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/admin/UserTaskAdminServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/admin/UserTaskAdminServiceImplTest.java
@@ -612,14 +612,17 @@ public class UserTaskAdminServiceImplTest extends AbstractKieServicesBaseTest {
         userTaskService.start(task.getId(), "salaboy");
         
         Collection<TaskReassignment> reassignments = userTaskAdminService.getTaskReassignments(task.getId(), false);
-        Assertions.assertThat(reassignments).isNotNull();
-        Assertions.assertThat(reassignments).hasSize(0);
+        Assertions.assertThat(reassignments).isNotNull().isEmpty();
         
         userTaskAdminService.reassignWhenNotCompleted(task.getId(), "2s", factory.newUser("john"));
         reassignments = userTaskAdminService.getTaskReassignments(task.getId(), true);
         Assertions.assertThat(reassignments).isNotNull();
         Assertions.assertThat(reassignments).hasSize(1);
         
+        Assertions
+                  .assertThatThrownBy(() -> userTaskAdminService.reassignWhenNotCompleted(task.getId(), "2s", factory.newUser("pepe")))
+                  .isInstanceOf(IllegalArgumentException.class);
+
         CountDownListenerFactory.getExistingTask("userTaskAdminService").waitTillCompleted();
         
         tasks = runtimeDataService.getTasksAssignedAsPotentialOwner("salaboy", new QueryFilter());


### PR DESCRIPTION
Currently If user does not exist in callback, the organizational entity is not created, but no exception is thrown, so later a constraint violation is thrown, as described in the JIRA.

This change will make error message more descriptive  (the operation itself cannot suceed if the user is not in the context, we cannot allow arbitrary users to be added to organizationentity)


**JIRA**:

[JBPM-9306](https://issues.redhat.com/browse/JBPM-9306)
