### PR TITLE
[JBPM-6943] Renamed deprecated method inside AbstractProcessAssembler

### DIFF
--- a/jbpm-flow-builder/src/main/java/org/jbpm/assembler/AbstractProcessAssembler.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/assembler/AbstractProcessAssembler.java
@@ -33,7 +33,7 @@ import org.kie.internal.builder.KnowledgeBuilderResult;
 
 public abstract class AbstractProcessAssembler implements KieAssemblerService {
 
-    public void addResource(
+    public void addResourceAfterRules(
             Object kbuilder,
             Resource resource,
             ResourceType type,


### PR DESCRIPTION
@danielezonca @afalhambra  @jiripetrlik

See https://issues.redhat.com/browse/JBPM-9643

Scope of this PR is to allow is to remove deprecated method.
A fix has already been made with https://github.com/kiegroup/droolsjbpm-knowledge/pull/508 but FDB take too much time.
This is an attempt to speed up resolution.
In my local machine I started full clean install and I've successfully  gone past the module that was failing, but the full build takes hours.

@jiripetrlik I'm not sure if you are the QE responsible for this project :smile: 