### PR TITLE
[JBPM-9470] User Task output variable mapping to an object attribute

### DIFF
--- a/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BusinessRuleTaskHandler.java
+++ b/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BusinessRuleTaskHandler.java
@@ -16,15 +16,13 @@
 
 package org.jbpm.bpmn2.xml;
 
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 
 import org.drools.compiler.compiler.xml.XmlDumper;
 import org.drools.core.xml.ExtensibleXmlParser;
+import org.jbpm.bpmn2.xml.elements.DataAssociationFactory;
 import org.jbpm.process.core.impl.DataTransformerRegistry;
 import org.jbpm.workflow.core.Node;
-import org.jbpm.workflow.core.node.Assignment;
 import org.jbpm.workflow.core.node.DataAssociation;
 import org.jbpm.workflow.core.node.RuleSetNode;
 import org.jbpm.workflow.core.node.Transformation;
@@ -125,17 +123,8 @@ public class BusinessRuleTaskHandler extends AbstractNodeHandler {
     			subNode = subNode.getNextSibling();
     		}
     		// assignments  
-            List<Assignment> assignments = new LinkedList<Assignment>();
-            while(subNode != null){
-                org.w3c.dom.Node ssubNode = subNode.getFirstChild();
-                String from = ssubNode.getTextContent();
-                String to = ssubNode.getNextSibling().getTextContent();
-                assignments.add(new Assignment("XPath", from, to));
-                subNode = subNode.getNextSibling();
-            }
-            ruleSetNode.addInAssociation(new DataAssociation(
-                    source,
-                    dataInputs.get(target), assignments, transformation));
+            ruleSetNode.addInAssociation(new DataAssociation(source, dataInputs.get(target), DataAssociationFactory
+                    .readAssignments(subNode), transformation));
         } else {
             // targetRef
             String to = subNode.getTextContent();
@@ -189,15 +178,8 @@ public class BusinessRuleTaskHandler extends AbstractNodeHandler {
  			subNode = subNode.getNextSibling();
  		}
  		// assignments 
-        List<Assignment> assignments = new LinkedList<Assignment>();
-        while(subNode != null){
-            org.w3c.dom.Node ssubNode = subNode.getFirstChild();
-            String from = ssubNode.getTextContent();
-            String to = ssubNode.getNextSibling().getTextContent();
-            assignments.add(new Assignment("XPath", from, to));
-            subNode = subNode.getNextSibling();
-        }
-        ruleSetNode.addOutAssociation(new DataAssociation(dataOutputs.get(source), target, assignments, transformation));
+        ruleSetNode.addOutAssociation(new DataAssociation(dataOutputs.get(source), target, DataAssociationFactory
+                .readAssignments(subNode), transformation));
     }
     
     protected void writeIO(RuleSetNode ruleSetNode, StringBuilder xmlDump) {

--- a/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/TaskHandler.java
+++ b/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/TaskHandler.java
@@ -17,20 +17,18 @@
 package org.jbpm.bpmn2.xml;
 
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 
-import org.jbpm.process.core.Work;
-import org.jbpm.process.core.impl.WorkImpl;
 import org.drools.core.xml.ExtensibleXmlParser;
 import org.jbpm.bpmn2.core.ItemDefinition;
+import org.jbpm.bpmn2.xml.elements.DataAssociationFactory;
 import org.jbpm.compiler.xml.ProcessBuildData;
+import org.jbpm.process.core.Work;
 import org.jbpm.process.core.impl.DataTransformerRegistry;
+import org.jbpm.process.core.impl.WorkImpl;
 import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.NodeContainer;
 import org.jbpm.workflow.core.impl.NodeImpl;
-import org.jbpm.workflow.core.node.Assignment;
 import org.jbpm.workflow.core.node.DataAssociation;
 import org.jbpm.workflow.core.node.ForEachNode;
 import org.jbpm.workflow.core.node.MilestoneNode;
@@ -175,19 +173,8 @@ public class TaskHandler extends AbstractNodeHandler {
     			
     			subNode = subNode.getNextSibling();
     		}
-    		// assignments    	
-    		List<Assignment> assignments = new LinkedList<Assignment>();
-    		while(subNode != null){
-    			org.w3c.dom.Node ssubNode = subNode.getFirstChild();
-    			String from = ssubNode.getTextContent();
-    			String to = ssubNode.getNextSibling().getTextContent();
-    			assignments.add(new Assignment("XPath", from, to));
-        		subNode = subNode.getNextSibling();
-    		}
-    		    		
-    		workItemNode.addInAssociation(new DataAssociation(
-    				source,
-    				dataInputs.get(target), assignments, transformation));
+            workItemNode.addInAssociation(new DataAssociation(source, dataInputs.get(target), DataAssociationFactory
+                    .readAssignments(subNode), transformation));
 		} else {
 			// targetRef
 			String to = subNode.getTextContent();
@@ -241,16 +228,8 @@ public class TaskHandler extends AbstractNodeHandler {
 //			transformation.setCompiledExpression(transformer.compile(expression));
 			subNode = subNode.getNextSibling();
 		}
-		// assignments  
-		List<Assignment> assignments = new LinkedList<Assignment>();
-		while(subNode != null){
-			org.w3c.dom.Node ssubNode = subNode.getFirstChild();
-			String from = ssubNode.getTextContent();
-			String to = ssubNode.getNextSibling().getTextContent();
-			assignments.add(new Assignment("XPath", from, to));
-    		subNode = subNode.getNextSibling();
-		}
-		workItemNode.addOutAssociation(new DataAssociation(dataOutputs.get(source), target, assignments, transformation));
+        workItemNode.addOutAssociation(new DataAssociation(dataOutputs.get(source), target, DataAssociationFactory
+                .readAssignments(subNode), transformation));
     }
 
     @Override

--- a/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/elements/DataAssociationFactory.java
+++ b/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/elements/DataAssociationFactory.java
@@ -17,9 +17,15 @@
 package org.jbpm.bpmn2.xml.elements;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import org.jbpm.process.builder.dialect.ProcessDialectRegistry;
+import org.jbpm.util.PatternConstants;
 import org.jbpm.workflow.core.node.Assignment;
 import org.jbpm.workflow.core.node.DataAssociation;
 import org.jbpm.workflow.core.node.Transformation;
@@ -30,8 +36,13 @@ import org.w3c.dom.NodeList;
 
 public final class DataAssociationFactory {
     
+    protected static final String LANG_EXPRESSION_ATTR = "language";
+    protected static final String DEFAULT_DIALECT = "XPath";
+    protected static final String USE_DEFINITION_LANGUAGE_PROPERTY = "org.kie.jbpm.bpmn2.useDefinitionLanguage";
     private static final Logger logger = LoggerFactory.getLogger(DataAssociationFactory.class);
     
+    private static Map<String, Pattern> dialectPatterns = buildDialectPatterns(ProcessDialectRegistry.getDialects());
+
     private DataAssociationFactory() {
         // do nothing
     }
@@ -63,7 +74,7 @@ public final class DataAssociationFactory {
                 }
                 case "transformation":
                 {
-                    String lang = subNode.getAttributes().getNamedItem("language").getNodeValue();
+                    String lang = subNode.getAttributes().getNamedItem(LANG_EXPRESSION_ATTR).getNodeValue();
                     String expression = subNode.getTextContent();
                     transformation = new Transformation(lang, expression, source);
                     break;
@@ -79,22 +90,74 @@ public final class DataAssociationFactory {
         return new DataAssociation(source, target, assignment, transformation);
     }
     
-    private static Assignment readAssignment(Node xmlNode) {
-        NodeList nodeList = xmlNode.getChildNodes();
-        String from = null;
-        String to = null;
-        for(int i = 0; i < nodeList.getLength(); i++) {
-            Node subNode = nodeList.item(i);
-            switch (subNode.getNodeName()) {
-                case "from":
-                    from = subNode.getTextContent();
-                    break;
-                case "to":
-                    to = subNode.getTextContent();
-                    break;
-            }
+    public static List<Assignment> readAssignments(Node subNode) {
+        List<Assignment> assignments = new LinkedList<>();
+        while (subNode != null) {
+            assignments.add(DataAssociationFactory.readAssignment(subNode));
+            subNode = subNode.getNextSibling();
         }
-        return new Assignment("XPath", from, to);
+        return assignments;
     }
 
+    public static Assignment readAssignment(Node xmlNode) {
+        Node from = xmlNode.getFirstChild();
+        if (from == null) {
+            throw new IllegalArgumentException("missing from for assignment");
+        }
+        Node to = from.getNextSibling();
+        if (to == null) {
+            throw new IllegalArgumentException("missing to for assignment");
+        }
+        return new Assignment(getDialect(xmlNode, from, to), from.getTextContent(), to.getTextContent());
+    }
+
+
+    protected static String getDialect(Node node, Node from, Node to) {
+        Collection<String> dialects = ProcessDialectRegistry.getDialects();
+        if (!dialects.equals(dialectPatterns.keySet())) {
+            dialectPatterns = buildDialectPatterns(dialects);
+        }
+
+        // trying to retrieve dialect from to or from overridden language
+        String dialect = findDialect(from.getAttributes().getNamedItem(LANG_EXPRESSION_ATTR));
+        if (dialect == null) {
+            dialect = findDialect(to.getAttributes().getNamedItem(LANG_EXPRESSION_ATTR));
+        }
+
+        // there are some working process which declares MVEL in definition but use XPATH, in order
+        // to prevent these files to fail, we check a flag (disable by default) before reading expression 
+        // language from definition
+        if (dialect == null && Boolean.getBoolean(USE_DEFINITION_LANGUAGE_PROPERTY)) {
+            Node parentNode = node.getParentNode();
+            while (parentNode != null && !parentNode.getLocalName().equals("Definitions")) {
+                parentNode = parentNode.getParentNode();
+            }
+            if (parentNode != null) {
+                dialect = findDialect(parentNode.getAttributes().getNamedItem("expressionLanguage"));
+            }
+        }
+        // finally, if still not able to determine language, check if from or to contains a mvel expression 
+        if (dialect == null && (PatternConstants.PARAMETER_MATCHER.matcher(from.getTextContent()).matches() ||
+                                PatternConstants.PARAMETER_MATCHER.matcher(to.getTextContent()).matches())) {
+            dialect = "mvel";
+        }
+        return dialect == null ? DEFAULT_DIALECT : dialect;
+    }
+
+    private static String findDialect(Node languageAttr) {
+        if (languageAttr != null) {
+            for (Map.Entry<String, Pattern> dialect : dialectPatterns.entrySet()) {
+                if (dialect.getValue().matcher(languageAttr.getNodeValue()).find()) {
+                    return dialect.getKey();
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Map<String, Pattern> buildDialectPatterns(Collection<String> dialects) {
+        return dialects.stream().collect(
+                Collectors.toMap(x -> x, dialect -> Pattern.compile("\\b" + dialect + "\\b",
+                        Pattern.CASE_INSENSITIVE)));
+    }
 }

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/DataTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/DataTest.java
@@ -17,8 +17,10 @@
 package org.jbpm.bpmn2;
 
 import java.io.ByteArrayInputStream;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,11 +29,11 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 import org.jbpm.bpmn2.core.Association;
 import org.jbpm.bpmn2.core.DataStore;
 import org.jbpm.bpmn2.core.Definitions;
 import org.jbpm.bpmn2.xml.ProcessHandler;
+import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -45,27 +47,92 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
+import org.kie.api.runtime.process.WorkflowProcessInstance;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class DataTest extends JbpmBpmn2TestCase {
 
+    public static class Person implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+        private String name;
+        private Address address;
+
+        public Person(String name, Address address) {
+            this.name = name;
+            this.address = address;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+
+        public void setAddress(Address address) {
+            this.address = address;
+        }
+
+        public Address getAddress() {
+            return address;
+        }
+    }
+
+    public static class Address implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+        private String city;
+        private String country;
+
+        public Address(String city, String country) {
+            this.city = city;
+            this.country = country;
+        }
+
+
+        public String getCity() {
+            return city;
+        }
+
+        public void setCity(String city) {
+            this.city = city;
+        }
+
+        public String getCountry() {
+            return country;
+        }
+
+        public void setCountry(String country) {
+            this.country = country;
+        }
+    }
+
+
     @Parameters
     public static Collection<Object[]> persistence() {
-        Object[][] data = new Object[][] { { false }, { true } };
+        Object[][] data = new Object[][]{{false}, {true}};
         return Arrays.asList(data);
     };
+
+
 
     private static final Logger logger = LoggerFactory.getLogger(DataTest.class);
 
     private StatefulKnowledgeSession ksession;
-    
+
     public DataTest(boolean persistence) {
         super(persistence);
     }
@@ -89,7 +156,7 @@ public class DataTest extends JbpmBpmn2TestCase {
         ksession = createKnowledgeSession(kbase);
         ProcessInstance processInstance = ksession.startProcess("Import");
         assertProcessInstanceCompleted(processInstance);
-        
+
     }
 
     @Test
@@ -101,7 +168,7 @@ public class DataTest extends JbpmBpmn2TestCase {
         ProcessInstance processInstance = ksession.startProcess("Evaluation",
                 params);
         assertProcessInstanceCompleted(processInstance);
-        
+
     }
 
     @Test
@@ -118,7 +185,7 @@ public class DataTest extends JbpmBpmn2TestCase {
         assertEquals("employeeStore", dataStore.getName());
         assertEquals(String.class.getCanonicalName(),
                 ((ObjectDataType) dataStore.getType()).getClassName());
-        
+
     }
 
     @Test
@@ -126,14 +193,15 @@ public class DataTest extends JbpmBpmn2TestCase {
         KieBase kbase = createKnowledgeBase("BPMN2-Association.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ProcessInstance processInstance = ksession.startProcess("Evaluation");
-        List<Association> associations = (List<Association>) processInstance.getProcess().getMetaData().get(ProcessHandler.ASSOCIATIONS);
+        List<Association> associations = (List<Association>) processInstance.getProcess().getMetaData().get(
+                ProcessHandler.ASSOCIATIONS);
         assertNotNull(associations);
         assertTrue(associations.size() == 1);
         Association assoc = associations.get(0);
         assertEquals("_1234", assoc.getId());
         assertEquals("_1", assoc.getSourceRef());
         assertEquals("_2", assoc.getTargetRef());
-        
+
     }
 
     @Test
@@ -149,7 +217,7 @@ public class DataTest extends JbpmBpmn2TestCase {
         ProcessInstance processInstance = ksession.startProcess("Evaluation",
                 params);
         assertProcessInstanceCompleted(processInstance);
-        
+
     }
 
     @Test
@@ -163,7 +231,7 @@ public class DataTest extends JbpmBpmn2TestCase {
         ProcessInstance processInstance = ksession.startProcess(
                 "com.sample.evaluation", params);
         assertProcessInstanceCompleted(processInstance);
-        
+
     }
 
     @Test
@@ -179,7 +247,7 @@ public class DataTest extends JbpmBpmn2TestCase {
         ProcessInstance processInstance = ksession.startProcess("Evaluation",
                 params);
         assertProcessInstanceCompleted(processInstance);
-        
+
     }
 
     @Test
@@ -197,7 +265,7 @@ public class DataTest extends JbpmBpmn2TestCase {
         ProcessInstance processInstance = ksession.startProcess("XPathProcess",
                 params);
         assertProcessInstanceCompleted(processInstance);
-        
+
     }
 
     @Test
@@ -206,13 +274,14 @@ public class DataTest extends JbpmBpmn2TestCase {
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new WorkItemHandler() {
+
                     public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                                              WorkItemManager mgr) {
 
                     }
 
                     public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                                                WorkItemManager mgr) {
                         assertEquals("hello world",
                                 workItem.getParameter("coId"));
                     }
@@ -226,7 +295,7 @@ public class DataTest extends JbpmBpmn2TestCase {
         params.put("instanceMetadata", document.getFirstChild());
         ProcessInstance processInstance = ksession.startProcess("process",
                 params);
-        
+
     }
 
     @Test
@@ -237,12 +306,12 @@ public class DataTest extends JbpmBpmn2TestCase {
                 new WorkItemHandler() {
 
                     public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                                              WorkItemManager mgr) {
 
                     }
 
                     public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                                                WorkItemManager mgr) {
                         assertEquals("hello", workItem.getParameter("coId"));
                     }
 
@@ -251,7 +320,60 @@ public class DataTest extends JbpmBpmn2TestCase {
         params.put("instanceMetadata", "hello");
         ProcessInstance processInstance = ksession.startProcess("process",
                 params);
-        
+
+    }
+
+
+    @Test
+    public void testDataInputAssociationsWithPojoPartial() throws Exception {
+        internalTestDataInputAssociationWithPojo("BPMN2-DataInputAssociations-Pojo.bpmn2");
+    }
+
+    @Test
+    public void testDataInputAssociationsWithPojoComplete() throws Exception {
+        internalTestDataInputAssociationWithPojo("BPMN2-DataInputAssociations-Pojo-Complete.bpmn2");
+    }
+
+    private void internalTestDataInputAssociationWithPojo(String bpmnFile) throws Exception {
+        KieBase kbase = createKnowledgeBaseWithoutDumper(bpmnFile);
+        ksession = createKnowledgeSession(kbase);
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new WorkItemHandler() {
+
+                    public void abortWorkItem(WorkItem manager,
+                                              WorkItemManager mgr) {
+
+                    }
+
+                    public void executeWorkItem(WorkItem workItem,
+                                                WorkItemManager mgr) {
+                        assertEquals("Sevilla", workItem.getParameter("coId"));
+                    }
+
+                });
+        ksession.startProcess("process", Collections.singletonMap("instanceMetadata", new Person("Javierito",
+                new Address("Sevilla", "Spain"))));
+    }
+
+    @Test
+    public void testDataInputAssociationsWithPojoNull() throws Exception {
+        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataInputAssociations-Pojo-Complete.bpmn2");
+        ksession = createKnowledgeSession(kbase);
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new WorkItemHandler() {
+
+                    public void abortWorkItem(WorkItem manager,
+                                              WorkItemManager mgr) {
+
+                    }
+
+                    public void executeWorkItem(WorkItem workItem,
+                                                WorkItemManager mgr) {
+                        assertNull(workItem.getParameter("coId"));
+                    }
+
+                });
+        ksession.startProcess("process", Collections.singletonMap("instanceMetadata", new Person("Javierito", null)));
     }
 
     /**
@@ -259,20 +381,19 @@ public class DataTest extends JbpmBpmn2TestCase {
      */
     @Test
     @Ignore
-    public void testDataInputAssociationsWithLazyLoading()
-            throws Exception {
+    public void testDataInputAssociationsWithLazyLoading() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-DataInputAssociations-lazy-creating.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new WorkItemHandler() {
 
                     public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                                              WorkItemManager mgr) {
 
                     }
 
                     public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                                                WorkItemManager mgr) {
                         Object coIdParamObj = workItem.getParameter("coId");
                         assertEquals("mydoc", ((Element) coIdParamObj).getNodeName());
                         assertEquals("mynode", ((Element) workItem.getParameter("coId")).getFirstChild().getNodeName());
@@ -297,7 +418,7 @@ public class DataTest extends JbpmBpmn2TestCase {
         params.put("instanceMetadata", document.getFirstChild());
         ProcessInstance processInstance = ksession.startProcess("process",
                 params);
-        
+
     }
 
     @Test
@@ -308,43 +429,42 @@ public class DataTest extends JbpmBpmn2TestCase {
                 new WorkItemHandler() {
 
                     public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                                              WorkItemManager mgr) {
 
                     }
 
                     public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                                                WorkItemManager mgr) {
                         assertEquals("hello", workItem.getParameter("coId"));
                     }
 
                 });
         ProcessInstance processInstance = ksession
                 .startProcess("process");
-        
+
     }
 
     @Test
-    public void testDataInputAssociationsWithStringWithoutQuotes()
-            throws Exception {
+    public void testDataInputAssociationsWithStringWithoutQuotes() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-DataInputAssociations-string-no-quotes.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new WorkItemHandler() {
 
                     public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                                              WorkItemManager mgr) {
 
                     }
 
                     public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                                                WorkItemManager mgr) {
                         assertEquals("hello", workItem.getParameter("coId"));
                     }
 
                 });
         ProcessInstance processInstance = ksession
                 .startProcess("process");
-        
+
     }
 
     @Test
@@ -355,23 +475,23 @@ public class DataTest extends JbpmBpmn2TestCase {
                 new WorkItemHandler() {
 
                     public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                                              WorkItemManager mgr) {
 
                     }
 
                     public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                                                WorkItemManager mgr) {
                         assertEquals("id", ((org.w3c.dom.Node) workItem
                                 .getParameter("coId")).getNodeName());
                         assertEquals("some text", ((org.w3c.dom.Node) workItem
                                 .getParameter("coId")).getFirstChild()
-                                .getTextContent());
+                                        .getTextContent());
                     }
 
                 });
         ProcessInstance processInstance = ksession
                 .startProcess("process");
-        
+
     }
 
     /**
@@ -386,12 +506,12 @@ public class DataTest extends JbpmBpmn2TestCase {
                 new WorkItemHandler() {
 
                     public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                                              WorkItemManager mgr) {
 
                     }
 
                     public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                                                WorkItemManager mgr) {
                         assertEquals("foo", ((Element) workItem
                                 .getParameter("Comment")).getNodeName());
                         // assertEquals("mynode", ((Element)
@@ -412,7 +532,7 @@ public class DataTest extends JbpmBpmn2TestCase {
         params.put("instanceMetadata", document.getFirstChild());
         ProcessInstance processInstance = ksession.startProcess("process",
                 params);
-        
+
     }
 
     @Test
@@ -423,12 +543,12 @@ public class DataTest extends JbpmBpmn2TestCase {
                 new WorkItemHandler() {
 
                     public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                                              WorkItemManager mgr) {
 
                     }
 
                     public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                                                WorkItemManager mgr) {
                         DocumentBuilderFactory factory = DocumentBuilderFactory
                                 .newInstance();
                         DocumentBuilder builder;
@@ -459,7 +579,7 @@ public class DataTest extends JbpmBpmn2TestCase {
         Map<String, Object> params = new HashMap<String, Object>();
         ProcessInstance processInstance = ksession.startProcess("process",
                 params);
-        
+
     }
 
     @Test
@@ -470,12 +590,12 @@ public class DataTest extends JbpmBpmn2TestCase {
                 new WorkItemHandler() {
 
                     public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                                              WorkItemManager mgr) {
 
                     }
 
                     public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                                                WorkItemManager mgr) {
                         try {
                             Document document = DocumentBuilderFactory
                                     .newInstance()
@@ -495,8 +615,149 @@ public class DataTest extends JbpmBpmn2TestCase {
                 });
         ProcessInstance processInstance = ksession
                 .startProcess("process");
-        
+
     }
+
+    @Test
+    public void testDataOutputAssociationsWithPojo() throws Exception {
+        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataOutputAssociations-Pojo.bpmn2");
+        ksession = createKnowledgeSession(kbase);
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new WorkItemHandler() {
+
+                    public void abortWorkItem(WorkItem manager,
+                                              WorkItemManager mgr) {
+
+                    }
+
+                    public void executeWorkItem(WorkItem workItem,
+                                                WorkItemManager mgr) {
+                        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.getProcessInstance(
+                                workItem.getProcessInstanceId());
+                        Person person = (Person) processInstance.getVariable("instanceMetadata");
+                        assertNotNull(person);
+                        assertEquals("Napoleon", person.getName());
+                        assertEquals("Paris", person.getAddress().getCity());
+                        assertEquals("France", person.getAddress().getCountry());
+                        mgr.completeWorkItem(workItem.getId(), Collections.singletonMap("output", new Person(
+                                "Javierito", new Address("Sevilla", "Spain"))));
+                        assertEquals("Napoleon", person.getName());
+                        assertEquals("Sevilla", person.getAddress().getCity());
+                        assertEquals("Spain", person.getAddress().getCountry());
+                    }
+
+                });
+        ksession.startProcess("process", Collections.singletonMap("instanceMetadata", new Person("Napoleon",
+                        new Address("Paris", "France"))));
+    }
+
+    @Test
+    public void testDataOutputAssociationsWithPojoEmptyFrom() throws Exception {
+        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataOutputAssociations-Pojo-EmptyFrom.bpmn2");
+        ksession = createKnowledgeSession(kbase);
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new WorkItemHandler() {
+
+                    public void abortWorkItem(WorkItem manager,
+                                              WorkItemManager mgr) {
+
+                    }
+
+                    public void executeWorkItem(WorkItem workItem,
+                                                WorkItemManager mgr) {
+                        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.getProcessInstance(
+                                workItem.getProcessInstanceId());
+                        Person person = (Person) processInstance.getVariable("instanceMetadata");
+                        assertNotNull(person);
+                        assertEquals("Napoleon", person.getName());
+                        assertEquals("Paris", person.getAddress().getCity());
+                        assertEquals("France", person.getAddress().getCountry());
+                        mgr.completeWorkItem(workItem.getId(), Collections.singletonMap("instanceAddress", new Address(
+                                "Sevilla", "Spain")));
+                        assertEquals("Napoleon", person.getName());
+                        assertEquals("Sevilla", person.getAddress().getCity());
+                        assertEquals("Spain", person.getAddress().getCountry());
+                    }
+
+                });
+        ksession.startProcess("process", Collections.singletonMap("instanceMetadata", new Person("Napoleon",
+                new Address("Paris", "France"))));
+    }
+
+    @Test
+    public void testDataOutputAssociationsWithPojoList() throws Exception {
+        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataOutputAssociations-PojoList.bpmn2");
+        ksession = createKnowledgeSession(kbase);
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new WorkItemHandler() {
+
+                    public void abortWorkItem(WorkItem manager,
+                                              WorkItemManager mgr) {
+
+                    }
+
+                    public void executeWorkItem(WorkItem workItem,
+                                                WorkItemManager mgr) {
+                        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.getProcessInstance(
+                                workItem.getProcessInstanceId());
+                        List<Person> persons = (List<Person>) processInstance.getVariable("instanceMetadata");
+                        assertNotNull(persons);
+                        Person person = persons.get(0);
+                        assertEquals("Javierito", person.getName());
+                        assertEquals("Paris", person.getAddress().getCity());
+                        assertEquals("France", person.getAddress().getCountry());
+                        mgr.completeWorkItem(workItem.getId(), Collections.singletonMap("output", Arrays.asList(
+                                new Person("Javierito", new Address("Paris", "France")), new Person("Napoleon",
+                                        new Address("Sevilla", "Spain")))));
+                        assertEquals("Javierito", person.getName());
+                        assertEquals("Sevilla", person.getAddress().getCity());
+                        assertEquals("Spain", person.getAddress().getCountry());
+                    }
+
+                });
+        ksession.startProcess("process", Collections.singletonMap("instanceMetadata", Arrays.asList(new Person(
+                "Javierito", new Address("Paris", "France")), new Person("Napoleon", new Address("Madrid",
+                        "Spain")))));
+    }
+
+    @Test
+    public void testDataOutputAssociationsWithPojoMap() throws Exception {
+        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataOutputAssociations-Map.bpmn2");
+        ksession = createKnowledgeSession(kbase);
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new WorkItemHandler() {
+                    public void abortWorkItem(WorkItem manager,
+                                              WorkItemManager mgr) {
+                    }
+
+                    public void executeWorkItem(WorkItem workItem,
+                                                WorkItemManager mgr) {
+                        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.getProcessInstance(
+                                workItem.getProcessInstanceId());
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> person = (Map<String, Object>) processInstance.getVariable(
+                                "instanceMetadata");
+                        assertNotNull(person);
+                        assertEquals("Javierito", person.get("name"));
+                        Address address = (Address) person.get("address");
+                        assertEquals("Paris", address.getCity());
+                        assertEquals("France", address.getCountry());
+                        mgr.completeWorkItem(workItem.getId(), Collections.singletonMap("output", Arrays.asList(
+                                new Person("Javierito", new Address("Paris", "France")), new Person("Napoleon",
+                                        new Address("Sevilla", "Spain")))));
+                        assertEquals("Javierito", person.get("name"));
+                        address = (Address) person.get("address");
+                        assertEquals("Sevilla", address.getCity());
+                        assertEquals("Spain", address.getCountry());
+                    }
+
+                });
+        Map<String, Object> person = new HashMap<>();
+        person.put("name", "Javierito");
+        person.put("address", new Address("Paris", "France"));
+        ksession.startProcess("process", Collections.singletonMap("instanceMetadata", person));
+    }
+
 
     @Test
     public void testDataOutputAssociationsXmlNode() throws Exception {
@@ -506,12 +767,12 @@ public class DataTest extends JbpmBpmn2TestCase {
                 new WorkItemHandler() {
 
                     public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                                              WorkItemManager mgr) {
 
                     }
 
                     public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                                                WorkItemManager mgr) {
                         try {
                             Document document = DocumentBuilderFactory
                                     .newInstance()
@@ -531,7 +792,7 @@ public class DataTest extends JbpmBpmn2TestCase {
                 });
         ProcessInstance processInstance = ksession
                 .startProcess("process");
-        
+
     }
 
 }

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/xml/elements/DataAssociationFactoryTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/xml/elements/DataAssociationFactoryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.bpmn2.xml.elements;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DataAssociationFactoryTest {
+
+    private Node node;
+    private Node from;
+    private Node to;
+    private NamedNodeMap attrs;
+
+    @Before
+    public void setup() {
+        node = mock(Node.class);
+        attrs = mock(NamedNodeMap.class);
+        from = mock(Node.class);
+        to = mock(Node.class);
+        when(from.getTextContent()).thenReturn(".");
+        when(to.getTextContent()).thenReturn(".");
+        when(from.getAttributes()).thenReturn(attrs);
+        when(to.getAttributes()).thenReturn(attrs);
+    }
+
+    @Test
+    public void testGetDialect() {
+        assertEquals(DataAssociationFactory.DEFAULT_DIALECT, DataAssociationFactory.getDialect(node, to, from));
+        Node attr = mock(Node.class);
+        when(attrs.getNamedItem(DataAssociationFactory.LANG_EXPRESSION_ATTR)).thenReturn(attr);
+        when(attr.getNodeValue()).thenReturn("http://www.mvel.org/2.0");
+        assertEquals("mvel", DataAssociationFactory.getDialect(node, to, from));
+        when(attr.getNodeValue()).thenReturn("java");
+        assertEquals("java", DataAssociationFactory.getDialect(node, to, from));
+        when(attr.getNodeValue()).thenReturn("javas");
+        assertEquals("XPath", DataAssociationFactory.getDialect(node, to, from));
+        when(attr.getNodeValue()).thenReturn("javascript");
+        assertEquals("JavaScript", DataAssociationFactory.getDialect(node, to, from));
+    }
+
+    @Test
+    public void testGetDialectFromDefinition() {
+        Node parentNode = mock(Node.class);
+        when(node.getParentNode()).thenReturn(parentNode);
+        when(node.getAttributes()).thenReturn(mock(NamedNodeMap.class));
+        when(parentNode.getAttributes()).thenReturn(attrs);
+        when(parentNode.getLocalName()).thenReturn("Definitions");
+        Node attr = mock(Node.class);
+        when(attr.getNodeValue()).thenReturn("http://www.mvel.org/2.0");
+        when(attrs.getNamedItem("expressionLanguage")).thenReturn(attr);
+        assertEquals("XPath", DataAssociationFactory.getDialect(node, from, to));
+        System.setProperty(DataAssociationFactory.USE_DEFINITION_LANGUAGE_PROPERTY, "true");
+        try {
+            assertEquals("mvel", DataAssociationFactory.getDialect(node, from, to));
+        } finally {
+            System.clearProperty(DataAssociationFactory.USE_DEFINITION_LANGUAGE_PROPERTY);
+        }
+    }
+
+}

--- a/jbpm-bpmn2/src/test/resources/BPMN2-DataInputAssociations-Pojo-Complete.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-DataInputAssociations-Pojo-Complete.bpmn2
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<definitions id="Definition"
+             targetNamespace=""
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:g="http://www.jboss.org/drools/flow/gpd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <itemDefinition id="_instanceMetadataItem" structureRef="org.jbpm.bpmn2.DataTest$Person" />
+
+  <process processType="Private" isExecutable="true" id="process" name="process" >
+  
+<!-- process variables -->
+    <property id="instanceMetadata" itemSubjectRef="_instanceMetadataItem"/>
+
+    <!-- nodes -->
+    <startEvent id="_1" name="" />
+    <userTask id="_2" name="Task">
+      <ioSpecification>
+        <dataInput id='coId' name='coId'/>
+        <inputSet>
+          <dataInputRefs>coId</dataInputRefs>
+        </inputSet>
+        <outputSet>
+        </outputSet>
+      </ioSpecification>
+      <dataInputAssociation>
+        <sourceRef>instanceMetadata</sourceRef>
+        <targetRef>coId</targetRef>
+        <assignment>
+          <from>#{instanceMetadata.?address.city}</from>
+          <to>coId</to>
+        </assignment>
+      </dataInputAssociation>
+    </userTask>
+    <endEvent id="_3" name="" />
+
+    <!-- connections -->
+    <sequenceFlow id="_1-_2" sourceRef="_1" targetRef="_2" />
+    <sequenceFlow id="_2-_3" sourceRef="_2" targetRef="_3" />
+
+  </process>
+
+</definitions>

--- a/jbpm-bpmn2/src/test/resources/BPMN2-DataInputAssociations-Pojo.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-DataInputAssociations-Pojo.bpmn2
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<definitions id="Definition"
+             targetNamespace=""
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:g="http://www.jboss.org/drools/flow/gpd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <itemDefinition id="_instanceMetadataItem" structureRef="org.jbpm.bpmn2.DataTest$Person" />
+
+  <process processType="Private" isExecutable="true" id="process" name="process" >
+  
+<!-- process variables -->
+    <property id="instanceMetadata" itemSubjectRef="_instanceMetadataItem"/>
+
+    <!-- nodes -->
+    <startEvent id="_1" name="" />
+    <userTask id="_2" name="Task">
+      <ioSpecification>
+        <dataInput id='coId' name='coId'/>
+        <inputSet>
+          <dataInputRefs>coId</dataInputRefs>
+        </inputSet>
+        <outputSet>
+        </outputSet>
+      </ioSpecification>
+      <dataInputAssociation>
+        <sourceRef>instanceMetadata</sourceRef>
+        <targetRef>coId</targetRef>
+        <assignment >
+          <from xsi:type="tFormalExpression" language="http://www.mvel.org/2.0">address.city</from>
+          <to>.</to>
+        </assignment>
+      </dataInputAssociation>
+    </userTask>
+    <endEvent id="_3" name="" />
+
+    <!-- connections -->
+    <sequenceFlow id="_1-_2" sourceRef="_1" targetRef="_2" />
+    <sequenceFlow id="_2-_3" sourceRef="_2" targetRef="_3" />
+
+  </process>
+
+</definitions>

--- a/jbpm-bpmn2/src/test/resources/BPMN2-DataOutputAssociations-Map.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-DataOutputAssociations-Map.bpmn2
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<definitions id="Definition"
+             targetNamespace=""
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:g="http://www.jboss.org/drools/flow/gpd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <itemDefinition id="_instanceMetadataItem" structureRef="java.util.Map" />
+  <itemDefinition id="_instanceAddressItem" structureRef="java.util.List" />
+
+  <process processType="Private" isExecutable="true" id="process" name="process" >
+  
+<!-- process variables -->
+    <property id="instanceMetadata" itemSubjectRef="_instanceMetadataItem"/>
+
+    <!-- nodes -->
+    <startEvent id="_1" name="" />
+    <userTask id="_2" name="Task">
+      <ioSpecification>
+        <dataOutput id='output' name='output'/>
+        <inputSet>
+        </inputSet>
+        <outputSet>
+          <dataOutputRefs>output</dataOutputRefs>
+        </outputSet>
+      </ioSpecification>
+      <dataOutputAssociation>
+        <sourceRef>output</sourceRef>
+        <targetRef>instanceMetadata</targetRef>
+        <assignment>
+          <from>#{this[1].address}</from>
+          <to>#{this['address']}</to>
+        </assignment>
+      </dataOutputAssociation>
+    </userTask>
+    <endEvent id="_3" name="" />
+
+    <!-- connections -->
+    <sequenceFlow id="_1-_2" sourceRef="_1" targetRef="_2" />
+    <sequenceFlow id="_2-_3" sourceRef="_2" targetRef="_3" />
+
+  </process>
+
+</definitions>

--- a/jbpm-bpmn2/src/test/resources/BPMN2-DataOutputAssociations-Pojo-EmptyFrom.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-DataOutputAssociations-Pojo-EmptyFrom.bpmn2
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<definitions id="Definition"
+             targetNamespace=""
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:g="http://www.jboss.org/drools/flow/gpd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <itemDefinition id="_instanceMetadataItem" structureRef="org.jbpm.bpmn2.DataTest$Person" />
+  <itemDefinition id="_instanceAddressItem" structureRef="org.jbpm.bpmn2.DataTest$Address" />
+
+  <process processType="Private" isExecutable="true" id="process" name="process" >
+  
+<!-- process variables -->
+    <property id="instanceMetadata" itemSubjectRef="_instanceMetadataItem"/>
+    <!-- nodes -->
+    <startEvent id="_1" name="" />
+    <userTask id="_2" name="Task">
+      <ioSpecification>
+        <dataOutput id="instanceAddress" name="instanceAddress"/>
+        <inputSet>
+        </inputSet>
+        <outputSet>
+          <dataOutputRefs>instanceAddress</dataOutputRefs>
+        </outputSet>
+      </ioSpecification>
+      <dataOutputAssociation>
+        <sourceRef>instanceAddress</sourceRef>
+        <targetRef>instanceMetadata</targetRef>
+        <assignment>
+          <from>this</from>
+          <to>#{instanceMetadata.address}</to>
+        </assignment>
+      </dataOutputAssociation>
+    </userTask>
+    <endEvent id="_3" name="" />
+
+    <!-- connections -->
+    <sequenceFlow id="_1-_2" sourceRef="_1" targetRef="_2" />
+    <sequenceFlow id="_2-_3" sourceRef="_2" targetRef="_3" />
+
+  </process>
+
+</definitions>

--- a/jbpm-bpmn2/src/test/resources/BPMN2-DataOutputAssociations-Pojo.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-DataOutputAssociations-Pojo.bpmn2
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<definitions id="Definition"
+             targetNamespace=""
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:g="http://www.jboss.org/drools/flow/gpd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <itemDefinition id="_instanceMetadataItem" structureRef="org.jbpm.bpmn2.DataTest$Person" />
+  
+  <process processType="Private" isExecutable="true" id="process" name="process" >
+  
+<!-- process variables -->
+    <property id="instanceMetadata" itemSubjectRef="_instanceMetadataItem"/>
+
+    <!-- nodes -->
+    <startEvent id="_1" name="" />
+    <userTask id="_2" name="Task">
+      <ioSpecification>
+        <dataOutput id='output' name='output'/>
+        <inputSet>
+        </inputSet>
+        <outputSet>
+          <dataOutputRefs>output</dataOutputRefs>
+        </outputSet>
+      </ioSpecification>
+      <dataOutputAssociation>
+        <sourceRef>output</sourceRef>
+        <targetRef>instanceMetadata</targetRef>
+        <assignment>
+          <from>#{address}</from>
+          <to>#{address}</to>
+        </assignment>
+      </dataOutputAssociation>
+    </userTask>
+    <endEvent id="_3" name="" />
+
+    <!-- connections -->
+    <sequenceFlow id="_1-_2" sourceRef="_1" targetRef="_2" />
+    <sequenceFlow id="_2-_3" sourceRef="_2" targetRef="_3" />
+
+  </process>
+
+</definitions>

--- a/jbpm-bpmn2/src/test/resources/BPMN2-DataOutputAssociations-PojoList.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-DataOutputAssociations-PojoList.bpmn2
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<definitions id="Definition"
+             targetNamespace=""
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:g="http://www.jboss.org/drools/flow/gpd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <itemDefinition id="_instanceMetadataItem" structureRef="java.util.List" />
+  <itemDefinition id="_instanceAddressItem" structureRef="java.util.List" />
+
+  <process processType="Private" isExecutable="true" id="process" name="process" >
+  
+<!-- process variables -->
+    <property id="instanceMetadata" itemSubjectRef="_instanceMetadataItem"/>
+
+    <!-- nodes -->
+    <startEvent id="_1" name="" />
+    <userTask id="_2" name="Task">
+      <ioSpecification>
+        <dataOutput id='output' name='output'/>
+        <inputSet>
+        </inputSet>
+        <outputSet>
+          <dataOutputRefs>output</dataOutputRefs>
+        </outputSet>
+      </ioSpecification>
+      <dataOutputAssociation>
+        <sourceRef>output</sourceRef>
+        <targetRef>instanceMetadata</targetRef>
+        <assignment>
+          <from>#{this[1].address}</from>
+          <to>#{this[0].address}</to>
+        </assignment>
+      </dataOutputAssociation>
+    </userTask>
+    <endEvent id="_3" name="" />
+
+    <!-- connections -->
+    <sequenceFlow id="_1-_2" sourceRef="_1" targetRef="_2" />
+    <sequenceFlow id="_2-_3" sourceRef="_2" targetRef="_3" />
+
+  </process>
+
+</definitions>

--- a/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/ProcessDialectRegistry.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/ProcessDialectRegistry.java
@@ -16,6 +16,8 @@
 
 package org.jbpm.process.builder.dialect;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -42,6 +44,10 @@ public class ProcessDialectRegistry {
 
     public static void setDialect(String dialectName, ProcessDialect dialect) {
         dialects.put(dialectName, dialect);
+    }
+
+    public static Collection<String> getDialects() {
+        return Collections.unmodifiableSet(dialects.keySet());
     }
 
 }

--- a/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELAssignmentAction.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELAssignmentAction.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.builder.dialect.mvel;
+
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+
+import org.drools.mvel.MVELSafeHelper;
+import org.jbpm.process.instance.impl.AssignmentAction;
+import org.jbpm.process.instance.impl.AssignmentProducer;
+import org.jbpm.util.PatternConstants;
+import org.jbpm.workflow.core.node.Assignment;
+import org.jbpm.workflow.instance.impl.NodeInstanceResolverFactory;
+import org.kie.api.runtime.process.NodeInstance;
+import org.kie.api.runtime.process.ProcessContext;
+
+public class MVELAssignmentAction implements AssignmentAction {
+
+    private String to;
+    private String from;
+    private String srcExpr;
+    private String targetExpr;
+    private AssignmentProducer producer;
+    private BiFunction<ProcessContext, NodeInstance, Object> src;
+    private BiFunction<ProcessContext, NodeInstance, Object> target;
+
+    private static final String THIS = "this";
+
+    public MVELAssignmentAction(Assignment assignment, String sourceExpr, String targetExpr,
+                                BiFunction<ProcessContext, NodeInstance, Object> source,
+                                BiFunction<ProcessContext, NodeInstance, Object> target, AssignmentProducer producer) {
+
+        Matcher fromMatcher = PatternConstants.PARAMETER_MATCHER.matcher(assignment.getFrom());
+        Matcher toMatcher = PatternConstants.PARAMETER_MATCHER.matcher(assignment.getTo());
+
+        this.from = fromMatcher.find() ? fromMatcher.group(1) : assignment.getFrom();
+        this.to = toMatcher.find() ? toMatcher.group(1) : assignment.getTo();
+        this.src = source;
+        this.target = target;
+        this.srcExpr = sourceExpr;
+        this.targetExpr = targetExpr;
+        this.producer = producer;
+    }
+
+    @Override
+    public void execute(NodeInstance nodeInstance, ProcessContext context) {
+        Object targetObject = this.target.apply(context, nodeInstance);
+        Object srcObject = this.src.apply(context, nodeInstance);
+        NodeInstanceResolverFactory resolver = new NodeInstanceResolverFactory(
+                (org.jbpm.workflow.instance.NodeInstance) nodeInstance);
+
+        // if just evaluating, not assignment
+        if (targetObject == null || notEvalTarget()) {
+            targetObject = notEvalSrc() ? srcObject : MVELSafeHelper.getEvaluator().eval(from, srcObject, resolver);
+        } else {
+            resolver.addExtraParameter(srcExpr, srcObject);
+            resolver.addExtraParameter(targetExpr, targetObject);
+            MVELSafeHelper.getEvaluator().eval(ensureLocated(targetExpr, to).concat("=").concat(ensureLocated(srcExpr,
+                    from)), resolver);
+        }
+        producer.accept(context, nodeInstance, targetObject);
+    }
+
+    private static boolean isThis(String assignmentExpr) {
+        return assignmentExpr.equals(".") || assignmentExpr.equals(THIS);
+    }
+
+    private static boolean notEval(String assignmentExpr, String expr) {
+        return isThis(assignmentExpr) || assignmentExpr.equals(expr);
+    }
+    
+    private static String ensureLocated(String prefix, String suffix) {
+        if (isThis(suffix)) {
+            return prefix;
+        }
+        if (suffix.startsWith(prefix)) {
+            return suffix;
+        }
+        StringBuilder sb = new StringBuilder(prefix);
+
+        if (suffix.startsWith(THIS)) {
+            sb.append(suffix.substring(THIS.length()));
+        } else {
+            if (!suffix.startsWith("[")) {
+                sb.append(".");
+            }
+            sb.append(suffix);
+        }
+        return sb.toString();
+    }
+
+    private boolean notEvalSrc() {
+        return notEval(from, srcExpr);
+    }
+
+    private boolean notEvalTarget() {
+        return notEval(to, targetExpr);
+    }
+
+}

--- a/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELAssignmentBuilder.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELAssignmentBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.builder.dialect.mvel;
+
+import java.util.function.BiFunction;
+
+import org.drools.compiler.rule.builder.PackageBuildContext;
+import org.jbpm.process.builder.AssignmentBuilder;
+import org.jbpm.process.instance.impl.AssignmentProducer;
+import org.jbpm.workflow.core.node.Assignment;
+import org.kie.api.runtime.process.NodeInstance;
+import org.kie.api.runtime.process.ProcessContext;
+
+
+public class MVELAssignmentBuilder implements AssignmentBuilder {
+
+    @Override
+    public void build(PackageBuildContext context,
+                      Assignment assignment,
+                      String sourceExpr,
+                      String targetExpr,
+                      BiFunction<ProcessContext, NodeInstance, Object> source,
+                      BiFunction<ProcessContext, NodeInstance, Object> target,
+                      AssignmentProducer producer) {
+        assignment.setMetaData("Action", new MVELAssignmentAction(assignment, sourceExpr, targetExpr, source, target,
+                producer));
+    }
+
+}

--- a/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELProcessDialect.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELProcessDialect.java
@@ -29,40 +29,41 @@ import org.jbpm.process.builder.dialect.ProcessDialect;
  */
 public class MVELProcessDialect implements ProcessDialect {
 
-	private static ActionBuilder actionBuilder = new MVELActionBuilder();
-	private static ReturnValueEvaluatorBuilder returnValueBuilder = new MVELReturnValueEvaluatorBuilder();
-	
-	public void addProcess(final ProcessBuildContext context) {
+    private static ActionBuilder actionBuilder = new MVELActionBuilder();
+    private static ReturnValueEvaluatorBuilder returnValueBuilder = new MVELReturnValueEvaluatorBuilder();
+    private static AssignmentBuilder assignmentBuilder = new MVELAssignmentBuilder();
+
+    public void addProcess(final ProcessBuildContext context) {
         // @TODO setup line mappings
-	}
+    }
 
-	public ActionBuilder getActionBuilder() {
-		return actionBuilder;
-	}
+    public ActionBuilder getActionBuilder() {
+        return actionBuilder;
+    }
 
-	public ProcessClassBuilder getProcessClassBuilder() {
-        throw new UnsupportedOperationException( "MVELProcessDialect.getProcessClassBuilder is not supported" );
-	}
+    public ProcessClassBuilder getProcessClassBuilder() {
+        throw new UnsupportedOperationException("MVELProcessDialect.getProcessClassBuilder is not supported");
+    }
 
-	public ReturnValueEvaluatorBuilder getReturnValueEvaluatorBuilder() {
-		return returnValueBuilder;
-	}
+    public ReturnValueEvaluatorBuilder getReturnValueEvaluatorBuilder() {
+        return returnValueBuilder;
+    }
 
-	public AssignmentBuilder getAssignmentBuilder() {
-		throw new UnsupportedOperationException("MVEL assignments not supported");
-	}
+    public AssignmentBuilder getAssignmentBuilder() {
+        return assignmentBuilder;
+    }
 
     /**
      * These methods are necessary for code in the jbpm-kie-services, that has
      * it's own {@link ReturnValueEvaluatorBuilder}, {@link ActionBuilder} and
      * {@link ProcessClassBuilder} implementations.
      */
-	
-    public static void setActionbuilder( ActionBuilder actionbuilder ) {
+
+    public static void setActionbuilder(ActionBuilder actionbuilder) {
         actionBuilder = actionbuilder;
     }
 
-    public static void setReturnvaluebuilder( ReturnValueEvaluatorBuilder returnvaluebuilder ) {
+    public static void setReturnvaluebuilder(ReturnValueEvaluatorBuilder returnvaluebuilder) {
         returnValueBuilder = returnvaluebuilder;
     }
 

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceResolverFactory.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceResolverFactory.java
@@ -47,13 +47,12 @@ public class NodeInstanceResolverFactory extends ImmutableDefaultFactory {
 	public boolean isResolveable(String name) {
 		boolean found = nodeInstance.resolveContextInstance(VariableScope.VARIABLE_SCOPE, name) != null;
 		if (!found) {
-		    return extraParameters.containsKey(name);
+            found = extraParameters.containsKey(name);
 		}
-		
 		return found;
 	}
-	
-	
+
+
 	public VariableResolver getVariableResolver(String name) {
 	    if (extraParameters.containsKey(name)) {
 	        return new SimpleValueResolver(extraParameters.get(name));
@@ -64,5 +63,12 @@ public class NodeInstanceResolverFactory extends ImmutableDefaultFactory {
 					VariableScope.VARIABLE_SCOPE, name)).getVariable(name);
 		return new SimpleValueResolver(value);
 	}
+
+    public void addExtraParameter(String key, Object value) {
+        if (value != null) {
+            extraParameters.putIfAbsent(key, value);
+        }
+
+    }
 	
 }


### PR DESCRIPTION
Reading expressionLanguage from process
Implementing assigment for mvel
Introduced system property (org.kie.jbpm.bpmn2.useDefinitionLanguage) to specify if expressionLanguage should be read from definitions if language is not specified in Assigment (default value false, since there are working process which have mvel as definition and are using Xpath)


**JIRA**: 

[JBPM-9470](https://issues.redhat.com/browse/JBPM-9470)
