### PR TITLE
(QE) [7.44.x] [JBPM-9447] No session found for context in case SLA on user task is violated

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
@@ -523,8 +523,11 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl
             }
         }
     }
-
-    public TimerInstance configureSLATimer(String slaDueDateExpression) {
+	public TimerInstance configureSLATimer(String slaDueDateExpression) {
+	    return this.configureSLATimer(slaDueDateExpression, null);
+	}
+	
+    public TimerInstance configureSLATimer(String slaDueDateExpression, String timerName) {
         // setup SLA if provided
         slaDueDateExpression = resolveVariable(slaDueDateExpression);
         if (slaDueDateExpression == null || slaDueDateExpression.trim().isEmpty()) {
@@ -546,6 +549,7 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl
         timerInstance.setId(-1);
         timerInstance.setDelay(duration);
         timerInstance.setPeriod(0);
+        timerInstance.setName(timerName);
         if (useTimerSLATracking()) {
             ((InternalProcessRuntime) kruntime.getProcessRuntime()).getTimerManager().registerTimer(timerInstance, this);
         }

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/EventNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/EventNodeInstance.java
@@ -88,9 +88,8 @@ public class EventNodeInstance extends ExtendedNodeInstanceImpl implements Event
     protected void configureSla() {
         String slaDueDateExpression = (String) getNode().getMetaData().get("customSLADueDate");
         if (slaDueDateExpression != null) {
-            TimerInstance timer = ((WorkflowProcessInstanceImpl)getProcessInstance()).configureSLATimer(slaDueDateExpression);
+            TimerInstance timer = ((WorkflowProcessInstanceImpl)getProcessInstance()).configureSLATimer(slaDueDateExpression, getNodeName());
             if (timer != null) {
-                timer.setName(getNodeName());
                 this.slaTimerId = timer.getId();
                 this.slaDueDate = new Date(System.currentTimeMillis() + timer.getDelay());
                 this.slaCompliance = ProcessInstance.SLA_PENDING;

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateBasedNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateBasedNodeInstance.java
@@ -122,9 +122,8 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
     protected void configureSla() {
         String slaDueDateExpression = (String) getNode().getMetaData().get("customSLADueDate");
         if (slaDueDateExpression != null) {
-            TimerInstance timer = ((WorkflowProcessInstanceImpl) getProcessInstance()).configureSLATimer(slaDueDateExpression);
+            TimerInstance timer = ((WorkflowProcessInstanceImpl) getProcessInstance()).configureSLATimer(slaDueDateExpression, getNodeName());
             if (timer != null) {
-                timer.setName(getNodeName());
                 this.slaTimerId = timer.getId();
                 this.slaDueDate = new Date(System.currentTimeMillis() + timer.getDelay());
                 this.slaCompliance = org.kie.api.runtime.process.ProcessInstance.SLA_PENDING;


### PR DESCRIPTION

added timer name to configure SLA in order to generate a proper job handle id.
Otherwise it will registered twice: once the node is reached and once the node is unmarshalled

Jira https://issues.redhat.com/browse/RHPAM-3233
cherry pick from 
https://github.com/kiegroup/jbpm/commit/885d1be66859fdbbab1736dc0b368064efb0db3c