### PR TITLE
[JBPM-9632] Intermediate Throw event signal stops processing workflow before signal is processed.

### DIFF
--- a/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/IntermediateThrowEventHandler.java
+++ b/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/IntermediateThrowEventHandler.java
@@ -187,6 +187,9 @@ public class IntermediateThrowEventHandler extends AbstractNodeHandler {
 			final String uri, final String localName,
 			final ExtensibleXmlParser parser) throws SAXException {
 		ActionNode actionNode = (ActionNode) node;
+		String executeActionAfterCompleteMetadata = (String) node.getMetaData().get("executeActionAfterComplete");
+		Boolean executeActionAfterComplete = executeActionAfterCompleteMetadata != null && Boolean.parseBoolean(executeActionAfterCompleteMetadata);
+		actionNode.setExecuteActionAfterComplete(executeActionAfterComplete);
 		org.w3c.dom.Node xmlNode = element.getFirstChild();
 		while (xmlNode != null) {
 			String nodeName = xmlNode.getNodeName();

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ActionNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ActionNode.java
@@ -32,12 +32,26 @@ public class ActionNode extends ExtendedNodeImpl {
 	
 	private DroolsAction action;
 
+    private boolean executeActionAfterComplete = false;
+
+    
+
+
     public ActionNode() {
         super(NodeType.SCRIPT_TASK);
     }
 
     public ActionNode(NodeType nodeType) {
         super(nodeType);
+    }
+
+    
+    public void setExecuteActionAfterComplete(boolean executeActionAfterComplete) {
+        this.executeActionAfterComplete = executeActionAfterComplete;
+    }
+
+    public boolean isExecuteActionAfterComplete() {
+        return executeActionAfterComplete;
     }
 
 	public DroolsAction getAction() {

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ActionNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ActionNodeInstance.java
@@ -31,6 +31,8 @@ public class ActionNodeInstance extends NodeInstanceImpl {
 
     private static final long serialVersionUID = 510l;
 
+
+
     protected ActionNode getActionNode() {
         return (ActionNode) getNode();
     }
@@ -40,20 +42,31 @@ public class ActionNodeInstance extends NodeInstanceImpl {
             throw new IllegalArgumentException(
                 "An ActionNode only accepts default incoming connections!");
         }
-		Action action = (Action) getActionNode().getAction().getMetaData("Action");
-		try {
-		    ProcessContext context = new ProcessContext(getProcessInstance().getKnowledgeRuntime());
-		    context.setNodeInstance(this);
-	        executeAction(action);
-		} catch( WorkflowRuntimeException wre) { 
-		    throw wre;
-		} catch (Exception e) {
-		    // for the case that one of the following throws an exception
-		    // - the ProcessContext() constructor 
-		    // - or context.setNodeInstance(this) 
-		    throw new WorkflowRuntimeException(this, getProcessInstance(), "Unable to execute Action: " + e.getMessage(), e);
-		} 
-    	triggerCompleted();
+        
+        if (!getActionNode().isExecuteActionAfterComplete()) {
+            executedAction();
+        }
+        triggerCompleted();
+
+        if (getActionNode().isExecuteActionAfterComplete()) {
+            executedAction();
+        }
+    }
+
+    private void executedAction () {
+        Action action = (Action) getActionNode().getAction().getMetaData("Action");
+        try {
+            ProcessContext context = new ProcessContext(getProcessInstance().getKnowledgeRuntime());
+            context.setNodeInstance(this);
+            executeAction(action);
+        } catch( WorkflowRuntimeException wre) { 
+            throw wre;
+        } catch (Exception e) {
+            // for the case that one of the following throws an exception
+            // - the ProcessContext() constructor 
+            // - or context.setNodeInstance(this) 
+            throw new WorkflowRuntimeException(this, getProcessInstance(), "Unable to execute Action: " + e.getMessage(), e);
+        } 
     }
 
     public void triggerCompleted() {

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/subprocess/IntermediateEventSubprocessCatchTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/subprocess/IntermediateEventSubprocessCatchTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.test.regression.subprocess;
+
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.jbpm.test.JbpmTestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.event.process.DefaultProcessEventListener;
+import org.kie.api.event.process.ProcessCompletedEvent;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.process.ProcessInstance;
+
+public class IntermediateEventSubprocessCatchTest extends JbpmTestCase {
+
+
+    private static final String INTERMEDIATE_CATCH_EVENT_SUBPROCESS_PROCESS = "org/jbpm/test/regression/subprocess/IntermediateEventSubprocessCatch.bpmn2";
+    private static final String INTERMEDIATE_CATCH_EVENT_SUBPROCESS_PROCESS_ID = "IntermediateEventSubprocessCatch";
+
+    private KieSession ksession;
+
+
+    @Before
+    public void init() throws Exception {
+        ksession = createKSession(INTERMEDIATE_CATCH_EVENT_SUBPROCESS_PROCESS);
+    }
+
+    @Test(timeout = 30000)
+    public void testIntermediateCatchEventSubprocess() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        ksession.addEventListener(new DefaultProcessEventListener() {
+            @Override
+            public void afterProcessCompleted(ProcessCompletedEvent event) {
+                latch.countDown();
+            }
+        });
+        ProcessInstance pi = ksession.startProcess(INTERMEDIATE_CATCH_EVENT_SUBPROCESS_PROCESS_ID, Collections.singletonMap("id", "1"));
+        latch.await(5000L, TimeUnit.MILLISECONDS);
+        this.assertProcessInstanceCompleted(pi.getId());
+    }
+
+}

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/regression/subprocess/IntermediateEventSubprocessCatch.bpmn2
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/regression/subprocess/IntermediateEventSubprocessCatch.bpmn2
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_E110wHdGEeuwCP4PHJc9Og" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_idItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_sub2idItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__991EBFB2-37F0-4B89-B11F-2BAC4ACACD6F_s2idOutputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_subidItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__0C5E6DE6-9268-4030-88A2-BC09F72766F7_sub2idInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FEB5FE24-82D7-49F1-9BD7-8617F85CB709_sidOutputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__6C8896A2-1855-4523-A19D-AE80BCDD42DF_subidInputXItem" structureRef="String"/>
+  <bpmn2:signal id="_7f0847e9-fc8c-396f-b622-6bf0d0e2e537" name="start_sub2"/>
+  <bpmn2:signal id="_60e36f59-a9dc-3904-b56b-f057c402f020" name="end_sub2"/>
+  <bpmn2:signal id="_7f0847e9-fc8c-396f-b622-6bf0d0e2e537" name="start_sub2"/>
+  <bpmn2:signal id="_8d5234bb-55a3-3bd9-ab4b-d4ea2123ecf9" name="end_sub1"/>
+  <bpmn2:signal id="_b79be69d-4df1-398c-ac01-70868d3665d7" name="start_sub1"/>
+  <bpmn2:signal id="_60e36f59-a9dc-3904-b56b-f057c402f020" name="end_sub2"/>
+  <bpmn2:signal id="_b79be69d-4df1-398c-ac01-70868d3665d7" name="start_sub1"/>
+  <bpmn2:signal id="_8d5234bb-55a3-3bd9-ab4b-d4ea2123ecf9" name="end_sub1"/>
+  <bpmn2:process id="IntermediateEventSubprocessCatch" drools:packageName="com.redhat" drools:version="1.0" drools:adHoc="false" name="main" isExecutable="true" processType="Public">
+    <bpmn2:property id="id" itemSubjectRef="_idItem" name="id"/>
+    <bpmn2:sequenceFlow id="_A570F321-92E4-4B45-8818-67A5A0F2F246" sourceRef="_B275D0A1-07EC-4A08-98F4-8ECEAD1BF631" targetRef="_AB7D2F8D-BF51-4508-9D65-50BFB8DA5BAB"/>
+    <bpmn2:sequenceFlow id="_0BB9D410-FD29-4D75-BACC-E45E6ACC18C8" sourceRef="_972A01F8-B0E3-43EE-A6CB-62DFA856C0AD" targetRef="_B275D0A1-07EC-4A08-98F4-8ECEAD1BF631">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_77A3126A-2BC9-4423-A982-61DA76E3E697" sourceRef="_6C8896A2-1855-4523-A19D-AE80BCDD42DF" targetRef="_972A01F8-B0E3-43EE-A6CB-62DFA856C0AD"/>
+    <bpmn2:sequenceFlow id="_46DB4364-381A-41CD-8BF8-991A7D114589" sourceRef="_E0DE2BCD-5E77-433D-AA07-57693EA860CB" targetRef="_6C8896A2-1855-4523-A19D-AE80BCDD42DF">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_CAC39364-3199-42E6-AFD7-69B7883FAC72" sourceRef="_49FFA9C3-7F4F-4B3D-9D5A-EF4C2357779D" targetRef="_E0DE2BCD-5E77-433D-AA07-57693EA860CB">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:endEvent id="_AB7D2F8D-BF51-4508-9D65-50BFB8DA5BAB" name="End Parent Process">
+      <bpmn2:incoming>_A570F321-92E4-4B45-8818-67A5A0F2F246</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:intermediateCatchEvent id="_972A01F8-B0E3-43EE-A6CB-62DFA856C0AD" name="Catch End Sub 1">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[End Sub 1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_77A3126A-2BC9-4423-A982-61DA76E3E697</bpmn2:incoming>
+      <bpmn2:outgoing>_0BB9D410-FD29-4D75-BACC-E45E6ACC18C8</bpmn2:outgoing>
+      <bpmn2:signalEventDefinition id="_E110wXdGEeuwCP4PHJc9Og" signalRef="_8d5234bb-55a3-3bd9-ab4b-d4ea2123ecf9"/>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:startEvent id="_49FFA9C3-7F4F-4B3D-9D5A-EF4C2357779D" name="Start Parent Process">
+      <bpmn2:outgoing>_CAC39364-3199-42E6-AFD7-69B7883FAC72</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:scriptTask id="_B275D0A1-07EC-4A08-98F4-8ECEAD1BF631" name="End Task" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[End Task]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_0BB9D410-FD29-4D75-BACC-E45E6ACC18C8</bpmn2:incoming>
+      <bpmn2:outgoing>_A570F321-92E4-4B45-8818-67A5A0F2F246</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("("+kcontext.getProcessInstance().getId()+") "+" End Task");]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:intermediateThrowEvent id="_6C8896A2-1855-4523-A19D-AE80BCDD42DF" name="Throw Sub 1">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Start Sub 1]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="customScope">
+          <drools:metaValue><![CDATA[processInstance]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="executeActionAfterComplete">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_46DB4364-381A-41CD-8BF8-991A7D114589</bpmn2:incoming>
+      <bpmn2:outgoing>_77A3126A-2BC9-4423-A982-61DA76E3E697</bpmn2:outgoing>
+      <bpmn2:dataInput id="_6C8896A2-1855-4523-A19D-AE80BCDD42DF_subidInputX" drools:dtype="String" itemSubjectRef="__6C8896A2-1855-4523-A19D-AE80BCDD42DF_subidInputXItem" name="subid"/>
+      <bpmn2:dataInputAssociation id="_E110w3dGEeuwCP4PHJc9Og">
+        <bpmn2:sourceRef>id</bpmn2:sourceRef>
+        <bpmn2:targetRef>_6C8896A2-1855-4523-A19D-AE80BCDD42DF_subidInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:inputSet id="_E110wndGEeuwCP4PHJc9Og">
+        <bpmn2:dataInputRefs>_6C8896A2-1855-4523-A19D-AE80BCDD42DF_subidInputX</bpmn2:dataInputRefs>
+      </bpmn2:inputSet>
+      <bpmn2:signalEventDefinition id="_E110xHdGEeuwCP4PHJc9Og" signalRef="_b79be69d-4df1-398c-ac01-70868d3665d7"/>
+    </bpmn2:intermediateThrowEvent>
+    <bpmn2:scriptTask id="_E0DE2BCD-5E77-433D-AA07-57693EA860CB" name="Task1" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_CAC39364-3199-42E6-AFD7-69B7883FAC72</bpmn2:incoming>
+      <bpmn2:outgoing>_46DB4364-381A-41CD-8BF8-991A7D114589</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("("+kcontext.getProcessInstance().getId()+") "+"#########################.");
+System.out.println("("+kcontext.getProcessInstance().getId()+") "+"Task1: Id " +id);
+System.out.println("("+kcontext.getProcessInstance().getId()+") "+"#########################.");]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:subProcess id="_D4B3B9EB-7B32-4BBF-BDA4-5A250503DFEA" name="Container Sub 1" triggeredByEvent="true">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Sub 1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:property id="subid" itemSubjectRef="_subidItem" name="subid"/>
+
+      <bpmn2:sequenceFlow id="_E6277E9F-2DD9-4D9E-A7D1-6558C65FEECD" sourceRef="_FEB5FE24-82D7-49F1-9BD7-8617F85CB709" targetRef="_D88A7FB5-C9B4-47E0-855F-215C8842D931"/>
+      <bpmn2:startEvent id="_FEB5FE24-82D7-49F1-9BD7-8617F85CB709" name="Start Sub 1" isInterrupting="false">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[Start Sub1]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:outgoing>_DEA9B8CD-FED1-482E-9479-1EC549580BFD</bpmn2:outgoing>
+        <bpmn2:dataOutput id="_FEB5FE24-82D7-49F1-9BD7-8617F85CB709_sidOutputX" drools:dtype="String" itemSubjectRef="__FEB5FE24-82D7-49F1-9BD7-8617F85CB709_sidOutputXItem" name="sid"/>
+        <bpmn2:dataOutputAssociation id="_E110yHdGEeuwCP4PHJc9Og">
+          <bpmn2:sourceRef>_FEB5FE24-82D7-49F1-9BD7-8617F85CB709_sidOutputX</bpmn2:sourceRef>
+          <bpmn2:targetRef>subid</bpmn2:targetRef>
+        </bpmn2:dataOutputAssociation>
+        <bpmn2:outputSet id="_E110x3dGEeuwCP4PHJc9Og">
+          <bpmn2:dataOutputRefs>_FEB5FE24-82D7-49F1-9BD7-8617F85CB709_sidOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+        <bpmn2:signalEventDefinition id="_E110yXdGEeuwCP4PHJc9Og" signalRef="_b79be69d-4df1-398c-ac01-70868d3665d7"/>
+      </bpmn2:startEvent>
+      <bpmn2:endEvent id="_D88A7FB5-C9B4-47E0-855F-215C8842D931" name="End Sub 1">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[End Sub 1]]></drools:metaValue>
+          </drools:metaData>
+          <drools:metaData name="customScope">
+            <drools:metaValue><![CDATA[processInstance]]></drools:metaValue>
+          </drools:metaData>
+          <drools:metaData name="customAsync">
+            <drools:metaValue><![CDATA[false]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:incoming>_E6277E9F-2DD9-4D9E-A7D1-6558C65FEECD</bpmn2:incoming>
+        <bpmn2:signalEventDefinition id="_E110yndGEeuwCP4PHJc9Og" signalRef="_8d5234bb-55a3-3bd9-ab4b-d4ea2123ecf9"/>
+      </bpmn2:endEvent>
+    </bpmn2:subProcess>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_E12b0HdGEeuwCP4PHJc9Og">
+    <bpmndi:BPMNPlane id="_E12b0XdGEeuwCP4PHJc9Og" bpmnElement="eventSubprocess.main">
+      <bpmndi:BPMNShape id="shape__25DC66BF-B8D5-4481-BA69-E1920B580BC7" bpmnElement="_25DC66BF-B8D5-4481-BA69-E1920B580BC7" isExpanded="true">
+        <dc:Bounds height="213.0" width="647.28564" x="173.35715" y="489.5"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__991EBFB2-37F0-4B89-B11F-2BAC4ACACD6F_to_shape__E4C06219-79F3-4759-A5C2-314800FD23FD" bpmnElement="_15B2CB85-654B-4800-BD85-2C3506748E13">
+        <di:waypoint xsi:type="dc:Point" x="253.50003" y="592.7857"/>
+        <di:waypoint xsi:type="dc:Point" x="435.50003" y="593.5"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="shape__E4C06219-79F3-4759-A5C2-314800FD23FD" bpmnElement="_E4C06219-79F3-4759-A5C2-314800FD23FD">
+        <dc:Bounds height="102.0" width="153.99997" x="435.50003" y="542.5"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__991EBFB2-37F0-4B89-B11F-2BAC4ACACD6F" bpmnElement="_991EBFB2-37F0-4B89-B11F-2BAC4ACACD6F">
+        <dc:Bounds height="56.0" width="56.0" x="225.5" y="564.7857"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__E4C06219-79F3-4759-A5C2-314800FD23FD_to_shape__BC4426B5-03C6-4659-B938-539F6CFF7397" bpmnElement="_77A57757-A174-4BF6-B0E9-1F3C77720D9D">
+        <di:waypoint xsi:type="dc:Point" x="512.5" y="593.5"/>
+        <di:waypoint xsi:type="dc:Point" x="694.0" y="592.6429"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="shape__BC4426B5-03C6-4659-B938-539F6CFF7397" bpmnElement="_BC4426B5-03C6-4659-B938-539F6CFF7397">
+        <dc:Bounds height="56.0" width="56.0" x="694.0" y="564.6429"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__D4B3B9EB-7B32-4BBF-BDA4-5A250503DFEA" bpmnElement="_D4B3B9EB-7B32-4BBF-BDA4-5A250503DFEA" isExpanded="true">
+        <dc:Bounds height="200.07901" width="923.24536" x="130.57143" y="230.85715"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__0C5E6DE6-9268-4030-88A2-BC09F72766F7_to_shape__A248C227-7BE2-493B-928B-63E50667FB0F" bpmnElement="_4933D991-CA40-4F56-94FE-01B59DC06575">
+        <di:waypoint xsi:type="dc:Point" x="607.1429" y="343.7143"/>
+        <di:waypoint xsi:type="dc:Point" x="684.0" y="344.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__6FED2DF5-8C21-42EC-9DA9-E216AEC83CBA_to_shape__D88A7FB5-C9B4-47E0-855F-215C8842D931" bpmnElement="_E6277E9F-2DD9-4D9E-A7D1-6558C65FEECD">
+        <di:waypoint xsi:type="dc:Point" x="855.0" y="342.0"/>
+        <di:waypoint xsi:type="dc:Point" x="960.0" y="343.85715"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__A248C227-7BE2-493B-928B-63E50667FB0F_to_shape__6FED2DF5-8C21-42EC-9DA9-E216AEC83CBA" bpmnElement="_64B68712-72CF-4803-B46A-F0FC06C39291">
+        <di:waypoint xsi:type="dc:Point" x="712.0" y="344.0"/>
+        <di:waypoint xsi:type="dc:Point" x="778.0" y="342.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="shape__0C5E6DE6-9268-4030-88A2-BC09F72766F7" bpmnElement="_0C5E6DE6-9268-4030-88A2-BC09F72766F7">
+        <dc:Bounds height="56.0" width="56.0" x="579.1429" y="315.7143"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__6FED2DF5-8C21-42EC-9DA9-E216AEC83CBA" bpmnElement="_6FED2DF5-8C21-42EC-9DA9-E216AEC83CBA">
+        <dc:Bounds height="102.0" width="154.0" x="778.0" y="291.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__D88A7FB5-C9B4-47E0-855F-215C8842D931" bpmnElement="_D88A7FB5-C9B4-47E0-855F-215C8842D931">
+        <dc:Bounds height="56.0" width="56.0" x="960.0" y="315.85715"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__D2DF676C-9E68-4132-968B-E5077D761B2F_to_shape__0C5E6DE6-9268-4030-88A2-BC09F72766F7" bpmnElement="_7885B2E3-6307-471F-8BE0-D16223AB4D02">
+        <di:waypoint xsi:type="dc:Point" x="452.57144" y="343.7143"/>
+        <di:waypoint xsi:type="dc:Point" x="607.1429" y="343.7143"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="shape__FEB5FE24-82D7-49F1-9BD7-8617F85CB709" bpmnElement="_FEB5FE24-82D7-49F1-9BD7-8617F85CB709">
+        <dc:Bounds height="56.0" width="56.000015" x="214.14287" y="316.14285"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__D2DF676C-9E68-4132-968B-E5077D761B2F" bpmnElement="_D2DF676C-9E68-4132-968B-E5077D761B2F">
+        <dc:Bounds height="102.0" width="153.99997" x="375.57144" y="292.7143"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__FEB5FE24-82D7-49F1-9BD7-8617F85CB709_to_shape__D2DF676C-9E68-4132-968B-E5077D761B2F" bpmnElement="_DEA9B8CD-FED1-482E-9479-1EC549580BFD">
+        <di:waypoint xsi:type="dc:Point" x="242.14287" y="344.14285"/>
+        <di:waypoint xsi:type="dc:Point" x="375.57144" y="343.7143"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="shape__A248C227-7BE2-493B-928B-63E50667FB0F" bpmnElement="_A248C227-7BE2-493B-928B-63E50667FB0F">
+        <dc:Bounds height="56.0" width="56.0" x="684.0" y="316.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__E0DE2BCD-5E77-433D-AA07-57693EA860CB" bpmnElement="_E0DE2BCD-5E77-433D-AA07-57693EA860CB">
+        <dc:Bounds height="102.0" width="154.0" x="278.0" y="48.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__6C8896A2-1855-4523-A19D-AE80BCDD42DF" bpmnElement="_6C8896A2-1855-4523-A19D-AE80BCDD42DF">
+        <dc:Bounds height="56.0" width="56.0" x="505.0" y="63.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__B275D0A1-07EC-4A08-98F4-8ECEAD1BF631" bpmnElement="_B275D0A1-07EC-4A08-98F4-8ECEAD1BF631">
+        <dc:Bounds height="102.0" width="154.0" x="788.0" y="43.142853"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__49FFA9C3-7F4F-4B3D-9D5A-EF4C2357779D" bpmnElement="_49FFA9C3-7F4F-4B3D-9D5A-EF4C2357779D">
+        <dc:Bounds height="56.0" width="56.0" x="149.0" y="66.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__972A01F8-B0E3-43EE-A6CB-62DFA856C0AD" bpmnElement="_972A01F8-B0E3-43EE-A6CB-62DFA856C0AD">
+        <dc:Bounds height="56.0" width="56.0" x="662.0" y="65.714294"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__AB7D2F8D-BF51-4508-9D65-50BFB8DA5BAB" bpmnElement="_AB7D2F8D-BF51-4508-9D65-50BFB8DA5BAB">
+        <dc:Bounds height="56.0" width="56.0" x="1012.0" y="63.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__49FFA9C3-7F4F-4B3D-9D5A-EF4C2357779D_to_shape__E0DE2BCD-5E77-433D-AA07-57693EA860CB" bpmnElement="_CAC39364-3199-42E6-AFD7-69B7883FAC72">
+        <di:waypoint xsi:type="dc:Point" x="177.0" y="94.0"/>
+        <di:waypoint xsi:type="dc:Point" x="278.0" y="99.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__E0DE2BCD-5E77-433D-AA07-57693EA860CB_to_shape__6C8896A2-1855-4523-A19D-AE80BCDD42DF" bpmnElement="_46DB4364-381A-41CD-8BF8-991A7D114589">
+        <di:waypoint xsi:type="dc:Point" x="355.0" y="99.0"/>
+        <di:waypoint xsi:type="dc:Point" x="533.0" y="63.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__6C8896A2-1855-4523-A19D-AE80BCDD42DF_to_shape__972A01F8-B0E3-43EE-A6CB-62DFA856C0AD" bpmnElement="_77A3126A-2BC9-4423-A982-61DA76E3E697">
+        <di:waypoint xsi:type="dc:Point" x="533.0" y="91.0"/>
+        <di:waypoint xsi:type="dc:Point" x="662.0" y="93.714294"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__972A01F8-B0E3-43EE-A6CB-62DFA856C0AD_to_shape__B275D0A1-07EC-4A08-98F4-8ECEAD1BF631" bpmnElement="_0BB9D410-FD29-4D75-BACC-E45E6ACC18C8">
+        <di:waypoint xsi:type="dc:Point" x="690.0" y="93.714294"/>
+        <di:waypoint xsi:type="dc:Point" x="865.0" y="43.142853"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__B275D0A1-07EC-4A08-98F4-8ECEAD1BF631_to_shape__AB7D2F8D-BF51-4508-9D65-50BFB8DA5BAB" bpmnElement="_A570F321-92E4-4B45-8818-67A5A0F2F246">
+        <di:waypoint xsi:type="dc:Point" x="865.0" y="94.14285"/>
+        <di:waypoint xsi:type="dc:Point" x="1012.0" y="91.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_E12b0ndGEeuwCP4PHJc9Og" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_E0DE2BCD-5E77-433D-AA07-57693EA860CB" id="_E12b03dGEeuwCP4PHJc9Og">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B275D0A1-07EC-4A08-98F4-8ECEAD1BF631" id="_E12b1HdGEeuwCP4PHJc9Og">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_49FFA9C3-7F4F-4B3D-9D5A-EF4C2357779D" id="_E12b1XdGEeuwCP4PHJc9Og">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_E110wHdGEeuwCP4PHJc9Og</bpmn2:source>
+    <bpmn2:target>_E110wHdGEeuwCP4PHJc9Og</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/JBPM-9632

To avoid problems with the action nodes (intermediate throw) I added a new metadata for the node
"executeActionAfterComplete" when is set to true the signal is process after finishing processing the current flow.(like a passthrough)