### PR TITLE
[JBPM-9645] Creating ProcessIndexerManager can cause NullPointerException

### DIFF
--- a/jbpm-audit/src/main/java/org/jbpm/process/audit/variable/ProcessIndexerManager.java
+++ b/jbpm-audit/src/main/java/org/jbpm/process/audit/variable/ProcessIndexerManager.java
@@ -82,7 +82,7 @@ public class ProcessIndexerManager {
         return null;
     }
     
-    public static ProcessIndexerManager get() {
+    public static synchronized ProcessIndexerManager get() {
         if (INSTANCE == null) {
             INSTANCE = new ProcessIndexerManager();
         }


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/JBPM-9645