### PR TITLE
[JBPM-9452] ClassCastException fix

### DIFF
--- a/jbpm-flow/pom.xml
+++ b/jbpm-flow/pom.xml
@@ -203,6 +203,11 @@
       <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/jbpm-flow/src/test/java/org/jbpm/workflow/instance/node/RuleSetInstanceTest.java
+++ b/jbpm-flow/src/test/java/org/jbpm/workflow/instance/node/RuleSetInstanceTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.workflow.instance.node;
+
+
+import org.jbpm.process.core.context.variable.Variable;
+import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.process.core.datatype.DataType;
+import org.jbpm.process.core.datatype.impl.type.*;
+import org.jbpm.process.instance.context.variable.VariableScopeInstance;
+import org.jbpm.test.util.AbstractBaseTest;
+import org.jbpm.workflow.core.node.Assignment;
+import org.jbpm.workflow.core.node.DataAssociation;
+import org.jbpm.workflow.core.node.RuleSetNode;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(Parameterized.class)
+public class RuleSetInstanceTest extends AbstractBaseTest {
+	
+    public void addLogger() { 
+        logger = LoggerFactory.getLogger(this.getClass());
+    }
+
+    RuleSetNodeInstance ruleSetNodeInstance;
+    RuleSetNode mockRuleSetNode;
+    VariableScopeInstance variableScopeInstance;
+    VariableScope variableScope;
+
+    @Parameters( name = "{index}: Actual: <{0}> Expected: <{1}> Type: <{3}>" )
+    public static Collection<Object[]> data() {
+        String className = "org.jbpm.workflow.instance.node.RuleSetInstanceTest$MyDataObject";
+
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("message", "abc");
+        sourceMap.put("status", true);
+        sourceMap.put("code", 1);
+
+        MyDataObject targetDataObject = new MyDataObject("abc", true, 1);
+
+        return Arrays.asList(new Object[][] {
+                {"abc", "abc", new StringDataType(), "java.lang.String"},
+                {true, true, new BooleanDataType(), "java.lang.Boolean"},
+                {"true", true, new BooleanDataType(), "java.lang.Boolean"},
+                {123, 123, new IntegerDataType(), "java.lang.Integer"},
+                {"123", 123, new IntegerDataType(), "java.lang.Integer"},
+                {12.3, 12.3, new ObjectDataType(), "java.lang.Double"},
+                {"12.3", 12.3F, new FloatDataType(), "java.lang.Float"},
+                {sourceMap, targetDataObject, new ObjectDataType(className), className},
+        });
+    }
+
+    private final String sourceName;
+    private final String targetName;
+    private final Object sourceObject;
+    private final Object targetObject;
+    private final DataType variableDataType;
+    private final String targetDataType;
+
+    public RuleSetInstanceTest(Object sourceObject, Object targetObject, DataType variableDataType, String targetDataType) {
+        this.sourceName = "sourceName";
+        this.targetName = "targetName";
+        this.sourceObject = sourceObject;
+        this.targetObject = targetObject;
+        this.variableDataType = variableDataType;
+        this.targetDataType = targetDataType;
+    }
+
+    @Before
+    public void setup() {
+        ruleSetNodeInstance = spy(RuleSetNodeInstance.class);
+
+        mockRuleSetNode = mock(RuleSetNode.class);
+        doReturn(mockRuleSetNode).when(ruleSetNodeInstance).getRuleSetNode();
+
+        variableScopeInstance = mock(VariableScopeInstance.class);
+        doReturn(variableScopeInstance).when(ruleSetNodeInstance).resolveContextInstance(any(), any());
+    }
+    
+    @Test
+    public void testProcessOutputs() {
+        List<Assignment> assignments = new ArrayList<>();
+        DataAssociation dataAssociation = new DataAssociation(sourceName, targetName, assignments, null);
+        List<DataAssociation> dataAssociations = new ArrayList<>();
+        dataAssociations.add(dataAssociation);
+
+        doReturn(dataAssociations).when(mockRuleSetNode).getOutAssociations();
+
+        Variable variable = new Variable();
+        variable.setName(targetName);
+        variable.setType(variableDataType);
+        List<Variable> variables = new ArrayList<>();
+        variables.add(variable);
+
+        variableScope = new VariableScope();
+        variableScope.setVariables(variables);
+        doReturn(variableScope).when(variableScopeInstance).getVariableScope();
+
+        Map<String, Object> outputs = new HashMap<>();
+        outputs.put(sourceName, sourceObject);
+        ruleSetNodeInstance.processOutputs(outputs);
+
+        ArgumentCaptor<String> targetCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object> valueCaptor = ArgumentCaptor.forClass(Object.class);
+
+        verify(variableScopeInstance, times(1)).setVariable(targetCaptor.capture(), valueCaptor.capture());
+
+        assertThat(targetCaptor.getValue()).isEqualTo(targetName);
+        assertThat(valueCaptor.getValue().getClass().getTypeName()).isEqualTo(targetDataType);
+        assertThat(valueCaptor.getValue()).isEqualToComparingFieldByField(targetObject);
+    }
+
+    public static class MyDataObject {
+        private String message;
+        private Boolean status;
+        private Integer code;
+
+        public MyDataObject() {
+        }
+
+        public MyDataObject(String message, Boolean status, Integer code) {
+            this.message = message;
+            this.status = status;
+            this.code = code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+        public Boolean getStatus() {
+            return status;
+        }
+
+        public void setStatus(Boolean status) {
+            this.status = status;
+        }
+
+        public Integer getCode() {
+            return code;
+        }
+
+        public void setCode(Integer code) {
+            this.code = code;
+        }
+
+        @Override
+        public String toString() {
+            return "MyDataObject{" +
+                    "message='" + message + '\'' +
+                    ", status=" + status +
+                    ", code=" + code +
+                    '}';
+        }
+    }
+}


### PR DESCRIPTION
ClassCastException occurs when mapping DMN output to a Java Object in a BPMN

**Thank you for submitting this pull request**

**JIRA**: 

[JBPM-9452](https://issues.redhat.com/browse/JBPM-9452)

I created a minimal, reproducible example [here](https://github.com/Optum/kie-examples/tree/master/1) and verified this fixes the issue. I didn't see any unit tests for the `RuleSetNodeInstance` class so I wasn't sure what would be the best way to get an automated test in place for this. If you think we need one, I'd be happy to work on that and I'd appreciate some guidance to point me in the right direction.

**referenced Pull Requests**:

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
