### PR TITLE
[BAQE-1456] Get rid of jbpm-executor test jar in jbpm-test-coverage

### DIFF
--- a/jbpm-services/jbpm-executor/src/test/java/org/jbpm/executor/test/CountDownAsyncJobListener.java
+++ b/jbpm-services/jbpm-executor/src/test/java/org/jbpm/executor/test/CountDownAsyncJobListener.java
@@ -38,7 +38,7 @@ public class CountDownAsyncJobListener implements AsynchronousJobListener {
         try {
             latch.await();
         } catch (InterruptedException e) {
-            logger.debug("Interrputed thread while waiting for all async jobs");
+            logger.debug("Interrupted thread while waiting for all async jobs");
         }
     }
     
@@ -46,7 +46,7 @@ public class CountDownAsyncJobListener implements AsynchronousJobListener {
         try {
             latch.await(timeOut, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
-            logger.debug("Interrputed thread while waiting for all async jobs");
+            logger.debug("Interrupted thread while waiting for all async jobs");
         }
     }
     

--- a/jbpm-test-coverage/pom.xml
+++ b/jbpm-test-coverage/pom.xml
@@ -78,12 +78,6 @@
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
-      <artifactId>jbpm-executor</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jbpm</groupId>
       <artifactId>jbpm-db-scripts</artifactId>
       <scope>test</scope>
     </dependency>

--- a/jbpm-test-coverage/src/main/java/org/jbpm/test/listener/CountDownAsyncJobListener.java
+++ b/jbpm-test-coverage/src/main/java/org/jbpm/test/listener/CountDownAsyncJobListener.java
@@ -38,7 +38,7 @@ public class CountDownAsyncJobListener implements AsynchronousJobListener {
         try {
             latch.await();
         } catch (InterruptedException e) {
-            logger.debug("Interrputed thread while waiting for all async jobs");
+            logger.debug("Interrupted thread while waiting for all async jobs");
         }
     }
     
@@ -46,7 +46,7 @@ public class CountDownAsyncJobListener implements AsynchronousJobListener {
         try {
             latch.await(timeOut, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
-            logger.debug("Interrputed thread while waiting for all async jobs");
+            logger.debug("Interrupted thread while waiting for all async jobs");
         }
     }
     

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/ParallelAsyncJobsTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/ParallelAsyncJobsTest.java
@@ -28,7 +28,7 @@ import org.assertj.core.api.Assertions;
 import org.jbpm.executor.AsynchronousJobEvent;
 import org.jbpm.executor.impl.ExecutorServiceImpl;
 import org.jbpm.executor.impl.wih.AsyncWorkItemHandler;
-import org.jbpm.executor.test.CountDownAsyncJobListener;
+import org.jbpm.test.listener.CountDownAsyncJobListener;
 import org.jbpm.test.persistence.util.PersistenceUtil;
 import org.jbpm.test.JbpmAsyncJobTestCase;
 import org.kie.test.util.db.PoolingDataSourceWrapper;


### PR DESCRIPTION
[**BAQE-1456**](https://issues.redhat.com/browse/BAQE-1456): Get rid of jbpm-executor test jar in jbpm-test-coverage