### PR TITLE
[JBPM-9590] Lazy loading runtime engine can cause not unlock the kie session id during disposal

### DIFF
--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/RuntimeEngineImpl.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/RuntimeEngineImpl.java
@@ -186,13 +186,18 @@ public class RuntimeEngineImpl implements InternalRuntimeEngine, Disposable {
     public void setContext(Context<?> context) {
         this.context = context;
     }
+
     
+    public Long getLazyKieSessionId() {
+        return (initializer != null && initializer.getKieSessionId() != null) ? initializer.getKieSessionId() : this.kieSessionId;
+    }
+
     public Long getKieSessionId() {
         return kieSessionId;
     }
 
     @Override
     public String toString() {
-        return super.toString() + "(KieSessionId=" + kieSessionId + ")";
+        return super.toString() + "(KieSessionId=" + getLazyKieSessionId() + ")";
     }
 }

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/RuntimeEngineInitlializer.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/RuntimeEngineInitlializer.java
@@ -24,6 +24,10 @@ import org.kie.internal.runtime.manager.InternalRuntimeManager;
 
 public interface RuntimeEngineInitlializer {
 
+    default Long getKieSessionId() {
+        return null;
+    }
+
 	KieSession initKieSession(Context<?> context, InternalRuntimeManager manager, RuntimeEngine engine);
 	
 	TaskService initTaskService(Context<?> context, InternalRuntimeManager manager, RuntimeEngine engine);


### PR DESCRIPTION
Jira :https://issues.redhat.com/browse/JBPM-9590