### PR TITLE
[7.48.x] JBPM-9542: Remove issue-keeper tool (#1828)

### DIFF
--- a/jbpm-test-coverage/pom.xml
+++ b/jbpm-test-coverage/pom.xml
@@ -26,10 +26,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>link.bek.tools</groupId>
-      <artifactId>issue-keeper-junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/JbpmTestCase.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/JbpmTestCase.java
@@ -16,9 +16,11 @@
 
 package org.jbpm.test;
 
+import java.util.Map;
+import java.util.Properties;
+
 import org.assertj.core.api.Assertions;
 import org.jbpm.test.persistence.util.PersistenceUtil;
-import org.kie.test.util.db.PoolingDataSourceWrapper;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
@@ -29,12 +31,6 @@ import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import qa.tools.ikeeper.client.BugzillaClient;
-import qa.tools.ikeeper.client.JiraClient;
-import qa.tools.ikeeper.test.IKeeperJUnitConnector;
-
-import java.util.Map;
-import java.util.Properties;
 
 public abstract class JbpmTestCase extends JbpmJUnitBaseTestCase {
 
@@ -72,12 +68,6 @@ public abstract class JbpmTestCase extends JbpmJUnitBaseTestCase {
         }
 
     };
-
-    @Rule
-    public IKeeperJUnitConnector issueKeeper = new IKeeperJUnitConnector(
-            new BugzillaClient("https://bugzilla.redhat.com"),
-            new JiraClient("https://issues.jboss.org")
-    );
 
     @Override
     protected Properties getDataSourceProperties(){

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/LdapJbpmTestCase.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/LdapJbpmTestCase.java
@@ -17,6 +17,7 @@
 package org.jbpm.test;
 
 import java.util.Properties;
+
 import javax.naming.Context;
 
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/ConditionalFlowTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/ConditionalFlowTest.java
@@ -27,7 +27,12 @@ import org.junit.Test;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.KieSession;
 
-import static org.jbpm.test.tools.IterableListenerAssert.*;
+import static org.jbpm.test.tools.IterableListenerAssert.assertChangedVariable;
+import static org.jbpm.test.tools.IterableListenerAssert.assertLeft;
+import static org.jbpm.test.tools.IterableListenerAssert.assertNextNode;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessCompleted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessStarted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertTriggered;
 
 /**
  * Testing conditional sequence flow without gateway.

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/DataObjectTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/DataObjectTest.java
@@ -33,8 +33,14 @@ import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.WorkItem;
 
-import static org.jbpm.test.tools.IterableListenerAssert.*;
-import static org.junit.Assert.*;
+import static org.jbpm.test.tools.IterableListenerAssert.assertChangedVariable;
+import static org.jbpm.test.tools.IterableListenerAssert.assertLeft;
+import static org.jbpm.test.tools.IterableListenerAssert.assertNextNode;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessCompleted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessStarted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertTriggered;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Testing data object and association.

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/EventListenersTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/EventListenersTest.java
@@ -26,7 +26,8 @@ import org.junit.Test;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.KieSession;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test to ensure event listeners for processes work properly BRMS 5.3 PRD: BRMS-BPM-10

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/FlexibleProcessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/FlexibleProcessTest.java
@@ -33,8 +33,12 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItem;
 
-import static org.jbpm.test.tools.TrackingListenerAssert.*;
-import static org.junit.Assert.*;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertProcessCompleted;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertProcessStarted;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggered;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggeredAndLeft;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Flexible process test. (process fragments without strict process flow

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/LaneTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/LaneTest.java
@@ -26,7 +26,11 @@ import org.junit.Test;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.KieSession;
 
-import static org.jbpm.test.tools.TrackingListenerAssert.*;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertLeft;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertProcessCompleted;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertProcessStarted;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggered;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggeredAndLeft;
 
 /**
  * Simple testing of lanes - there is nothing special to test.

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/TransactionsTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/TransactionsTest.java
@@ -19,6 +19,7 @@ package org.jbpm.test.functional;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.naming.InitialContext;
 import javax.transaction.Status;
 import javax.transaction.UserTransaction;
@@ -34,7 +35,7 @@ import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 public class TransactionsTest extends JbpmTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/async/AsyncAdHocSubprocessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/async/AsyncAdHocSubprocessTest.java
@@ -16,12 +16,6 @@
 
 package org.jbpm.test.functional.async;
 
-import static java.util.Collections.emptyMap;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.jbpm.test.tools.TrackingListenerAssert.assertProcessStarted;
-import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggeredAndLeft;
-
 import java.util.concurrent.CountDownLatch;
 
 import org.jbpm.executor.ExecutorServiceFactory;
@@ -39,6 +33,12 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertProcessStarted;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggeredAndLeft;
 
 /**
  * process1: start -> catch signal -> first time exception -> end process2:

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/async/AsyncThrowSignalTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/async/AsyncThrowSignalTest.java
@@ -25,9 +25,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.api.event.process.DefaultProcessEventListener;
 import org.kie.api.event.process.ProcessCompletedEvent;
+import org.kie.api.executor.ExecutorService;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
-import org.kie.api.executor.ExecutorService;
 
 /**
  * process1: start -> catch signal -> first time exception -> end process2:

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/correlation/AbstractStartProcessWithCorrelationKeyTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/correlation/AbstractStartProcessWithCorrelationKeyTest.java
@@ -32,7 +32,10 @@ import org.kie.internal.process.CorrelationKeyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 public abstract class AbstractStartProcessWithCorrelationKeyTest extends JbpmTestCase {
     

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/event/BoundaryErrorMultiInstanceProcessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/event/BoundaryErrorMultiInstanceProcessTest.java
@@ -27,7 +27,7 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.task.TaskService;
 import org.kie.api.task.model.TaskSummary;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 
 public class BoundaryErrorMultiInstanceProcessTest extends JbpmTestCase{

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/event/BoundaryEventOnTaskWithCalendarTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/event/BoundaryEventOnTaskWithCalendarTest.java
@@ -29,7 +29,7 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.process.ProcessInstance;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
 
 /**
  * This is a sample file to test a process.

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/event/BoundaryEventWithOutputSetPersistenceTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/event/BoundaryEventWithOutputSetPersistenceTest.java
@@ -16,11 +16,6 @@
 
 package org.jbpm.test.functional.event;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,6 +32,11 @@ import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/event/EndEventTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/event/EndEventTest.java
@@ -32,10 +32,14 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.internal.command.CommandFactory;
-import qa.tools.ikeeper.annotation.BZ;
 
-import static org.jbpm.test.tools.IterableListenerAssert.*;
-import static org.junit.Assert.*;
+import static org.jbpm.test.tools.IterableListenerAssert.assertChangedVariable;
+import static org.jbpm.test.tools.IterableListenerAssert.assertLeft;
+import static org.jbpm.test.tools.IterableListenerAssert.assertNextNode;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessCompleted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessStarted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertTriggered;
+import static org.junit.Assert.assertFalse;
 
 public class EndEventTest extends JbpmTestCase {
 
@@ -61,7 +65,6 @@ public class EndEventTest extends JbpmTestCase {
         super(false);
     }
 
-    @BZ("1021631")
     @Test(timeout = 30000)
     public void testCompensateEndEvent() {
         KieSession ksession = createKSession(COMPENSATE);
@@ -120,7 +123,6 @@ public class EndEventTest extends JbpmTestCase {
         Assertions.assertThat(events.hasNext()).isFalse();
     }
 
-    @BZ("1015221")
     @Test(timeout = 30000)
     public void testEscalationEndEvent() {
         KieSession ksession = createKSession(ESCALATION);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/event/StartEventTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/event/StartEventTest.java
@@ -27,8 +27,10 @@ import org.junit.Test;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.KieSession;
 
-import static org.jbpm.test.tools.IterableListenerAssert.*;
-import static org.junit.Assert.*;
+import static org.jbpm.test.tools.IterableListenerAssert.assertNextNode;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessCompleted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessStarted;
+import static org.junit.Assert.assertTrue;
 
 public class StartEventTest extends JbpmTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/gateway/EventBasedGatewayTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/gateway/EventBasedGatewayTest.java
@@ -19,7 +19,6 @@ package org.jbpm.test.functional.gateway;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.kie.api.time.SessionPseudoClock;
 import org.jbpm.test.JbpmTestCase;
 import org.jbpm.test.listener.TrackingProcessEventListener;
 import org.jbpm.test.tools.TrackingListenerAssert;
@@ -29,9 +28,10 @@ import org.junit.Test;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.api.time.SessionPseudoClock;
 import org.kie.internal.command.CommandFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Event-based gateway execution test. branches: condition event, signal event, message event, timer event

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/gateway/ExclusiveGatewayTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/gateway/ExclusiveGatewayTest.java
@@ -18,6 +18,7 @@ package org.jbpm.test.functional.gateway;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -32,7 +33,10 @@ import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import static org.jbpm.test.tools.IterableListenerAssert.*;
+import static org.jbpm.test.tools.IterableListenerAssert.assertMultipleVariablesChanged;
+import static org.jbpm.test.tools.IterableListenerAssert.assertNextNode;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessCompleted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessStarted;
 
 /**
  * Exclusive gateway test. priorities, default gate, conditions (XPath, Java, MVEL)

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/gateway/InclusiveGatewayTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/gateway/InclusiveGatewayTest.java
@@ -26,7 +26,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 
-import static org.jbpm.test.tools.IterableListenerAssert.*;
+import static org.jbpm.test.tools.IterableListenerAssert.assertChangedVariable;
+import static org.jbpm.test.tools.IterableListenerAssert.assertLeft;
+import static org.jbpm.test.tools.IterableListenerAssert.assertNextNode;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessCompleted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessStarted;
 
 /**
  * Inclusive gateway tests. combination of diverging OR gateway with converging XOR gateway

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/gateway/InclusiveGatewayWithHumanTasksProcessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/gateway/InclusiveGatewayWithHumanTasksProcessTest.java
@@ -27,7 +27,8 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.task.TaskService;
 import org.kie.api.task.model.TaskSummary;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 
 public class InclusiveGatewayWithHumanTasksProcessTest extends JbpmTestCase{

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/AsyncTaskCallbackTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/AsyncTaskCallbackTest.java
@@ -30,7 +30,8 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItemManager;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 //
 // BZ-1121396

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/AsyncTaskTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/AsyncTaskTest.java
@@ -31,9 +31,8 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.api.runtime.query.QueryContext;
 
-import qa.tools.ikeeper.annotation.BZ;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 //
 // TODO: Add asserts job results
@@ -82,7 +81,6 @@ public class AsyncTaskTest extends JbpmAsyncJobTestCase {
     }
 
     @Test(timeout=10000)
-    @BZ("1121027")
     public void testTaskComplete() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("Process async", 1);
         CountDownAsyncJobListener countDownJobListener = new CountDownAsyncJobListener(1);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/AsyncTaskTransactionTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/AsyncTaskTransactionTest.java
@@ -26,17 +26,17 @@ import javax.transaction.UserTransaction;
 import org.assertj.core.api.Assertions;
 import org.jbpm.executor.impl.ExecutorServiceImpl;
 import org.jbpm.executor.impl.wih.AsyncWorkItemHandler;
-import org.jbpm.test.persistence.util.PersistenceUtil;
 import org.jbpm.test.JbpmAsyncJobTestCase;
 import org.jbpm.test.listener.CountDownAsyncJobListener;
-import org.kie.test.util.db.PoolingDataSourceWrapper;
+import org.jbpm.test.persistence.util.PersistenceUtil;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.api.runtime.query.QueryContext;
+import org.kie.test.util.db.PoolingDataSourceWrapper;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
 
 public class AsyncTaskTransactionTest extends JbpmAsyncJobTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/LogCleanupCommandTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/LogCleanupCommandTest.java
@@ -17,7 +17,11 @@
 package org.jbpm.test.functional.jobexec;
 
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javax.persistence.EntityManagerFactory;
 
@@ -33,7 +37,6 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.task.TaskService;
 import org.kie.internal.executor.api.CommandContext;
-import qa.tools.ikeeper.annotation.BZ;
 
 /**
  * BZ-TODO: SingleRun - only accepts "true"/"false" but is boolean type, other boolean types accept true/false.
@@ -185,7 +188,6 @@ public class LogCleanupCommandTest extends JbpmAsyncJobTestCase {
     }
 
     @Test(timeout=10000)
-    @BZ("1190881")
     public void deleteAllLogsOlderThanNow() throws Exception {
         CountDownAsyncJobListener countDownListener = new CountDownAsyncJobListener(1);
         ((ExecutorServiceImpl) getExecutorService()).addAsyncJobListener(countDownListener);
@@ -216,7 +218,6 @@ public class LogCleanupCommandTest extends JbpmAsyncJobTestCase {
     }
 
     @Test(timeout=10000)
-    @BZ("1190881")
     public void deleteAllLogsOlderThanPeriod() throws Exception {
         CountDownAsyncJobListener countDownListener = new CountDownAsyncJobListener(1);
         ((ExecutorServiceImpl) getExecutorService()).addAsyncJobListener(countDownListener);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jpa/ParentChildMarshallingJpaTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jpa/ParentChildMarshallingJpaTest.java
@@ -16,9 +16,6 @@
 
 package org.jbpm.test.functional.jpa;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,7 +31,6 @@ import org.drools.persistence.jpa.marshaller.JPAPlaceholderResolverStrategy;
 import org.jbpm.services.task.impl.command.CommandBasedTaskService;
 import org.jbpm.services.task.utils.ContentMarshallerHelper;
 import org.jbpm.test.JbpmTestCase;
-import org.jbpm.test.JbpmJUnitBaseTestCase.Strategy;
 import org.jbpm.test.entity.Application;
 import org.jbpm.test.entity.Person;
 import org.junit.Test;
@@ -49,8 +45,9 @@ import org.kie.api.task.model.Content;
 import org.kie.api.task.model.Task;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 public class ParentChildMarshallingJpaTest extends JbpmTestCase {

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jpa/PatientVariablePersistenceStrategyTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jpa/PatientVariablePersistenceStrategyTest.java
@@ -16,7 +16,6 @@
 
 package org.jbpm.test.functional.jpa;
 
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -33,7 +32,6 @@ import javax.transaction.UserTransaction;
 import org.drools.core.marshalling.impl.ClassObjectMarshallingStrategyAcceptor;
 import org.drools.core.marshalling.impl.SerializablePlaceholderResolverStrategy;
 import org.drools.persistence.jpa.marshaller.JPAPlaceholderResolverStrategy;
-import org.jbpm.marshalling.impl.ProcessInstanceResolverStrategy;
 import org.jbpm.services.task.utils.ContentMarshallerHelper;
 import org.jbpm.test.JbpmTestCase;
 import org.jbpm.test.entity.MedicalRecord;
@@ -54,7 +52,9 @@ import org.kie.api.task.model.TaskSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class PatientVariablePersistenceStrategyTest extends JbpmTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jpa/SupportProcessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jpa/SupportProcessTest.java
@@ -28,7 +28,7 @@ import org.kie.api.task.TaskService;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.task.api.InternalTaskService;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 
 public class SupportProcessTest extends JbpmTestCase{

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/ExecutorLogCleanTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/ExecutorLogCleanTest.java
@@ -34,8 +34,6 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.api.runtime.query.QueryContext;
 
-import qa.tools.ikeeper.annotation.BZ;
-
 public class ExecutorLogCleanTest extends JbpmAsyncJobTestCase {
 
     private static final String ASYNC_DATA_EXEC = "org/jbpm/test/functional/common/AsyncDataExecutor.bpmn2";
@@ -96,7 +94,6 @@ public class ExecutorLogCleanTest extends JbpmAsyncJobTestCase {
     }
 
     @Test
-    @BZ("1188702")
     public void deleteErrorLogsByDate() throws Exception {
         CountDownAsyncJobListener countDownListener = new CountDownAsyncJobListener(2);
         ((ExecutorServiceImpl) getExecutorService()).addAsyncJobListener(countDownListener);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/ProcessInstanceLogCleanTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/ProcessInstanceLogCleanTest.java
@@ -34,7 +34,6 @@ import org.kie.api.runtime.manager.audit.ProcessInstanceLog;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.internal.runtime.manager.audit.query.ProcessInstanceLogDeleteBuilder;
 import org.kie.internal.runtime.manager.audit.query.ProcessInstanceLogQueryBuilder;
-import qa.tools.ikeeper.annotation.BZ;
 
 /**
  * TODO:
@@ -223,7 +222,6 @@ public class ProcessInstanceLogCleanTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1188702")
     public void deleteLogsByDate() throws InterruptedException {
         Date testStartDate = new Date();
 
@@ -271,7 +269,6 @@ public class ProcessInstanceLogCleanTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1192498")
     public void deleteLogsByDateRange() throws InterruptedException {
         KieSession kieSession = createKSession(PARENT_PROCESS_CALLER, PARENT_PROCESS_INFO, HELLO_WORLD_PROCESS);
 
@@ -306,19 +303,16 @@ public class ProcessInstanceLogCleanTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1192498")
     public void deleteLogsByDateRangeEndingYesterday() throws InterruptedException {
         deleteLogsByDateRange(getYesterday(), getYesterday(), false);
     }
 
     @Test
-    @BZ("1192498")
     public void deleteLogsByDateRangeIncludingToday() throws InterruptedException {
         deleteLogsByDateRange(getYesterday(), getTomorrow(), true);
     }
 
     @Test
-    @BZ("1192498")
     public void deleteLogsByDateRangeStartingTomorrow() throws InterruptedException {
         deleteLogsByDateRange(getTomorrow(), getTomorrow(), false);
     }

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/TaskLogCleanTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/TaskLogCleanTest.java
@@ -37,7 +37,6 @@ import org.kie.api.task.model.Status;
 import org.kie.api.task.model.Task;
 import org.kie.internal.task.api.AuditTask;
 import org.kie.internal.task.api.TaskVariable;
-import qa.tools.ikeeper.annotation.BZ;
 
 /**
  * Tests for:
@@ -120,7 +119,6 @@ public class TaskLogCleanTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1188702")
     public void testDeleteLogsByDate() {
         kieSession = createKSession(HUMAN_TASK);
 
@@ -152,7 +150,6 @@ public class TaskLogCleanTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1193017")
     public void testDeleteLogsByDateRange() throws InterruptedException {
         processInstanceList = new ArrayList<ProcessInstance>();
         kieSession = createKSession(HUMAN_TASK, INPUT_ASSOCIATION);
@@ -319,7 +316,6 @@ public class TaskLogCleanTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1192912")
     public void testClearLogs() {
         kieSession = createKSession(HUMAN_TASK);
         processInstanceList = startProcess(kieSession, HUMAN_TASK_ID, 2);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/VariableInstanceLogCleanTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/VariableInstanceLogCleanTest.java
@@ -16,7 +16,11 @@
 
 package org.jbpm.test.functional.log;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.assertj.core.api.Assertions;
 import org.jbpm.process.audit.JPAAuditLogService;

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/monitoring/MBeansMonitoringWithJBpmTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/monitoring/MBeansMonitoringWithJBpmTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executors;
 
 import javax.management.JMX;
 import javax.management.MBeanServer;
+
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.core.ClockType;
 import org.drools.core.management.DroolsManagementAgent;

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/service/ServiceTaskHandlerTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/service/ServiceTaskHandlerTest.java
@@ -30,7 +30,7 @@ import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.manager.RuntimeManager;
 import org.kie.api.runtime.process.ProcessInstance;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class ServiceTaskHandlerTest extends JbpmTestCase {
     

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/AdHocSubProcessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/AdHocSubProcessTest.java
@@ -26,6 +26,7 @@ import org.jbpm.test.JbpmTestCase;
 import org.jbpm.test.listener.TrackingProcessEventListener;
 import org.jbpm.workflow.instance.node.DynamicNodeInstance;
 import org.jbpm.workflow.instance.node.DynamicUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.KieSession;
@@ -35,7 +36,6 @@ import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.api.runtime.process.WorkflowProcessInstance;
 import org.kie.internal.command.CommandFactory;
-import qa.tools.ikeeper.annotation.BZ;
 
 import static org.jbpm.test.tools.TrackingListenerAssert.assertLeft;
 import static org.jbpm.test.tools.TrackingListenerAssert.assertProcessCompleted;
@@ -104,7 +104,7 @@ public class AdHocSubProcessTest extends JbpmTestCase {
         assertEquals("addedWorkItem", wi.getName());
     }
 
-    @BZ("807187")
+    @Ignore("BZ-807187")
     @Test(timeout = 30000)
     public void testAdHocSubprocess() {
         KieSession kieSession = createKSession(ADHOC);
@@ -173,7 +173,7 @@ public class AdHocSubProcessTest extends JbpmTestCase {
         assertProcessCompleted(eventListener, ADHOC_AUTOCOMPLETE_ID);
     }
 
-    @BZ("808070")
+    @Ignore("BZ-808070")
     @Test(timeout = 30000)
     public void testAdHocSubProcessAutoComplete2() {
         KieSession kieSession = createKSession(ADHOC_AUTOCOMPLETE2);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/CallActivitiesWithUserTasksProcessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/CallActivitiesWithUserTasksProcessTest.java
@@ -41,7 +41,8 @@ import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
 import org.kie.internal.task.api.InternalTaskService;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 
 @RunWith(Parameterized.class)

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/CallActivityWithReadOnlyProcessInstanceTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/CallActivityWithReadOnlyProcessInstanceTest.java
@@ -37,7 +37,8 @@ import org.kie.api.task.TaskService;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(Parameterized.class)
 public class CallActivityWithReadOnlyProcessInstanceTest extends JbpmTestCase {

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/EmbeddedSubProcessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/EmbeddedSubProcessTest.java
@@ -22,7 +22,11 @@ import org.junit.Test;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.KieSession;
 
-import static org.jbpm.test.tools.IterableListenerAssert.*;
+import static org.jbpm.test.tools.IterableListenerAssert.assertLeft;
+import static org.jbpm.test.tools.IterableListenerAssert.assertNextNode;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessCompleted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessStarted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertTriggered;
 
 public class EmbeddedSubProcessTest extends JbpmTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/HumanTaskEventSubprocessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/HumanTaskEventSubprocessTest.java
@@ -28,7 +28,7 @@ import org.kie.api.task.model.TaskSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class HumanTaskEventSubprocessTest extends JbpmTestCase {
 	

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/MultipleInstancesSubProcessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/MultipleInstancesSubProcessTest.java
@@ -27,9 +27,14 @@ import org.jbpm.test.listener.IterableProcessEventListener;
 import org.junit.Test;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.KieSession;
-import qa.tools.ikeeper.annotation.BZ;
 
-import static org.jbpm.test.tools.IterableListenerAssert.*;
+import static org.jbpm.test.tools.IterableListenerAssert.assertChangedMultipleInstancesVariable;
+import static org.jbpm.test.tools.IterableListenerAssert.assertChangedVariable;
+import static org.jbpm.test.tools.IterableListenerAssert.assertLeft;
+import static org.jbpm.test.tools.IterableListenerAssert.assertNextNode;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessCompleted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessStarted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertTriggered;
 
 public class MultipleInstancesSubProcessTest extends JbpmTestCase {
 
@@ -42,7 +47,6 @@ public class MultipleInstancesSubProcessTest extends JbpmTestCase {
         super(false);
     }
 
-    @BZ("802721")
     @Test(timeout = 30000)
     public void testMultipleInstances() {
         KieSession kieSession = createKSession(MULTIPLE_INSTANCES);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/SubprocessesTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/subprocess/SubprocessesTest.java
@@ -31,8 +31,13 @@ import org.kie.api.command.Command;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
 
-import static org.jbpm.test.tools.IterableListenerAssert.*;
-import static org.junit.Assert.*;
+import static org.jbpm.test.tools.IterableListenerAssert.assertChangedVariable;
+import static org.jbpm.test.tools.IterableListenerAssert.assertLeft;
+import static org.jbpm.test.tools.IterableListenerAssert.assertNextNode;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessCompleted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessStarted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertTriggered;
+import static org.junit.Assert.assertTrue;
 
 public class SubprocessesTest extends JbpmTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/AdminAPIsWithListenerTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/AdminAPIsWithListenerTest.java
@@ -49,7 +49,9 @@ import org.kie.internal.task.api.UserInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 public class AdminAPIsWithListenerTest extends JbpmTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ConcurrentHumanTaskTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ConcurrentHumanTaskTest.java
@@ -57,7 +57,7 @@ import org.kie.internal.task.api.InternalTaskService;
 import org.kie.internal.task.api.TaskModelProvider;
 import org.kie.internal.task.api.UserGroupCallback;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class ConcurrentHumanTaskTest extends JbpmTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/HumanTaskQueryFilterTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/HumanTaskQueryFilterTest.java
@@ -30,7 +30,6 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.query.QueryFilter;
 import org.kie.internal.task.api.InternalTaskService;
-import qa.tools.ikeeper.annotation.BZ;
 
 public class HumanTaskQueryFilterTest extends JbpmTestCase {
 
@@ -124,7 +123,6 @@ public class HumanTaskQueryFilterTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1132157")
     public void testFilterParams() {
         startHumanTaskProcess(10, "john's task", "john");
         Map<String, Object> parameters = new HashMap<String, Object>();

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/HumanTaskReassignmentTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/HumanTaskReassignmentTest.java
@@ -16,7 +16,6 @@
 
 package org.jbpm.test.functional.task;
 
-
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -36,7 +35,9 @@ import org.kie.api.task.TaskService;
 import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.Task;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 public class HumanTaskReassignmentTest extends JbpmTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/HumanTaskVariablesAccessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/HumanTaskVariablesAccessTest.java
@@ -33,7 +33,9 @@ import org.kie.api.task.model.TaskSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class HumanTaskVariablesAccessTest extends JbpmTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/LocalTaskServiceTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/LocalTaskServiceTest.java
@@ -25,7 +25,6 @@ import org.jbpm.services.task.identity.JBossUserGroupCallbackImpl;
 import org.jbpm.services.task.utils.ContentMarshallerHelper;
 import org.jbpm.services.task.wih.util.LocalHTWorkItemHandlerUtil;
 import org.jbpm.test.JbpmTestCase;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
@@ -36,7 +35,9 @@ import org.kie.api.task.model.Content;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.logger.KnowledgeRuntimeLoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class LocalTaskServiceTest extends JbpmTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/MultipleRuntimeManagerTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/MultipleRuntimeManagerTest.java
@@ -37,7 +37,7 @@ import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.task.api.UserGroupCallback;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class MultipleRuntimeManagerTest extends JbpmTestCase  {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ProcessPersistenceHumanTaskOnLaneTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ProcessPersistenceHumanTaskOnLaneTest.java
@@ -36,7 +36,9 @@ import org.kie.internal.task.api.EventService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This is a sample file to test a process.

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ProcessPersistenceHumanTaskTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ProcessPersistenceHumanTaskTest.java
@@ -31,7 +31,9 @@ import org.kie.api.task.model.TaskSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This is a sample file to test a process.

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/RuleTaskTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/RuleTaskTest.java
@@ -30,7 +30,6 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkflowProcessInstance;
 import org.kie.internal.command.CommandFactory;
-import qa.tools.ikeeper.annotation.BZ;
 
 import static org.jbpm.test.tools.IterableListenerAssert.assertNextNode;
 import static org.jbpm.test.tools.IterableListenerAssert.assertProcessCompleted;
@@ -123,7 +122,6 @@ public class RuleTaskTest extends JbpmTestCase {
         }
     }
 
-    @BZ("1044504")
     @Test(timeout = 30000)
     public void testRuleTask2() {
         Map<String, ResourceType> res = new HashMap<String, ResourceType>();

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ScriptTaskTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ScriptTaskTest.java
@@ -16,14 +16,6 @@
 
 package org.jbpm.test.functional.task;
 
-import static org.jbpm.test.tools.IterableListenerAssert.assertChangedVariable;
-import static org.jbpm.test.tools.IterableListenerAssert.assertLeft;
-import static org.jbpm.test.tools.IterableListenerAssert.assertMultipleVariablesChanged;
-import static org.jbpm.test.tools.IterableListenerAssert.assertNextNode;
-import static org.jbpm.test.tools.IterableListenerAssert.assertProcessCompleted;
-import static org.jbpm.test.tools.IterableListenerAssert.assertProcessStarted;
-import static org.jbpm.test.tools.IterableListenerAssert.assertTriggered;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -35,6 +27,14 @@ import org.jbpm.test.listener.IterableProcessEventListener;
 import org.junit.Test;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.KieSession;
+
+import static org.jbpm.test.tools.IterableListenerAssert.assertChangedVariable;
+import static org.jbpm.test.tools.IterableListenerAssert.assertLeft;
+import static org.jbpm.test.tools.IterableListenerAssert.assertMultipleVariablesChanged;
+import static org.jbpm.test.tools.IterableListenerAssert.assertNextNode;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessCompleted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertProcessStarted;
+import static org.jbpm.test.tools.IterableListenerAssert.assertTriggered;
 
 /**
  * Testing script task - both Java and MVEL language.

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ScriptTaskWithDependencyTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ScriptTaskWithDependencyTest.java
@@ -16,8 +16,6 @@
 
 package org.jbpm.test.functional.task;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
@@ -29,35 +27,25 @@ import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.jbpm.kie.test.util.AbstractKieServicesBaseTest;
 import org.jbpm.process.instance.event.DefaultSignalManagerFactory;
 import org.jbpm.process.instance.impl.DefaultProcessInstanceManagerFactory;
-import org.jbpm.test.JbpmTestCase;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
-import org.kie.api.builder.KieBuilder;
-import org.kie.api.builder.KieFileSystem;
-import org.kie.api.builder.Message;
 import org.kie.api.builder.ReleaseId;
-import org.kie.api.builder.model.KieBaseModel;
-import org.kie.api.builder.model.KieModuleModel;
-import org.kie.api.builder.model.KieSessionModel;
-import org.kie.api.conf.EqualityBehaviorOption;
-import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
-import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.manager.RuntimeEnvironment;
 import org.kie.api.runtime.manager.RuntimeEnvironmentBuilder;
 import org.kie.api.runtime.manager.RuntimeManager;
 import org.kie.api.runtime.manager.RuntimeManagerFactory;
 import org.kie.api.runtime.process.ProcessInstance;
-import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.runtime.manager.context.EmptyContext;
 import org.kie.scanner.KieMavenRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Testing script task - both Java and MVEL language.

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/ExceptionAfterTimerNodeTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/ExceptionAfterTimerNodeTest.java
@@ -31,7 +31,8 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.process.ProcessInstance;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 @RunWith(Parameterized.class)
 public class ExceptionAfterTimerNodeTest extends JbpmTestCase {

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/GlobalThreadPoolTimerServiceTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/GlobalThreadPoolTimerServiceTest.java
@@ -47,7 +47,9 @@ import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.runtime.manager.SessionNotFoundException;
 import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class GlobalThreadPoolTimerServiceTest extends GlobalTimerServiceBaseTest {

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/GlobalTimerServiceVolumeTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/GlobalTimerServiceVolumeTest.java
@@ -16,7 +16,6 @@
 
 package org.jbpm.test.functional.timer;
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -75,7 +74,8 @@ import org.kie.internal.task.api.model.InternalOrganizationalEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(Parameterized.class)
 public class GlobalTimerServiceVolumeTest extends TimerBaseTest {

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/InMemoryTimerPersistenceTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/InMemoryTimerPersistenceTest.java
@@ -16,9 +16,6 @@
 
 package org.jbpm.test.functional.timer;
 
-import static org.jbpm.test.JbpmJUnitBaseTestCase.processStateName;
-import static org.junit.Assert.*;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,6 +28,10 @@ import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * See JBPM-3170/JBPM-3391

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/MultipleTimerServicesTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/MultipleTimerServicesTest.java
@@ -18,8 +18,6 @@ package org.jbpm.test.functional.timer;
 
 import java.io.File;
 import java.io.FilenameFilter;
-import java.io.IOException;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -52,7 +50,9 @@ import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This test is dedicated to quartz scheduler service as it is controlled

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/SerializedTimerRollbackTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/SerializedTimerRollbackTest.java
@@ -30,6 +30,7 @@ import javax.naming.InitialContext;
 import javax.persistence.EntityManager;
 import javax.transaction.TransactionManager;
 import javax.transaction.UserTransaction;
+
 import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.marshalling.impl.MarshallingConfigurationImpl;
 import org.drools.serialization.protobuf.ProtobufMarshaller;

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/TimerPersistenceTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/TimerPersistenceTest.java
@@ -16,10 +16,6 @@
 
 package org.jbpm.test.functional.timer;
 
-import static org.jbpm.test.JbpmJUnitBaseTestCase.processStateName;
-import static org.junit.Assert.*;
-import static org.kie.api.runtime.EnvironmentName.ENTITY_MANAGER_FACTORY;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,6 +33,13 @@ import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.kie.api.runtime.EnvironmentName.ENTITY_MANAGER_FACTORY;
 
 /**
  * See JBPM-3170/JBPM-3391

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/workitem/RetrySyncWorkItemByJPATest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/workitem/RetrySyncWorkItemByJPATest.java
@@ -31,7 +31,7 @@ import org.kie.api.task.TaskService;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.runtime.manager.context.EmptyContext;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class RetrySyncWorkItemByJPATest extends JbpmTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/workitem/WorkitemAssignmentTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/workitem/WorkitemAssignmentTest.java
@@ -15,24 +15,25 @@
  */
 package org.jbpm.test.functional.workitem;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 
 import org.drools.core.process.instance.WorkItemManager;
 import org.jbpm.test.JbpmTestCase;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
-import org.kie.api.runtime.process.ProcessInstance;
-import org.kie.api.runtime.process.WorkflowProcessInstance;
 import org.kie.api.runtime.manager.audit.AuditService;
 import org.kie.api.runtime.manager.audit.VariableInstanceLog;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.api.runtime.process.WorkflowProcessInstance;
 import org.kie.api.task.TaskService;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.runtime.manager.context.EmptyContext;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class WorkitemAssignmentTest extends JbpmTestCase {
     public WorkitemAssignmentTest() {

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/BusinessCalendarTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/BusinessCalendarTest.java
@@ -33,9 +33,7 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.task.TaskService;
 import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.Task;
-import qa.tools.ikeeper.annotation.BZ;
 
-@BZ("958384")
 public class BusinessCalendarTest extends JbpmTestCase {
 
     private static final String TIMER = "org/jbpm/test/regression/BusinessCalendar-timer.bpmn2";

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/GatewayTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/GatewayTest.java
@@ -18,6 +18,7 @@ package org.jbpm.test.regression;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
@@ -28,7 +29,6 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import qa.tools.ikeeper.annotation.BZ;
 
 public class GatewayTest extends JbpmTestCase {
 
@@ -39,7 +39,6 @@ public class GatewayTest extends JbpmTestCase {
     private static final String XPATH_EVALUATION_ID = "org.jbpm.test.regression.Gateway-xPathEvaluation";
 
     @Test
-    @BZ("1146829")
     public void testInclusiveGatewayDefaultGate() {
         KieSession ksession = createKSession(INCLUSIVE_DEFAULT);
         Map<String, Object> params = new HashMap<String, Object>();
@@ -49,7 +48,6 @@ public class GatewayTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1071000")
     public void testExclusiveSplitXPathAdvanced() throws Exception {
         KieSession ksession = createKSession(XPATH_EVALUATION);
         ksession.getWorkItemManager().registerWorkItemHandler("Email", new SystemOutWorkItemHandler());

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/ParallelAsyncJobsTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/ParallelAsyncJobsTest.java
@@ -28,17 +28,15 @@ import org.assertj.core.api.Assertions;
 import org.jbpm.executor.AsynchronousJobEvent;
 import org.jbpm.executor.impl.ExecutorServiceImpl;
 import org.jbpm.executor.impl.wih.AsyncWorkItemHandler;
+import org.jbpm.test.JbpmAsyncJobTestCase;
 import org.jbpm.test.listener.CountDownAsyncJobListener;
 import org.jbpm.test.persistence.util.PersistenceUtil;
-import org.jbpm.test.JbpmAsyncJobTestCase;
-import org.kie.test.util.db.PoolingDataSourceWrapper;
 import org.junit.Test;
 import org.kie.api.executor.ExecutorService;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.query.QueryContext;
-
-import qa.tools.ikeeper.annotation.BZ;
+import org.kie.test.util.db.PoolingDataSourceWrapper;
 
 public class ParallelAsyncJobsTest extends JbpmAsyncJobTestCase {
 
@@ -62,7 +60,6 @@ public class ParallelAsyncJobsTest extends JbpmAsyncJobTestCase {
      * the 4 seconds so pending task count should not be lower than 3 if parallelism does not work.
      */
     @Test(timeout=30000)
-    @BZ("1146829")
     public void testRunBasicAsync() throws Exception {
         ExecutorService executorService = getExecutorService();
         final Set<String> threadExeuctingJobs = new HashSet<>();

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/ProcessInstanceTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/ProcessInstanceTest.java
@@ -19,6 +19,7 @@ package org.jbpm.test.regression;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.persistence.EntityManager;
 
 import org.assertj.core.api.Assertions;
@@ -38,7 +39,6 @@ import org.kie.api.runtime.manager.RuntimeEnvironmentBuilder;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
-import qa.tools.ikeeper.annotation.BZ;
 
 public class ProcessInstanceTest extends JbpmTestCase {
 
@@ -51,7 +51,6 @@ public class ProcessInstanceTest extends JbpmTestCase {
             "org.jbpm.test.regression.ProcessInstance-variablePersistence";
 
     @Test
-    @BZ("949973")
     public void testProcessEquals() throws Exception {
         KieSession ksession = createKSession(EQUALS);
         ProcessInstance pi = ksession.startProcess(EQUALS_ID);
@@ -59,7 +58,6 @@ public class ProcessInstanceTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1062346")
     public void testJPAStrategy() {
         RuntimeEnvironment environment = RuntimeEnvironmentBuilder.Factory.get().newDefaultBuilder()
                 .entityManagerFactory(getEmf())

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/RuleTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/RuleTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import org.kie.api.command.Command;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
-import qa.tools.ikeeper.annotation.BZ;
 
 public class RuleTest extends JbpmTestCase {
 
@@ -39,7 +38,6 @@ public class RuleTest extends JbpmTestCase {
     private static final String ON_ENTRY_EVENT_DRL = "org/jbpm/test/regression/Rule-onEntryEvent.drl";
 
     @Test
-    @BZ("852095")
     public void testNoOnEntryEvent() {
         Map<String, ResourceType> res = new HashMap<String, ResourceType>();
         res.put(ON_ENTRY_EVENT, ResourceType.BPMN2);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/SessionIsolationTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/SessionIsolationTest.java
@@ -27,9 +27,7 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
-import qa.tools.ikeeper.annotation.BZ;
 
-@BZ("852738")
 public class SessionIsolationTest extends JbpmTestCase {
 
     private static final String SIGNAL = "org/jbpm/test/regression/SessionIsolation-signal.bpmn";

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/async/AsyncWIHOnOracleTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/async/AsyncWIHOnOracleTest.java
@@ -19,9 +19,9 @@ package org.jbpm.test.regression.async;
 import org.assertj.core.api.Assertions;
 import org.jbpm.executor.impl.wih.AsyncWorkItemHandler;
 import org.jbpm.persistence.jpa.hibernate.DisabledFollowOnLockOracle10gDialect;
-import org.jbpm.test.persistence.util.PersistenceUtil;
 import org.jbpm.test.JbpmAsyncJobTestCase;
 import org.jbpm.test.listener.TrackingProcessEventListener;
+import org.jbpm.test.persistence.util.PersistenceUtil;
 import org.junit.After;
 import org.junit.Test;
 import org.kie.api.executor.Command;
@@ -29,7 +29,6 @@ import org.kie.api.executor.CommandContext;
 import org.kie.api.executor.ExecutionResults;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.WorkItemHandler;
-import qa.tools.ikeeper.annotation.BZ;
 
 public class AsyncWIHOnOracleTest extends JbpmAsyncJobTestCase {
 
@@ -56,7 +55,6 @@ public class AsyncWIHOnOracleTest extends JbpmAsyncJobTestCase {
     }
 
     @Test
-    @BZ("1234592")
     public void testAsyncWIHExecutedMoreThanOnceOnOracle() throws Exception {
         KieSession ksession = createKSession(PROCESS);
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/event/BoundaryErrorEventTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/event/BoundaryErrorEventTest.java
@@ -30,11 +30,9 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
-import qa.tools.ikeeper.annotation.BZ;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
-@BZ("1175689")
 @RunWith(Parameterized.class)
 public class BoundaryErrorEventTest extends JbpmTestCase {
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/event/MessageEventTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/event/MessageEventTest.java
@@ -20,7 +20,6 @@ import org.jbpm.test.JbpmTestCase;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
-import qa.tools.ikeeper.annotation.BZ;
 
 public class MessageEventTest extends JbpmTestCase {
 
@@ -35,7 +34,6 @@ public class MessageEventTest extends JbpmTestCase {
             "org.jbpm.test.regression.event.MessageEvent-multipleSubprocess";
 
     @Test
-    @BZ("1163864")
     public void testMultipleIntermediateMessageEventsSimpleProcess() {
         KieSession ksession = createKSession(MULTIPLE_SIMPLE);
         ProcessInstance pi = ksession.startProcess(MULTIPLE_SIMPLE_ID);
@@ -46,7 +44,6 @@ public class MessageEventTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1163864")
     public void testMultipleIntermediateMessageEventsEmbeddedSubProcess() {
         KieSession ksession = createKSession(MULTIPLE_SUBPROCESS);
         ProcessInstance pi = ksession.startProcess(MULTIPLE_SUBPROCESS_ID);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/event/StartEventTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/event/StartEventTest.java
@@ -29,7 +29,6 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.audit.VariableInstanceLog;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkflowProcessInstance;
-import qa.tools.ikeeper.annotation.BZ;
 
 public class StartEventTest extends JbpmTestCase {
 
@@ -50,7 +49,6 @@ public class StartEventTest extends JbpmTestCase {
             "org/jbpm/test/regression/event/StartEvent-signalOutputType.bpmn2";
 
     @Test
-    @BZ("1186015")
     public void testErrorStartEventDefaultExceptionHandler() {
         KieSession ksession = createKSession(ERROR_EXCEPTION_HANDLER);
         ProcessInstance pi = ksession.startProcess(ERROR_EXCEPTION_HANDLER_ID);
@@ -63,7 +61,6 @@ public class StartEventTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1186016")
     public void testErrorStartEventDataOutputMapping() {
         KieSession ksession = createKSession(ERROR_EXCEPTION_MAPPING);
         ProcessInstance pi = ksession.startProcess(ERROR_EXCEPTION_MAPPING_ID);
@@ -76,7 +73,6 @@ public class StartEventTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1154557")
     public void testSignalStartEventDataMapping() throws Exception {
         KieSession ksession = createKSession(SIGNAL_DATA_MAPPING);
         final List<Long> list = new ArrayList<Long>();
@@ -93,7 +89,6 @@ public class StartEventTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1090375")
     public void testSignalOutputType() throws Exception {
         KieSession ksession = createKSession(SIGNAL_OUTPUT_TYPE);
         SignalObjectReport report = new SignalObjectReport("Type of signal object report");

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/event/TimerEventTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/event/TimerEventTest.java
@@ -34,7 +34,6 @@ import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.api.task.TaskService;
 import org.kie.api.task.model.Task;
-import qa.tools.ikeeper.annotation.BZ;
 
 public class TimerEventTest extends JbpmTestCase {
 
@@ -56,7 +55,6 @@ public class TimerEventTest extends JbpmTestCase {
             "org.jbpm.test.regression.event.TimerEvent-boundaryMultipleInstances";
 
     @Test
-    @BZ({"958390", "1167738"})
     public void testRuntimeExceptionAfterTimer() throws InterruptedException {
         KieSession ksession = createKSession(EXCEPTION_AFTER_TIMER);
         ProcessInstance pi = ksession.startProcess(EXCEPTION_AFTER_TIMER_ID);
@@ -69,7 +67,6 @@ public class TimerEventTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1104563")
     public void testStartTimerCycle() throws InterruptedException {
         createKSession(START_TIMER_CYCLE); //this starts already the timer
         AuditService auditService = getLogService();
@@ -85,7 +82,6 @@ public class TimerEventTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1148304")
     public void testCancelledTimerNotScheduled() {
         for (int i = 0; i < 5; i++) {
             createRuntimeManager(Strategy.PROCESS_INSTANCE, (String) null, CANCELLED_TIMER);
@@ -114,7 +110,6 @@ public class TimerEventTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1036761")
     public void testTimerAndGateway() throws Exception {
         KieSession ksession = createKSession(TIMER_AND_GATEWAY);
         int sessionId = ksession.getId();
@@ -151,7 +146,6 @@ public class TimerEventTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1213209")
     public void testBoundaryTimerInMultipleInstancesSubprocess() throws InterruptedException {
         KieSession ksession = createKSession(BOUNDARY_MULTIPLE_INSTANCES);
         ksession.setGlobal("counter", 0);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/subprocess/AdHocSubprocessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/subprocess/AdHocSubprocessTest.java
@@ -19,7 +19,6 @@ package org.jbpm.test.regression.subprocess;
 import org.assertj.core.api.Assertions;
 import org.jbpm.test.JbpmTestCase;
 import org.junit.Test;
-import qa.tools.ikeeper.annotation.BZ;
 
 public class AdHocSubprocessTest extends JbpmTestCase {
 
@@ -27,7 +26,6 @@ public class AdHocSubprocessTest extends JbpmTestCase {
             "org/jbpm/test/regression/subprocess/AdHocSubprocess-emptyCompletionCondition.bpmn2";
 
     @Test
-    @BZ("1170281")
     public void testEmptyCompletionCondition() {
         try {
             createKSession(EMPTY_COMPLETION_CONDITION);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/subprocess/EmbeddedSubprocessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/subprocess/EmbeddedSubprocessTest.java
@@ -25,12 +25,12 @@ import org.assertj.core.api.Assertions;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.jbpm.test.JbpmTestCase;
 import org.jbpm.test.listener.TrackingProcessEventListener;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.audit.VariableInstanceLog;
 import org.kie.api.runtime.process.ProcessInstance;
-import qa.tools.ikeeper.annotation.BZ;
 
 public class EmbeddedSubprocessTest extends JbpmTestCase {
 
@@ -51,7 +51,7 @@ public class EmbeddedSubprocessTest extends JbpmTestCase {
             "org.jbpm.test.regression.subprocess.EmbeddedSubprocess-taskCompensation";
 
     @Test
-    @BZ("1139591")
+    @Ignore("BZ-1139591")
     public void testInvalidSubprocess() {
         try {
             createKSession(INVALID_SUBPROCESS);
@@ -62,7 +62,6 @@ public class EmbeddedSubprocessTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1150226")
     public void testInvalidSubprocess2() {
         try {
             createKSession(INVALID_SUBPROCESS2);
@@ -74,7 +73,6 @@ public class EmbeddedSubprocessTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("851286")
     public void testTerminatingEndEvent() {
         KieSession ksession = createKSession(TERMINATING_END_EVENT);
         TrackingProcessEventListener processEvents = new TrackingProcessEventListener();
@@ -87,7 +85,6 @@ public class EmbeddedSubprocessTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1191768")
     public void testTaskCompensation() throws Exception {
         KieSession kieSession = createKSession(TASK_COMPENSATION);
         kieSession.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/subprocess/EventSubprocessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/subprocess/EventSubprocessTest.java
@@ -28,9 +28,8 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
-import qa.tools.ikeeper.annotation.BZ;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 public class EventSubprocessTest extends JbpmTestCase {
 
@@ -40,7 +39,6 @@ public class EventSubprocessTest extends JbpmTestCase {
             "org.jbpm.test.regression.subprocess.EventSubprocess-errorCodeException";
 
     @Test
-    @BZ("1082111")
     public void testErrorCodeException() {
         KieSession ksession = createKSession(ERROR_CODE_EXCEPTION);
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/subprocess/MultipleInstancesSubprocessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/subprocess/MultipleInstancesSubprocessTest.java
@@ -31,9 +31,7 @@ import org.kie.api.runtime.manager.audit.ProcessInstanceLog;
 import org.kie.api.runtime.manager.audit.VariableInstanceLog;
 import org.kie.api.runtime.process.ProcessInstance;
 
-import qa.tools.ikeeper.annotation.BZ;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 public class MultipleInstancesSubprocessTest extends JbpmTestCase {
 
@@ -56,7 +54,6 @@ public class MultipleInstancesSubprocessTest extends JbpmTestCase {
             "org.jbpm.test.regression.subprocess.MultipleInstancesSubprocess-entryAndExitScript-subprocess";
 
     @Test
-    @BZ("958390")
     public void testTimerEvent() throws Exception {
         KieSession ksession = createKSession(TIMER_EVENT_PARENT, TIMER_EVENT_SUBPROCESS1, TIMER_EVENT_SUBPROCESS2);
         TrackingProcessEventListener processEvents = new TrackingProcessEventListener();
@@ -84,7 +81,6 @@ public class MultipleInstancesSubprocessTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1123789")
     public void testEntryAndExitScript() {
         createRuntimeManager(ENTRY_AND_EXIT_SCRIPT_PARENT, ENTRY_AND_EXIT_SCRIPT_SUBPROCESS);
         KieSession ksession = getRuntimeEngine().getKieSession();

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/subprocess/ReusableSubprocessTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/subprocess/ReusableSubprocessTest.java
@@ -28,7 +28,6 @@ import org.kie.api.runtime.manager.audit.AuditService;
 import org.kie.api.runtime.manager.audit.ProcessInstanceLog;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
-import qa.tools.ikeeper.annotation.BZ;
 
 public class ReusableSubprocessTest extends JbpmTestCase {
 
@@ -49,7 +48,6 @@ public class ReusableSubprocessTest extends JbpmTestCase {
             "org.jbpm.test.regression.subprocess.ReusableSubprocess-dependentSubprocessAbort-subprocess";
 
     @Test
-    @BZ("1194180")
     public void testWaitForCompletionFalse() throws Exception {
         createRuntimeManager(Strategy.PROCESS_INSTANCE, "BZ1194180-ppi-manager", WAIT_FOR_COMPLETION_FALSE_PARENT,
                 WAIT_FOR_COMPLETION_FALSE_SUBPROCESS);
@@ -61,7 +59,6 @@ public class ReusableSubprocessTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1128597")
     public void testDependentSubprocessAbort() {
         RuntimeManager manager = createRuntimeManager(Strategy.PROCESS_INSTANCE, "myPpiManager",
                 DEPENDENT_SUBPROCESS_ABORT_PARENT, DEPENDENT_SUBPROCESS_ABORT_SUBPROCESS);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/task/HumanTaskAssignmentTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/task/HumanTaskAssignmentTest.java
@@ -28,7 +28,6 @@ import org.kie.api.task.model.Status;
 import org.kie.api.task.model.Task;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.task.api.InternalTaskService;
-import qa.tools.ikeeper.annotation.BZ;
 
 public class HumanTaskAssignmentTest extends JbpmTestCase {
 
@@ -43,7 +42,6 @@ public class HumanTaskAssignmentTest extends JbpmTestCase {
             "org.jbpm.test.regression.task.HumanTaskAssignment-getTasksOwnerUser";
 
     @Test
-    @BZ("1103977")
     public void testGetTasksAssignedAsPotentialOwnerGroup() {
         createRuntimeManager(GET_TASKS_OWNER_GROUP);
         KieSession ksession = getRuntimeEngine().getKieSession();
@@ -78,7 +76,6 @@ public class HumanTaskAssignmentTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1178153")
     public void testGetTasksAssignedAsPotentialOwnerUser() {
         createRuntimeManager(GET_TASKS_OWNER_USER);
         KieSession ksession = getRuntimeEngine().getKieSession();

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/task/HumanTaskCleanUpEarlyFlushTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/task/HumanTaskCleanUpEarlyFlushTest.java
@@ -27,9 +27,8 @@ import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.task.TaskService;
 import org.kie.api.task.model.TaskSummary;
-import qa.tools.ikeeper.annotation.BZ;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class HumanTaskCleanUpEarlyFlushTest extends JbpmTestCase {
 
@@ -50,7 +49,6 @@ public class HumanTaskCleanUpEarlyFlushTest extends JbpmTestCase {
             "org/jbpm/test/regression/task/HumanTaskCleanUpEarlyFlush-signal-receiver.bpmn2";
 
     @Test
-    @BZ({"1128377", "1177736"})
     public void testSubprocess() {
         createRuntimeManager(SUBPROCESS_PARENT, SUBPROCESS_CHILD1, SUBPROCESS_CHILD2);
 
@@ -86,19 +84,16 @@ public class HumanTaskCleanUpEarlyFlushTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1165466")
     public void testSignalSingleton() {
         testSignal(JbpmJUnitBaseTestCase.Strategy.SINGLETON);
     }
 
     @Test
-    @BZ("1165466")
     public void testSignalPerRequest() {
         testSignal(JbpmJUnitBaseTestCase.Strategy.REQUEST);
     }
 
     @Test
-    @BZ("1165466")
     public void testSignalPerProcessInstance() {
         testSignal(JbpmJUnitBaseTestCase.Strategy.PROCESS_INSTANCE);
     }

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/task/HumanTaskSwimlaneTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/task/HumanTaskSwimlaneTest.java
@@ -35,9 +35,9 @@ import org.kie.api.task.model.Status;
 import org.kie.api.task.model.Task;
 import org.kie.api.task.model.TaskSummary;
 
-import qa.tools.ikeeper.annotation.BZ;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class HumanTaskSwimlaneTest extends JbpmTestCase {
 
@@ -59,7 +59,6 @@ public class HumanTaskSwimlaneTest extends JbpmTestCase {
     private TaskService taskService;
 
     @Test
-    @BZ("997139")
     public void testSameGroups() {
         createRuntimeManager(SWIMLANE_SAME_GROUPS);
         KieSession ksession = getRuntimeEngine().getKieSession();
@@ -79,7 +78,6 @@ public class HumanTaskSwimlaneTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("997139")
     public void testDifferentGroups() {
         createRuntimeManager(SWIMLANE_DIFFERENT_GROUPS);
         KieSession ksession = getRuntimeEngine().getKieSession();

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/task/HumanTaskTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/task/HumanTaskTest.java
@@ -27,6 +27,7 @@ import org.assertj.core.api.Assertions;
 import org.jbpm.services.task.events.DefaultTaskEventListener;
 import org.jbpm.test.JbpmTestCase;
 import org.jbpm.test.listener.TrackingProcessEventListener;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
@@ -38,7 +39,6 @@ import org.kie.api.task.model.Status;
 import org.kie.api.task.model.Task;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.task.api.EventService;
-import qa.tools.ikeeper.annotation.BZ;
 
 import static java.util.Collections.emptyMap;
 import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggered;
@@ -73,7 +73,6 @@ public class HumanTaskTest extends JbpmTestCase {
     private static final String HUMAN_TASK_LISTENER_ID = "org.jbpm.test.regression.task.HumanTask-Listener";
 
     @Test
-    @BZ("958397")
     public void testBoundaryTimer() throws Exception {
         createRuntimeManager(BOUNDARY_TIMER);
         KieSession ksession = getRuntimeEngine().getKieSession();
@@ -101,7 +100,6 @@ public class HumanTaskTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1004681")
     public void testCompletionRollback() {
         createRuntimeManager(COMPLETION_ROLLBACK);
         TaskService taskService = getRuntimeEngine().getTaskService();
@@ -132,7 +130,6 @@ public class HumanTaskTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1120122")
     public void testOnEntryScriptException() {
         createRuntimeManager(ON_ENTRY_SCRIPT_EXCEPTION);
         KieSession ksession = getRuntimeEngine().getKieSession();
@@ -148,7 +145,6 @@ public class HumanTaskTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1120122")
     public void testOnExitScriptException() {
         createRuntimeManager(ON_EXIT_SCRIPT_EXCEPTION);
         KieSession ksession = getRuntimeEngine().getKieSession();
@@ -176,7 +172,6 @@ public class HumanTaskTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1145046")
     public void testAbortWorkItemTaskStatus() {
         for (int i = 0; i < 5; i++) {
             createRuntimeManager(Strategy.PROCESS_INSTANCE, "abortWorkItemTaskStatus" + i, ABORT_WORKITEM_TASK_STATUS);
@@ -197,7 +192,6 @@ public class HumanTaskTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1139496")
     public void testLocale() {
         KieSession ksession = createKSession(LOCALE);
 
@@ -218,7 +212,6 @@ public class HumanTaskTest extends JbpmTestCase {
     }
 
     @Test
-    @BZ("1081508")
     public void testInputTransformation() {
         KieSession ksession = createKSession(INPUT_TRANSFORMATION);
 


### PR DESCRIPTION
#1828 cherry-pick 

* JBPM-9542: Remove issue-keeper tool

Due to recent jira authentication changes we decided to stop using issue-keeper tool for preventing test method run. It was replaced by simple '@Ignore' junit annotations.

For more details see:
- https://issues.redhat.com/browse/JBPM-9542
- https://github.com/ibek/issue-keeper

* keep just non closed BZs

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1564
* https://github.com/kiegroup/kie-wb-distributions/pull/1081

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
