### PR TITLE
[JBPM-9650] Potential owners of tasks retrieved by query don't match expected owners

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/preprocessor/PotOwnerTasksPreprocessor.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/preprocessor/PotOwnerTasksPreprocessor.java
@@ -89,7 +89,7 @@ public class PotOwnerTasksPreprocessor extends UserTasksPreprocessor {
 
     @Override
     protected Collection<String> getGroupColumns(Collection<String> columns) {
-        columns.remove(COLUMN_ORGANIZATIONAL_ENTITY);
+        columns.removeIf(c -> c.equalsIgnoreCase(COLUMN_ORGANIZATIONAL_ENTITY));
         return columns;
     }
 


### PR DESCRIPTION
Comparison to remove the ID column should be case sensitive. Constant is
upper case and column names in pgsql/mysql are lower case. This causes
the ID column to be grouped, which leads to redundant rows that makes
the test fails



**JIRA**: 

[link](https://issues.redhat.com/browse/JBPM-9650)



