### PR TITLE
[BXMSPROD-1037] - exclusions for Enforcer banDuplicationClasses viola…

### DIFF
--- a/jbpm-xes/pom.xml
+++ b/jbpm-xes/pom.xml
@@ -27,12 +27,12 @@
   <name>jBPM :: XES Exporter</name>
   <description>jBPM XES Exporter</description>
   <artifactId>jbpm-xes</artifactId>
-  
+
   <properties>
     <version.commons-cli>1.4</version.commons-cli>
     <version.com.h2database>1.4.193</version.com.h2database>
   </properties>
-   
+
 
   <dependencies>
 
@@ -44,6 +44,10 @@
         <exclusion>
           <groupId>javax.activation</groupId>
           <artifactId>javax.activation-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.xml.bind</groupId>
+          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -133,7 +137,7 @@
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>
-    
+
     <!-- needed for jdk 11 -->
     <dependency>
       <groupId>org.jboss.spec.javax.xml.bind</groupId>
@@ -186,4 +190,26 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>jdk11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
+      <dependencies>
+        <!-- needed for jdk 11 -->
+        <dependency>
+          <groupId>org.jboss.spec.javax.xml.bind</groupId>
+          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/jbpm-xes/pom.xml
+++ b/jbpm-xes/pom.xml
@@ -138,17 +138,6 @@
       <artifactId>postgresql</artifactId>
     </dependency>
 
-    <!-- needed for jdk 11 -->
-    <dependency>
-      <groupId>org.jboss.spec.javax.xml.bind</groupId>
-      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-    </dependency>
-
   </dependencies>
 
   <build>


### PR DESCRIPTION
[BXMSPROD-1037] - exclusions for Enforcer banDuplicationClasses violation
**Thank you for submitting this pull request**

**JIRA**: https://issues.redhat.com/browse/BXMSPROD-1037

**referenced Pull Requests**:

* parent PR https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1557

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
