### PR TITLE
[JBPM-9312] - Add .gitignore file to jbpm-workitems-repository-archetype module

### DIFF
--- a/jbpm-workitems/jbpm-workitems-repository-archetype/.gitignore
+++ b/jbpm-workitems/jbpm-workitems-repository-archetype/.gitignore
@@ -1,0 +1,12 @@
+/target
+/local
+/bin
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml
+


### PR DESCRIPTION
[**JBPM-9312**](https://issues.redhat.com/browse/JBPM-9312)