### PR TITLE
[JBPM-9261] unclear validation message for link in different subprocess

### DIFF
--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/ErrorLinkProcessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/ErrorLinkProcessTest.java
@@ -33,6 +33,7 @@ public class ErrorLinkProcessTest extends JbpmTestCase {
     public static final String PROCESS_MULTI_THROW = "org/jbpm/test/functional/common/MultipleThrowLinkProcess.bpmn2";
     public static final String PROCESS_MULTI_CATCH = "org/jbpm/test/functional/common/MultipleCatchLinkProcess.bpmn2";
     public static final String PROCESS_UNCONNECTED = "org/jbpm/test/functional/common/UnconnectedLinkProcess.bpmn2";
+    public static final String DIFFERENT_PROCESS = "org/jbpm/test/functional/common/DifferentLinkProcess.bpmn2";
     
     public ErrorLinkProcessTest() {
         super(false);
@@ -63,5 +64,13 @@ public class ErrorLinkProcessTest extends JbpmTestCase {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("not connection");
         createKSession(PROCESS_UNCONNECTED);
+    }
+    
+    @Test
+    public void testDifferentProcess() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("not connection");
+        exceptionRule.expectMessage("subprocess");
+        createKSession (DIFFERENT_PROCESS);
     }
 }

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/common/DifferentLinkProcess.bpmn2
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/common/DifferentLinkProcess.bpmn2
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_2ofjoNGhEeqG0t6JmlVZxg" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:process id="LinksTest.DifferentProcessLevels" drools:packageName="com.myspace.linkstest" drools:version="1.0" drools:adHoc="false" name="DifferentProcessLevels" isExecutable="true" processType="Public">
+    <bpmn2:sequenceFlow id="_76BD5E01-A911-4EDC-A41D-7DDFFBC90629" sourceRef="_38180F01-E891-4E8E-9F29-6F8B0E7EBAF7" targetRef="_23C1F34D-6BF2-43AE-92A4-D91F165BAA0E"/>
+    <bpmn2:sequenceFlow id="_303723C5-829E-4E7F-8DD6-5D6782FC4354" sourceRef="_CD894616-043A-486F-9503-7E5FCFC4A601" targetRef="_94F60FED-6946-4349-982F-F5D7F667DBC0">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_AE684CF0-CE37-48C7-B843-8B7DD719DAB7" sourceRef="_E8F88EF6-B6A6-4E0F-B324-526EC15FAB7A" targetRef="_CD894616-043A-486F-9503-7E5FCFC4A601">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:scriptTask id="_CD894616-043A-486F-9503-7E5FCFC4A601" name="Prints &quot;Executed&quot;" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Prints "Executed"]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_AE684CF0-CE37-48C7-B843-8B7DD719DAB7</bpmn2:incoming>
+      <bpmn2:outgoing>_303723C5-829E-4E7F-8DD6-5D6782FC4354</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Executed");]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:startEvent id="_38180F01-E891-4E8E-9F29-6F8B0E7EBAF7">
+      <bpmn2:outgoing>_76BD5E01-A911-4EDC-A41D-7DDFFBC90629</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:endEvent id="_94F60FED-6946-4349-982F-F5D7F667DBC0">
+      <bpmn2:incoming>_303723C5-829E-4E7F-8DD6-5D6782FC4354</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:intermediateCatchEvent id="_E8F88EF6-B6A6-4E0F-B324-526EC15FAB7A" name="newLink">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[newLink]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_AE684CF0-CE37-48C7-B843-8B7DD719DAB7</bpmn2:outgoing>
+      <bpmn2:linkEventDefinition id="_2ofjodGhEeqG0t6JmlVZxg" name="newLink"/>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:subProcess id="_23C1F34D-6BF2-43AE-92A4-D91F165BAA0E" name="Sub-process">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Sub-process]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_76BD5E01-A911-4EDC-A41D-7DDFFBC90629</bpmn2:incoming>
+      <bpmn2:sequenceFlow id="_29097771-6546-46C9-833E-F351F9DD919A" sourceRef="_62BE0025-93F5-4483-AC83-3B7DF57EBDE1" targetRef="_56D68B48-E9F5-42BC-9118-9EDC9D91E07C"/>
+      <bpmn2:sequenceFlow id="_6C312D40-A516-4AA7-8472-472242B994E7" sourceRef="_C097E8E3-869B-45DD-8627-8ABEF6DE4BDC" targetRef="_62BE0025-93F5-4483-AC83-3B7DF57EBDE1"/>
+      <bpmn2:sequenceFlow id="_6D839FF3-448E-4B16-8108-A89F79D897A6" sourceRef="_62BE0025-93F5-4483-AC83-3B7DF57EBDE1" targetRef="_8CA9901E-1E9D-4A86-A882-A167C8D1B101"/>
+      <bpmn2:parallelGateway id="_62BE0025-93F5-4483-AC83-3B7DF57EBDE1" gatewayDirection="Diverging">
+        <bpmn2:incoming>_6C312D40-A516-4AA7-8472-472242B994E7</bpmn2:incoming>
+        <bpmn2:outgoing>_6D839FF3-448E-4B16-8108-A89F79D897A6</bpmn2:outgoing>
+        <bpmn2:outgoing>_29097771-6546-46C9-833E-F351F9DD919A</bpmn2:outgoing>
+      </bpmn2:parallelGateway>
+      <bpmn2:intermediateThrowEvent id="_56D68B48-E9F5-42BC-9118-9EDC9D91E07C" name="newLink">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[newLink]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:incoming>_29097771-6546-46C9-833E-F351F9DD919A</bpmn2:incoming>
+        <bpmn2:linkEventDefinition id="_2ofjotGhEeqG0t6JmlVZxg" name="newLink"/>
+      </bpmn2:intermediateThrowEvent>
+      <bpmn2:startEvent id="_C097E8E3-869B-45DD-8627-8ABEF6DE4BDC">
+        <bpmn2:outgoing>_6C312D40-A516-4AA7-8472-472242B994E7</bpmn2:outgoing>
+      </bpmn2:startEvent>
+      <bpmn2:endEvent id="_8CA9901E-1E9D-4A86-A882-A167C8D1B101">
+        <bpmn2:incoming>_6D839FF3-448E-4B16-8108-A89F79D897A6</bpmn2:incoming>
+      </bpmn2:endEvent>
+    </bpmn2:subProcess>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_2ofjo9GhEeqG0t6JmlVZxg">
+    <bpmndi:BPMNPlane id="_2ogKsNGhEeqG0t6JmlVZxg" bpmnElement="LinksTest.DifferentProcessLevels">
+      <bpmndi:BPMNShape id="shape__23C1F34D-6BF2-43AE-92A4-D91F165BAA0E" bpmnElement="_23C1F34D-6BF2-43AE-92A4-D91F165BAA0E" isExpanded="true">
+        <dc:Bounds height="291.0" width="385.0" x="448.0" y="77.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__8CA9901E-1E9D-4A86-A882-A167C8D1B101" bpmnElement="_8CA9901E-1E9D-4A86-A882-A167C8D1B101">
+        <dc:Bounds height="56.0" width="56.0" x="729.0" y="176.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__C097E8E3-869B-45DD-8627-8ABEF6DE4BDC_to_shape__62BE0025-93F5-4483-AC83-3B7DF57EBDE1" bpmnElement="_6C312D40-A516-4AA7-8472-472242B994E7">
+        <di:waypoint xsi:type="dc:Point" x="541.0" y="204.0"/>
+        <di:waypoint xsi:type="dc:Point" x="621.0" y="204.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__62BE0025-93F5-4483-AC83-3B7DF57EBDE1_to_shape__56D68B48-E9F5-42BC-9118-9EDC9D91E07C" bpmnElement="_29097771-6546-46C9-833E-F351F9DD919A">
+        <di:waypoint xsi:type="dc:Point" x="677.0" y="204.0"/>
+        <di:waypoint xsi:type="dc:Point" x="729.0" y="282.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="shape__C097E8E3-869B-45DD-8627-8ABEF6DE4BDC" bpmnElement="_C097E8E3-869B-45DD-8627-8ABEF6DE4BDC">
+        <dc:Bounds height="56.0" width="56.0" x="485.0" y="176.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__56D68B48-E9F5-42BC-9118-9EDC9D91E07C" bpmnElement="_56D68B48-E9F5-42BC-9118-9EDC9D91E07C">
+        <dc:Bounds height="56.0" width="56.0" x="729.0" y="254.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__62BE0025-93F5-4483-AC83-3B7DF57EBDE1_to_shape__8CA9901E-1E9D-4A86-A882-A167C8D1B101" bpmnElement="_6D839FF3-448E-4B16-8108-A89F79D897A6">
+        <di:waypoint xsi:type="dc:Point" x="649.0" y="232.0"/>
+        <di:waypoint xsi:type="dc:Point" x="757.0" y="176.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="shape__62BE0025-93F5-4483-AC83-3B7DF57EBDE1" bpmnElement="_62BE0025-93F5-4483-AC83-3B7DF57EBDE1">
+        <dc:Bounds height="56.0" width="56.0" x="621.0" y="176.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__E8F88EF6-B6A6-4E0F-B324-526EC15FAB7A" bpmnElement="_E8F88EF6-B6A6-4E0F-B324-526EC15FAB7A">
+        <dc:Bounds height="56.0" width="56.0" x="456.0" y="438.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__94F60FED-6946-4349-982F-F5D7F667DBC0" bpmnElement="_94F60FED-6946-4349-982F-F5D7F667DBC0">
+        <dc:Bounds height="56.0" width="56.0" x="787.0" y="438.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__38180F01-E891-4E8E-9F29-6F8B0E7EBAF7" bpmnElement="_38180F01-E891-4E8E-9F29-6F8B0E7EBAF7">
+        <dc:Bounds height="56.0" width="56.0" x="302.0" y="195.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__CD894616-043A-486F-9503-7E5FCFC4A601" bpmnElement="_CD894616-043A-486F-9503-7E5FCFC4A601">
+        <dc:Bounds height="102.0" width="154.0" x="572.0" y="415.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__E8F88EF6-B6A6-4E0F-B324-526EC15FAB7A_to_shape__CD894616-043A-486F-9503-7E5FCFC4A601" bpmnElement="_AE684CF0-CE37-48C7-B843-8B7DD719DAB7">
+        <di:waypoint xsi:type="dc:Point" x="484.0" y="466.0"/>
+        <di:waypoint xsi:type="dc:Point" x="600.0" y="415.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__CD894616-043A-486F-9503-7E5FCFC4A601_to_shape__94F60FED-6946-4349-982F-F5D7F667DBC0" bpmnElement="_303723C5-829E-4E7F-8DD6-5D6782FC4354">
+        <di:waypoint xsi:type="dc:Point" x="726.0" y="466.0"/>
+        <di:waypoint xsi:type="dc:Point" x="787.0" y="466.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__38180F01-E891-4E8E-9F29-6F8B0E7EBAF7_to_shape__23C1F34D-6BF2-43AE-92A4-D91F165BAA0E" bpmnElement="_76BD5E01-A911-4EDC-A41D-7DDFFBC90629">
+        <di:waypoint xsi:type="dc:Point" x="330.0" y="223.0"/>
+        <di:waypoint xsi:type="dc:Point" x="448.0" y="222.5"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_2ogKsdGhEeqG0t6JmlVZxg" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_38180F01-E891-4E8E-9F29-6F8B0E7EBAF7" id="_2ogKstGhEeqG0t6JmlVZxg">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_CD894616-043A-486F-9503-7E5FCFC4A601" id="_2ogKs9GhEeqG0t6JmlVZxg">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_2ofjoNGhEeqG0t6JmlVZxg</bpmn2:source>
+    <bpmn2:target>_2ofjoNGhEeqG0t6JmlVZxg</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION
Actually, the way engine works, links are included as metadata
information of the parent process or every container node, so there is
not vissibility between the links of a subprocess and links of the
parent process, meaning that, at all effects, a no link scenario is
similar to a link in different subprocess.

Error Message was already improved as part of RPHAM-3132, so message
when there is no association is

"There is not connection from any throw link to these catch links {list
of ids}" or "There is not connection from any catch link to these throw
links {list of ids}"

Since now the ids of the missing connections are logged, although the
same message is printed regardless there is no link or there is a link
in a different process,  the user can easily tie knots, avoiding the
confusion.

A test case was added to verify message is printed

**JIRA**:

[JBPM-9261](https://issues.redhat.com/browse/JBPM-9261)

