### PR TITLE
JBPM-9469 - Task inputs are not updated in TaskVariableImpl table aft…

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/admin/commands/UpdateTaskCommand.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/admin/commands/UpdateTaskCommand.java
@@ -116,6 +116,7 @@ public class UpdateTaskCommand extends UserGroupCallbackTaskCommand<Void> {
                 persistenceContext.persistContent(inputContent);
             }
             ((InternalTaskData)task.getTaskData()).setTaskInputVariables(mergedContent);
+            taskEventSupport.fireAfterTaskInputVariablesChanged(task, context, inputs);
         }
         
         if (outputs != null) {

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/UserTaskServiceCDIImplTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/UserTaskServiceCDIImplTest.java
@@ -31,11 +31,14 @@ import org.jbpm.services.api.DeploymentService;
 import org.jbpm.services.api.ProcessService;
 import org.jbpm.services.api.RuntimeDataService;
 import org.jbpm.services.api.UserTaskService;
+import org.jbpm.services.task.audit.TaskAuditServiceFactory;
+import org.jbpm.services.task.audit.service.TaskAuditService;
 import org.jbpm.shared.services.impl.TransactionalCommandService;
 import org.jbpm.shared.services.impl.commands.UpdateStringCommand;
 import org.jbpm.test.services.TestIdentityProvider;
 import org.junit.After;
 import org.junit.runner.RunWith;
+import org.kie.api.task.TaskService;
 
 @RunWith(Arquillian.class)
 public class UserTaskServiceCDIImplTest extends UserTaskServiceImplTest {
@@ -130,6 +133,15 @@ public class UserTaskServiceCDIImplTest extends UserTaskServiceImplTest {
 	@Override
 	protected void configureServices() {
 		// do nothing here and let CDI configure services 
+	}
+
+	// Needed for correct initialization of the TaskAuditService
+	@Inject
+	private TaskService taskService;
+
+	@Override
+	protected TaskAuditService getTaskAuditService() {
+		return TaskAuditServiceFactory.newTaskAuditServiceConfigurator().setTaskService(taskService).getTaskAuditService();
 	}
 
 	@Inject	


### PR DESCRIPTION
…er the task is updated

[JBPM-9469](https://issues.redhat.com/browse/JBPM-9469)

Currently supports addition of the new inputs. If the input is overwritten, it adds another record to the table currently. For deletion of the old/updated inputs it would take more effort as the deletion of the old inputs in TaskVariableImpl was removed to have good performance when adding a new task [1]. In short, at that time it was considered that task inputs are not changeable. But since we already have the `UpdateTaskCommand` available as a public API, this fix at least allows proper addition of the input, so better than not reflecting changes at all I think. But your call guys, I am OK with closing this if we decide we either want all or nothing to be reflected in the TaskVariableImpl table in case the inputs are updated.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1322398

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
