### PR TITLE
[JBPM-9465] Add support for using the public API to retrieve a node type

### DIFF
--- a/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/IntermediateThrowEventHandler.java
+++ b/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/IntermediateThrowEventHandler.java
@@ -35,6 +35,7 @@ import org.jbpm.workflow.core.node.ActionNode;
 import org.jbpm.workflow.core.node.CompositeNode;
 import org.jbpm.workflow.core.node.ThrowLinkNode;
 import org.jbpm.workflow.core.node.Transformation;
+import org.kie.api.definition.process.NodeType;
 import org.kie.api.runtime.process.DataTransformer;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -52,7 +53,7 @@ public class IntermediateThrowEventHandler extends AbstractNodeHandler {
 	public static final String LINK_TARGET = "target";
 
 	protected Node createNode(Attributes attrs) {
-		return new ActionNode();
+        return new ActionNode(NodeType.THROW_EVENT);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ScriptTaskHandler.java
+++ b/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ScriptTaskHandler.java
@@ -21,6 +21,7 @@ import org.drools.mvel.java.JavaDialect;
 import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
 import org.jbpm.workflow.core.node.ActionNode;
+import org.kie.api.definition.process.NodeType;
 import org.w3c.dom.Element;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -28,13 +29,13 @@ import org.xml.sax.SAXException;
 public class ScriptTaskHandler extends AbstractNodeHandler {
     
     protected Node createNode(Attributes attrs) {
-        ActionNode result = new ActionNode();
+        ActionNode result = new ActionNode(NodeType.SCRIPT_TASK);
         result.setAction(new DroolsConsequenceAction());
         return result;
     }
     
-    @SuppressWarnings("unchecked")
-	public Class generateNodeFor() {
+
+    public Class<?> generateNodeFor() {
         return Node.class;
     }
 

--- a/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/ActionNodeFactory.java
+++ b/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/ActionNodeFactory.java
@@ -30,10 +30,7 @@ public class ActionNodeFactory<T extends NodeContainerBuilder<T, ?>> extends Nod
     public ActionNodeFactory(T nodeContainerFactory,
                              NodeContainer nodeContainer,
                              long id) {
-        super(nodeContainerFactory,
-              nodeContainer,
-              new ActionNode(),
-              id);
+        super(nodeContainerFactory, nodeContainer, new ActionNode(), id);
     }
 
     protected ActionNode getActionNode() {
@@ -56,20 +53,17 @@ public class ActionNodeFactory<T extends NodeContainerBuilder<T, ?>> extends Nod
                                     boolean isDroolsAction) {
         if (isDroolsAction) {
             DroolsAction droolsAction = new DroolsAction();
-            droolsAction.setMetaData("Action",
-                                     action);
+            droolsAction.setMetaData("Action", action);
             getActionNode().setAction(droolsAction);
         } else {
-            getActionNode().setAction(new DroolsConsequenceAction(dialect,
-                                                                  action));
+            getActionNode().setAction(new DroolsConsequenceAction(dialect, action));
         }
         return this;
     }
 
     public ActionNodeFactory<T> action(Action action) {
         DroolsAction droolsAction = new DroolsAction();
-        droolsAction.setMetaData("Action",
-                                 action);
+        droolsAction.setMetaData("Action", action);
         getActionNode().setAction(droolsAction);
         return this;
     }

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/ExtendedNodeImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/ExtendedNodeImpl.java
@@ -21,12 +21,17 @@ import java.util.List;
 import java.util.Map;
 
 import org.jbpm.workflow.core.DroolsAction;
+import org.kie.api.definition.process.NodeType;
 
-public class ExtendedNodeImpl extends NodeImpl {
+public abstract class ExtendedNodeImpl extends NodeImpl {
 	
 	public static final String EVENT_NODE_ENTER = "onEntry";
 	public static final String EVENT_NODE_EXIT = "onExit";
 	
+    protected ExtendedNodeImpl(NodeType nodeType) {
+        super(nodeType);
+    }
+
 	private static final String[] EVENT_TYPES =
 		new String[] { EVENT_NODE_ENTER, EVENT_NODE_EXIT };
 	

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/NodeImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/NodeImpl.java
@@ -31,6 +31,7 @@ import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.node.CompositeNode;
 import org.kie.api.definition.process.Connection;
 import org.kie.api.definition.process.NodeContainer;
+import org.kie.api.definition.process.NodeType;
 
 /**
  * Default implementation of a node.
@@ -51,19 +52,35 @@ public abstract class NodeImpl implements Node, Serializable, ContextResolver {
     private NodeContainer parentNodeContainer;
     private Map<String, Context> contexts = new HashMap<String, Context>();
     private Map<String, Object> metaData = new HashMap<String, Object>();
+    private NodeType nodeType;
     
     protected Map<ConnectionRef, Constraint> constraints = new HashMap<ConnectionRef, Constraint>();
 
+    // needed to keep backward compatibility
     public NodeImpl() {
+        this(NodeType.INTERNAL);
+    }
+
+    protected NodeImpl(NodeType nodeType) {
         this.id = -1;
         this.incomingConnections = new HashMap<String, List<Connection>>();
         this.outgoingConnections = new HashMap<String, List<Connection>>();
+        this.nodeType = nodeType;
     }
 
     public long getId() {
         return this.id;
     }
     
+    @Override
+    public NodeType getNodeType() {
+        return nodeType;
+    }
+
+    protected void setNodeType(NodeType nodeType) {
+        this.nodeType = nodeType;
+    }
+
     public String getNodeUniqueId() {
         return (String) getMetaData().get("UniqueId");
     }

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ActionNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ActionNode.java
@@ -16,9 +16,10 @@
 
 package org.jbpm.workflow.core.node;
 
-import org.kie.api.definition.process.Connection;
 import org.jbpm.workflow.core.DroolsAction;
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
+import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 
 /**
@@ -30,6 +31,14 @@ public class ActionNode extends ExtendedNodeImpl {
 	private static final long serialVersionUID = 510l;
 	
 	private DroolsAction action;
+
+    public ActionNode() {
+        super(NodeType.SCRIPT_TASK);
+    }
+
+    public ActionNode(NodeType nodeType) {
+        super(nodeType);
+    }
 
 	public DroolsAction getAction() {
 		return action;

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/BoundaryEventNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/BoundaryEventNode.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.jbpm.process.core.event.EventFilter;
+import org.kie.api.definition.process.NodeType;
 
 public class BoundaryEventNode extends EventNode {
 
@@ -29,6 +30,10 @@ public class BoundaryEventNode extends EventNode {
     private String attachedToNodeId;
 
     private List<DataAssociation> outMapping = new LinkedList<DataAssociation>();
+
+    public BoundaryEventNode() {
+        super(NodeType.BOUNDARY_EVENT);
+    }
 
     public String getAttachedToNodeId() {
         return attachedToNodeId;

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/CatchLinkNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/CatchLinkNode.java
@@ -17,10 +17,15 @@
 package org.jbpm.workflow.core.node;
 
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
+import org.kie.api.definition.process.NodeType;
 
 public class CatchLinkNode extends ExtendedNodeImpl {
 
 
 	private static final long serialVersionUID = 201105121554L;
+
+    public CatchLinkNode() {
+        super(NodeType.CATCH_LINK);
+    }
 
 }

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/CompositeContextNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/CompositeContextNode.java
@@ -22,6 +22,7 @@ import org.jbpm.process.core.Context;
 import org.jbpm.process.core.ContextContainer;
 import org.jbpm.process.core.context.AbstractContext;
 import org.jbpm.process.core.impl.ContextContainerImpl;
+import org.kie.api.definition.process.NodeType;
 
 /**
  * 
@@ -30,6 +31,14 @@ public class CompositeContextNode extends CompositeNode implements ContextContai
 
     private static final long serialVersionUID = 510l;
     
+    protected CompositeContextNode(NodeType nodeType) {
+        super(nodeType);
+    }
+
+    public CompositeContextNode() {
+        super(NodeType.INTERNAL);
+    }
+
     private ContextContainer contextContainer = new ContextContainerImpl();
 
     public List<Context> getContexts(String contextType) {

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/CompositeNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/CompositeNode.java
@@ -28,6 +28,7 @@ import org.jbpm.workflow.core.impl.NodeContainerImpl;
 import org.jbpm.workflow.core.impl.NodeImpl;
 import org.kie.api.definition.process.Connection;
 import org.kie.api.definition.process.Node;
+import org.kie.api.definition.process.NodeType;
 
 /**
  * 
@@ -44,6 +45,11 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
 	private boolean autoComplete = true;
 	
     public CompositeNode() {
+        this(NodeType.INTERNAL);
+    }
+
+    protected CompositeNode(NodeType type) {
+        super(type);
         this.nodeContainer = new NodeContainerImpl();
     }
     
@@ -435,6 +441,7 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
         private String inType;
         
         public CompositeNodeStart(CompositeNode parentNode, Node outNode, String outType) {
+            super(NodeType.INTERNAL);
             setName("Composite node start");
             this.inNodeId = outNode.getId();
             this.inNode = outNode;
@@ -470,6 +477,7 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
         private String outType;
         
         public CompositeNodeEnd(CompositeNode parentNode, Node outNode, String outType) {
+            super(NodeType.INTERNAL);
             setName("Composite node end");
             this.outNodeId = outNode.getId();
             this.outNode = outNode;

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/DynamicNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/DynamicNode.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import org.jbpm.workflow.core.WorkflowProcess;
 import org.kie.api.definition.process.Node;
+import org.kie.api.definition.process.NodeType;
 
 
 public class DynamicNode extends CompositeContextNode {
@@ -32,7 +33,11 @@ public class DynamicNode extends CompositeContextNode {
 	private String activationExpression;
 	private String completionExpression;
 	private String language;
-			
+
+    public DynamicNode() {
+	    super (NodeType.AD_HOC_SUBPROCESS);
+	}
+
     @Override
     public boolean acceptsEvent(String type, Object event, Function<String, String> resolver) {
         if (type.equals(getActivationEventName())) {

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EndNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EndNode.java
@@ -16,8 +16,9 @@
 
 package org.jbpm.workflow.core.node;
 
-import org.kie.api.definition.process.Connection;
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
+import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 /**
  * Default implementation of an end node.
@@ -35,6 +36,10 @@ public class EndNode extends ExtendedNodeImpl {
     
     private boolean terminate = true;
     private int scope = CONTAINER_SCOPE;
+
+    public EndNode() {
+        super(NodeType.END);
+    }
 
     public boolean isTerminate() {
 		return terminate;

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventNode.java
@@ -19,11 +19,12 @@ package org.jbpm.workflow.core.node;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.kie.api.definition.process.Connection;
 import org.jbpm.process.core.event.EventFilter;
 import org.jbpm.process.core.event.EventTransformer;
 import org.jbpm.process.core.event.EventTypeFilter;
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
+import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 public class EventNode extends ExtendedNodeImpl implements EventNodeInterface {
 
@@ -32,7 +33,15 @@ public class EventNode extends ExtendedNodeImpl implements EventNodeInterface {
 	private List<EventFilter> filters = new ArrayList<EventFilter>();
 	private EventTransformer transformer;
 	private String variableName;
-	private String scope; 
+    private String scope;
+
+    public EventNode() {
+        super(NodeType.CATCH_EVENT);
+    }
+
+    protected EventNode(NodeType nodeType) {
+        super(nodeType);
+    }
 
 	public String getVariableName() {
 		return variableName;

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventSubProcessNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventSubProcessNode.java
@@ -23,6 +23,7 @@ import org.jbpm.process.core.event.EventTypeFilter;
 import org.jbpm.process.core.timer.Timer;
 import org.jbpm.workflow.core.DroolsAction;
 import org.kie.api.definition.process.Node;
+import org.kie.api.definition.process.NodeType;
 
 public class EventSubProcessNode extends CompositeContextNode {
 
@@ -32,6 +33,10 @@ public class EventSubProcessNode extends CompositeContextNode {
     private List<EventTypeFilter> eventTypeFilters = new ArrayList<EventTypeFilter>();
     private boolean keepActive = true;
     
+    public EventSubProcessNode() {
+        super(NodeType.EVENT_SUBPROCESS);
+    }
+
     public void addEvent(EventTypeFilter filter) {
         String type = filter.getType();
         this.events.add(type);

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/FaultNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/FaultNode.java
@@ -16,8 +16,9 @@
 
 package org.jbpm.workflow.core.node;
 
-import org.kie.api.definition.process.Connection;
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
+import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 /**
  * Default implementation of a fault node.
@@ -33,6 +34,10 @@ public class FaultNode extends ExtendedNodeImpl {
 	private String faultName;
 	private String faultVariable;
 	private boolean terminateParent = false;
+
+    public FaultNode() {
+        super(NodeType.FAULT);
+    }
 
     public String getFaultVariable() {
 		return faultVariable;

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ForEachNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ForEachNode.java
@@ -19,14 +19,15 @@ package org.jbpm.workflow.core.node;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.kie.api.definition.process.Node;
-import org.jbpm.process.core.datatype.DataType;
 import org.jbpm.process.core.Context;
 import org.jbpm.process.core.context.AbstractContext;
 import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.process.core.datatype.DataType;
 import org.jbpm.workflow.core.impl.ConnectionImpl;
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
+import org.kie.api.definition.process.Node;
+import org.kie.api.definition.process.NodeType;
 
 /**
  * A for each node.
@@ -50,6 +51,7 @@ public class ForEachNode extends CompositeContextNode {
     private boolean sequential = false;
 
     public ForEachNode() {
+        super(NodeType.FOR_EACH);
         // Split
         ForEachSplitNode split = new ForEachSplitNode();
         split.setName("ForEachSplit");
@@ -254,10 +256,18 @@ public class ForEachNode extends CompositeContextNode {
 
     public static class ForEachSplitNode extends ExtendedNodeImpl {
         private static final long serialVersionUID = 510l;
+
+        public ForEachSplitNode() {
+            super(NodeType.INTERNAL);
+        }
     }
 
     public static class ForEachJoinNode extends ExtendedNodeImpl {
         private static final long serialVersionUID = 510l;
+
+        public ForEachJoinNode() {
+            super(NodeType.INTERNAL);
+        }
     }
 
     @Override

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/HumanTaskNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/HumanTaskNode.java
@@ -24,6 +24,7 @@ import org.jbpm.process.core.Work;
 import org.jbpm.process.core.datatype.impl.type.StringDataType;
 import org.jbpm.process.core.impl.ParameterDefinitionImpl;
 import org.jbpm.process.core.impl.WorkImpl;
+import org.kie.api.definition.process.NodeType;
 
 public class HumanTaskNode extends WorkItemNode {
 
@@ -32,6 +33,7 @@ public class HumanTaskNode extends WorkItemNode {
     private String swimlane;
     
     public HumanTaskNode() {
+        super(NodeType.HUMAN_TASK);
         Work work = new WorkImpl();
         work.setName("Human Task");
         Set<ParameterDefinition> parameterDefinitions = new HashSet<ParameterDefinition>();

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Join.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Join.java
@@ -16,8 +16,9 @@
 
 package org.jbpm.workflow.core.node;
 
-import org.kie.api.definition.process.Connection;
 import org.jbpm.workflow.core.impl.NodeImpl;
+import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 /**
  * Default implementation of a join.
@@ -57,11 +58,26 @@ public class Join extends NodeImpl {
     private String n;
 
     public Join() {
+        super(NodeType.COMPLEX_GATEWAY);
         this.type = TYPE_UNDEFINED;
     }
 
     public void setType(final int type) {
         this.type = type;
+        this.setNodeType(fromType(type));
+    }
+
+    private static NodeType fromType(int type) {
+        switch (type) {
+            case TYPE_AND:
+                return NodeType.PARALLEL_GATEWAY;
+            case TYPE_OR:
+                return NodeType.INCLUSIVE_GATEWAY;
+            case TYPE_XOR:
+                return NodeType.EXCLUSIVE_GATEWAY;
+            default:
+                return NodeType.COMPLEX_GATEWAY;
+        }
     }
 
     public int getType() {

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/MilestoneNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/MilestoneNode.java
@@ -16,9 +16,10 @@
 
 package org.jbpm.workflow.core.node;
 
-import org.kie.api.definition.process.Connection;
 import org.jbpm.workflow.core.Constraint;
 import org.jbpm.workflow.core.impl.ConnectionRef;
+import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 /**
  * Default implementation of a milestone node.
@@ -30,6 +31,10 @@ public class MilestoneNode extends StateBasedNode implements Constrainable {
 
 	private String constraint;
 	private String matchVariable;
+
+    public MilestoneNode() {
+        super(NodeType.MILESTONE);
+    }
 
     public void addConstraint(ConnectionRef connection, Constraint constraint) {
     	if (connection != null) {

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
@@ -27,6 +27,7 @@ import org.jbpm.process.core.ContextContainer;
 import org.jbpm.process.core.context.AbstractContext;
 import org.jbpm.process.core.impl.ContextContainerImpl;
 import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 /**
  * Default implementation of a RuleSet node.
@@ -57,6 +58,10 @@ public class RuleSetNode extends StateBasedNode implements ContextContainer {
     private List<DataAssociation> outMapping = new LinkedList<DataAssociation>();
     
     private Map<String, Object> parameters = new HashMap<String, Object>();
+
+    public RuleSetNode() {
+        super(NodeType.BUSINESS_RULE);
+    }
 
     public void setRuleFlowGroup(final String ruleFlowGroup) {
         this.ruleFlowGroup = ruleFlowGroup;

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Split.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Split.java
@@ -23,6 +23,7 @@ import org.jbpm.workflow.core.Constraint;
 import org.jbpm.workflow.core.impl.ConnectionRef;
 import org.jbpm.workflow.core.impl.NodeImpl;
 import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 /**
  * Default implementation of a split node.
@@ -59,18 +60,35 @@ public class Split extends NodeImpl implements Constrainable {
     private static final long serialVersionUID = 510l;
 
     private int type;
-//    private Map<ConnectionRef, Constraint> constraints = new HashMap<ConnectionRef, Constraint>();
 
     public Split() {
+        super(NodeType.COMPLEX_GATEWAY);
         this.type = TYPE_UNDEFINED;
     }
 
     public Split(final int type) {
+        super(fromType(type));
         this.type = type;
     }    
 
     public void setType(final int type) {
+        this.setNodeType(fromType(type));
         this.type = type;
+    }
+
+    private static NodeType fromType(int type) {
+        switch (type) {
+            case TYPE_AND:
+                return NodeType.PARALLEL_GATEWAY;
+            case TYPE_XAND:
+                return NodeType.EVENT_BASED_GATEWAY;
+            case TYPE_OR:
+                return NodeType.INCLUSIVE_GATEWAY;
+            case TYPE_XOR:
+                return NodeType.EXCLUSIVE_GATEWAY;
+            default:
+                return NodeType.COMPLEX_GATEWAY;
+        }
     }
 
     public int getType() {

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StartNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StartNode.java
@@ -28,6 +28,7 @@ import org.jbpm.process.core.event.EventTransformer;
 import org.jbpm.process.core.timer.Timer;
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
 import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 /**
  * Default implementation of a start node.
@@ -49,6 +50,10 @@ public class StartNode extends ExtendedNodeImpl implements Mappable {
     private Timer timer;
     
     private EventTransformer transformer;
+
+    public StartNode() {
+        super(NodeType.START);
+    }
 
 
 	public void addTrigger(Trigger trigger) {

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateBasedNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateBasedNode.java
@@ -24,8 +24,9 @@ import java.util.Map;
 import org.jbpm.process.core.timer.Timer;
 import org.jbpm.workflow.core.DroolsAction;
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
+import org.kie.api.definition.process.NodeType;
 
-public class StateBasedNode extends ExtendedNodeImpl {
+public abstract class StateBasedNode extends ExtendedNodeImpl {
 
     private static final long serialVersionUID = 510l;
 
@@ -33,6 +34,10 @@ public class StateBasedNode extends ExtendedNodeImpl {
 	
 	private List<String> boundaryEvents;
 	
+    protected StateBasedNode(NodeType nodeType) {
+        super(nodeType);
+    }
+
 	public Map<Timer, DroolsAction> getTimers() {
 		return timers;
 	}

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateNode.java
@@ -19,9 +19,10 @@ package org.jbpm.workflow.core.node;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.kie.api.definition.process.Connection;
 import org.jbpm.workflow.core.Constraint;
 import org.jbpm.workflow.core.impl.ConnectionRef;
+import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 public class StateNode extends CompositeContextNode implements Constrainable {
 
@@ -31,6 +32,10 @@ public class StateNode extends CompositeContextNode implements Constrainable {
    
     public void setConstraints(Map<ConnectionRef, Constraint> constraints) {
         this.constraints = constraints;
+    }
+
+    public StateNode() {
+        super(NodeType.CONDITIONAL);
     }
 
     public void setConstraint(final Connection connection, final Constraint constraint) {

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/SubProcessNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/SubProcessNode.java
@@ -19,16 +19,17 @@ package org.jbpm.workflow.core.node;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
-import org.kie.api.definition.process.Connection;
 import org.jbpm.process.core.Context;
 import org.jbpm.process.core.ContextContainer;
 import org.jbpm.process.core.context.AbstractContext;
 import org.jbpm.process.core.context.variable.Mappable;
 import org.jbpm.process.core.impl.ContextContainerImpl;
+import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 
 /**
@@ -50,7 +51,11 @@ public class SubProcessNode extends StateBasedNode implements Mappable, ContextC
     private List<DataAssociation> inMapping = new LinkedList<DataAssociation>();
     private List<DataAssociation> outMapping = new LinkedList<DataAssociation>();
 
-    private boolean independent = true;    
+    private boolean independent = true;
+
+    public SubProcessNode() {
+        super(NodeType.SUBPROCESS);
+    }
 
     public void setProcessId(final String processId) {
         this.processId = processId;

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ThrowLinkNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ThrowLinkNode.java
@@ -17,10 +17,15 @@
 package org.jbpm.workflow.core.node;
 
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
+import org.kie.api.definition.process.NodeType;
 
 public class ThrowLinkNode extends ExtendedNodeImpl {
 
 
 	private static final long serialVersionUID = 201105121554L;
 	
+    public ThrowLinkNode() {
+        super(NodeType.THROW_LINK);
+    }
+
 }

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/TimerNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/TimerNode.java
@@ -16,9 +16,10 @@
 
 package org.jbpm.workflow.core.node;
 
-import org.kie.api.definition.process.Connection;
 import org.jbpm.process.core.timer.Timer;
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
+import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 public class TimerNode extends ExtendedNodeImpl {
 
@@ -26,6 +27,10 @@ public class TimerNode extends ExtendedNodeImpl {
     
     private Timer timer;
     
+    public TimerNode() {
+        super(NodeType.TIMER);
+    }
+
     public void setTimer(Timer timer) {
         this.timer = timer;
     }

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/WorkItemNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/WorkItemNode.java
@@ -23,13 +23,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.kie.api.definition.process.Connection;
-import org.jbpm.process.core.Work;
 import org.jbpm.process.core.Context;
 import org.jbpm.process.core.ContextContainer;
+import org.jbpm.process.core.Work;
 import org.jbpm.process.core.context.AbstractContext;
 import org.jbpm.process.core.context.variable.Mappable;
 import org.jbpm.process.core.impl.ContextContainerImpl;
+import org.kie.api.definition.process.Connection;
+import org.kie.api.definition.process.NodeType;
 
 /**
  * Default implementation of a task node.
@@ -47,6 +48,14 @@ public class WorkItemNode extends StateBasedNode implements Mappable, ContextCon
 	private List<DataAssociation> outMapping = new LinkedList<DataAssociation>();
     private boolean waitForCompletion = true;
     // TODO boolean independent (cancel work item if node gets cancelled?)
+
+    public WorkItemNode() {
+        super(NodeType.WORKITEM_TASK);
+    }
+
+    protected WorkItemNode(NodeType nodeType) {
+        super(nodeType);
+    }
 
 	public Work getWork() {
 		return work;

--- a/jbpm-flow/src/test/java/org/jbpm/process/test/NodeCreator.java
+++ b/jbpm-flow/src/test/java/org/jbpm/process/test/NodeCreator.java
@@ -32,13 +32,13 @@ public class NodeCreator<T extends NodeImpl> {
 
     private static long idGen = 1;
 
-    public NodeCreator(NodeContainer nodeContainer, Class<T> clazz) {
+    public NodeCreator(NodeContainer nodeContainer, Class<T> clazz) throws NoSuchMethodException {
         this.nodeContainer = nodeContainer;
-        this.constructor = (Constructor<T>) clazz.getConstructors()[0];
+        this.constructor = clazz.getConstructor();
     }
 
     public T createNode(String name) throws Exception {
-        T result = this.constructor.newInstance(new Object[0]);
+        T result = this.constructor.newInstance();
         result.setId(idGen++);
         result.setName(name);
         this.nodeContainer.addNode(result);

--- a/jbpm-flow/src/test/java/org/jbpm/workflow/core/node/NodeInnerClassesTest.java
+++ b/jbpm-flow/src/test/java/org/jbpm/workflow/core/node/NodeInnerClassesTest.java
@@ -19,8 +19,8 @@ package org.jbpm.workflow.core.node;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 import org.jbpm.process.core.context.variable.Variable;
+import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 import org.jbpm.process.test.TestProcessEventListener;
 import org.jbpm.ruleflow.core.RuleFlowProcess;
 import org.jbpm.test.util.AbstractBaseTest;
@@ -54,10 +54,7 @@ public class NodeInnerClassesTest extends AbstractBaseTest {
         process.getVariableScope().setVariables(variables);
 
         process.setDynamic(true);
-        CompositeNode compositeNode = new CompositeNode();
-        compositeNode.setName("CompositeNode");
-        compositeNode.setId(2);
-        
+
         ForEachNode forEachNode = new ForEachNode();
         ForEachNode.ForEachSplitNode split = new ForEachNode.ForEachSplitNode();
         split.setName("ForEachSplit");

--- a/jbpm-flow/src/test/java/org/jbpm/workflow/core/node/NodeTypeTest.java
+++ b/jbpm-flow/src/test/java/org/jbpm/workflow/core/node/NodeTypeTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.workflow.core.node;
+
+import org.junit.Test;
+import org.kie.api.definition.process.Node;
+import org.kie.api.definition.process.NodeType;
+
+import static org.junit.Assert.assertEquals;
+
+public class NodeTypeTest {
+
+    @Test
+    public void testNodeTypeSpec() {
+
+        Node node = new ActionNode();
+        assertEquals(NodeType.SCRIPT_TASK, node.getNodeType());
+        node = new ForEachNode();
+        assertEquals(NodeType.FOR_EACH, node.getNodeType());
+        node = new MilestoneNode();
+        assertEquals(NodeType.MILESTONE, node.getNodeType());
+        node = new FaultNode();
+        assertEquals(NodeType.FAULT, node.getNodeType());
+        node = new Join();
+        assertEquals(NodeType.COMPLEX_GATEWAY, node.getNodeType());
+        node = new Split(Split.TYPE_AND);
+        assertEquals(NodeType.PARALLEL_GATEWAY, node.getNodeType());
+        node = new Split(Split.TYPE_OR);
+        assertEquals(NodeType.INCLUSIVE_GATEWAY, node.getNodeType());
+        node = new Split(Split.TYPE_XOR);
+        assertEquals(NodeType.EXCLUSIVE_GATEWAY, node.getNodeType());
+        node = new Split(Split.TYPE_XAND);
+        assertEquals(NodeType.EVENT_BASED_GATEWAY, node.getNodeType());
+        node = new ThrowLinkNode();
+        assertEquals(NodeType.THROW_LINK, node.getNodeType());
+        node = new CatchLinkNode();
+        assertEquals(NodeType.CATCH_LINK, node.getNodeType());
+        node = new RuleSetNode();
+        assertEquals(NodeType.BUSINESS_RULE, node.getNodeType());
+        node = new TimerNode();
+        assertEquals(NodeType.TIMER, node.getNodeType());
+        node = new WorkItemNode();
+        assertEquals(NodeType.WORKITEM_TASK, node.getNodeType());
+        node = new SubProcessNode();
+        assertEquals(NodeType.SUBPROCESS, node.getNodeType());
+        node = new StateNode();
+        assertEquals(NodeType.CONDITIONAL, node.getNodeType());
+        node = new StartNode();
+        assertEquals(NodeType.START, node.getNodeType());
+        node = new HumanTaskNode();
+        assertEquals(NodeType.HUMAN_TASK, node.getNodeType());
+        node = new EventNode();
+        assertEquals(NodeType.CATCH_EVENT, node.getNodeType());
+        node = new EndNode();
+        assertEquals(NodeType.END, node.getNodeType());
+        node = new DynamicNode();
+        assertEquals(NodeType.AD_HOC_SUBPROCESS, node.getNodeType());
+        node = new EventSubProcessNode();
+        assertEquals(NodeType.EVENT_SUBPROCESS, node.getNodeType());
+        node = new BoundaryEventNode();
+        assertEquals(NodeType.BOUNDARY_EVENT, node.getNodeType());
+    }
+}

--- a/jbpm-flow/src/test/java/org/jbpm/workflow/instance/node/MockNode.java
+++ b/jbpm-flow/src/test/java/org/jbpm/workflow/instance/node/MockNode.java
@@ -17,9 +17,14 @@
 package org.jbpm.workflow.instance.node;
 
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
+import org.kie.api.definition.process.NodeType;
 
 public class MockNode extends ExtendedNodeImpl {
 
     private static final long serialVersionUID = 510l;
+
+    public MockNode() {
+        super(NodeType.INTERNAL);
+    }
 
 }


### PR DESCRIPTION
Implementing getNodeType

**Depends on**

[droolsjbpm-knowledge:484](https://github.com/kiegroup/droolsjbpm-knowledge/pull/484)

**JIRA**: 

[JBPM-9465]( https://github.com/fjtirado/droolsjbpm-knowledge/pull/new/JBPM-9465)