### PR TITLE
[JBPM-9485] Missing dependency for ibm jdk8 after descope ecj

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/pom.xml
+++ b/jbpm-human-task/jbpm-human-task-core/pom.xml
@@ -275,6 +275,13 @@
       <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
       <scope>provided</scope>
     </dependency>
+    
+    <!-- needed for ibm jdk1.8 tests -->
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-ecj</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
**JIRA**: [JBPM-9485](https://issues.redhat.com/browse/JBPM-9485)

