### PR TITLE
[JBPM-9316] Missing javax.xml.bind package with jdk11

### DIFF
--- a/jbpm-workitems/jbpm-workitems-rest/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-rest/pom.xml
@@ -122,6 +122,12 @@
       <artifactId>bcpkix-jdk15on</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- needed for jdk 11 -->
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
**JIRA**: 

[JBPM-9316](https://issues.redhat.com/browse/JBPM-9316)

