### PR TITLE
[JBPM-9685] Add support for Date ranges

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/AbstractAdvanceRuntimeDataServiceImpl.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/AbstractAdvanceRuntimeDataServiceImpl.java
@@ -257,7 +257,7 @@ public abstract class AbstractAdvanceRuntimeDataServiceImpl {
             });
 
             taskVariables.stream().filter(e -> e.getObjectValue() != null).forEach(var -> {
-                String valueParam = computeVarValueParameter(var, "V", var.getColumn());
+                String valueParam = computeVarValueParameter(var, "V");
                 query.setParameter(valueParam, var.getObjectValue());
             });
 
@@ -270,7 +270,7 @@ public abstract class AbstractAdvanceRuntimeDataServiceImpl {
                 query.setParameter(nameParam, varPrefix + var.getColumn());
             });
             processVariables.stream().filter(e -> e.getObjectValue() != null).forEach(var -> {
-                String valueParam = computeVarValueParameter(var, "P", var.getColumn());
+                String valueParam = computeVarValueParameter(var, "P");
                 query.setParameter(valueParam, var.getObjectValue());
             });
 
@@ -286,7 +286,15 @@ public abstract class AbstractAdvanceRuntimeDataServiceImpl {
                 }
             }
 
-            attributes.stream().filter(e -> e.getObjectValue() != null).forEach(entry -> query.setParameter("ATTR_" + entry.getColumn(), entry.getObjectValue()));
+            attributes.stream().filter(e -> e.getObjectValue() != null).forEach(entry -> {
+                if ("BETWEEN".equals(entry.getOperator())) {
+                    for (int i = 0; i < entry.getValue().size(); i++) {
+                        query.setParameter("ATTR_" + entry.getColumn() + "_" + i, entry.getValue().get(i));
+                    }
+                } else {
+                    query.setParameter("ATTR_" + entry.getColumn(), entry.getObjectValue());
+                }
+            });
             query.setParameter("processType", processType);
 
             addPagination(query, queryContext);
@@ -347,7 +355,7 @@ public abstract class AbstractAdvanceRuntimeDataServiceImpl {
 
             List<QueryParam> varParams = params.stream().filter(e -> e.getColumn().equals(var)).collect(toList());
             varParams.stream().forEach(expr -> {
-                String valueParam = computeVarValueParameter(expr, prefix, expr.getColumn());
+                String valueParam = computeVarValueParameter(expr, prefix);
                 condition.append(" AND " + computeExpression(expr, valueField, ":" + valueParam));
             });
 
@@ -361,7 +369,7 @@ public abstract class AbstractAdvanceRuntimeDataServiceImpl {
         return prefix + "_NAME_" + sanitize(name);
     }
 
-    private String computeVarValueParameter(QueryParam expr, String prefix, String name) {
+    private String computeVarValueParameter(QueryParam expr, String prefix) {
         return prefix + "_VALUE_" + expr.getOperator() + "_" + sanitize(expr.getColumn());
     }
 
@@ -388,8 +396,21 @@ public abstract class AbstractAdvanceRuntimeDataServiceImpl {
                 return leftOperand + " <> " + rightOperand + " ";
             case "LIKE_TO":
                 return leftOperand + " LIKE " + rightOperand + " ";
+            case "GREATER_THAN":
+                return leftOperand + " > " + rightOperand;
+            case "GREATER_OR_EQUALS_TO":
+                return leftOperand + " >= " + rightOperand;
+            case "LOWER_THAN":
+                return leftOperand + " < " + rightOperand;
+            case "LOWER_OR_EQUALS_TO":
+                return leftOperand + " <= " + leftOperand;
+            case "BETWEEN":
+                 if(expr.getValue().size() != 2) {
+                    throw new IllegalArgumentException("BETWEEN operator requires 2 values. Received: " + expr.getValue().size());
+                }
+                return leftOperand + " >= " + rightOperand + "_0 AND " + leftOperand + " <= " + rightOperand + "_1";
             default:
-                throw new UnsupportedOperationException("Queryparam: " + expr + " not supported");
+                throw new UnsupportedOperationException("Queryparam: " + expr.getOperator() + " not supported");
         }
     }
 

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/AbstractAdvanceRuntimeDataServiceImpl.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/AbstractAdvanceRuntimeDataServiceImpl.java
@@ -403,7 +403,7 @@ public abstract class AbstractAdvanceRuntimeDataServiceImpl {
             case "LOWER_THAN":
                 return leftOperand + " < " + rightOperand;
             case "LOWER_OR_EQUALS_TO":
-                return leftOperand + " <= " + leftOperand;
+                return leftOperand + " <= " + rightOperand;
             case "BETWEEN":
                  if(expr.getValue().size() != 2) {
                     throw new IllegalArgumentException("BETWEEN operator requires 2 values. Received: " + expr.getValue().size());

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/AdvanceRuntimeDataServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/AdvanceRuntimeDataServiceImplTest.java
@@ -18,14 +18,20 @@ package org.jbpm.kie.services.test;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.jbpm.kie.services.impl.KModuleDeploymentUnit;
 import org.jbpm.kie.test.util.AbstractKieServicesBaseTest;
 import org.jbpm.services.api.AdvanceRuntimeDataService;
@@ -63,14 +69,19 @@ import static org.jbpm.services.api.AdvanceRuntimeDataService.TASK_ATTR_NAME;
 import static org.jbpm.services.api.AdvanceRuntimeDataService.TASK_ATTR_OWNER;
 import static org.jbpm.services.api.query.model.QueryParam.all;
 import static org.jbpm.services.api.query.model.QueryParam.any;
+import static org.jbpm.services.api.query.model.QueryParam.between;
 import static org.jbpm.services.api.query.model.QueryParam.equalsTo;
 import static org.jbpm.services.api.query.model.QueryParam.exclude;
+import static org.jbpm.services.api.query.model.QueryParam.greaterOrEqualTo;
+import static org.jbpm.services.api.query.model.QueryParam.greaterThan;
 import static org.jbpm.services.api.query.model.QueryParam.history;
 import static org.jbpm.services.api.query.model.QueryParam.in;
 import static org.jbpm.services.api.query.model.QueryParam.isNotNull;
 import static org.jbpm.services.api.query.model.QueryParam.isNull;
 import static org.jbpm.services.api.query.model.QueryParam.likeTo;
 import static org.jbpm.services.api.query.model.QueryParam.list;
+import static org.jbpm.services.api.query.model.QueryParam.lowerOrEqualTo;
+import static org.jbpm.services.api.query.model.QueryParam.lowerThan;
 import static org.jbpm.services.api.query.model.QueryParam.notEqualsTo;
 import static org.jbpm.services.api.query.model.QueryParam.notIn;
 import static org.jbpm.services.api.query.model.QueryParam.type;
@@ -377,6 +388,48 @@ public class AdvanceRuntimeDataServiceImplTest extends AbstractKieServicesBaseTe
         for (UserTaskInstanceWithPotOwnerDesc p : data) {
             Assert.assertNotEquals("test.test_A", p.getProcessId());
         }
+    }
+
+    @Test
+    public void testQueryTaskCreatedOnDateRanges() {
+        List<QueryParam> attributes = emptyList();
+
+        List<String> potOwners = emptyList();
+        List<UserTaskInstanceWithPotOwnerDesc> data = advanceVariableDataService.queryUserTasksByVariables(attributes, emptyList(), emptyList(), potOwners, queryContext);
+        if (queryContext.getCount() > 0) {
+            assertThat(data.size(), is(queryContext.getCount()));
+            return;
+        } else {
+            assertThat(data.size(), is(20));
+        }
+
+        List<UserTaskInstanceWithPotOwnerDesc> sortedTasks = data.stream().sorted(Comparator.comparing(UserTaskInstanceDesc::getCreatedOn)).collect(Collectors.toList());
+        String column = "createdOn";
+
+        // Between
+        attributes = list(between(column, sortedTasks.get(0).getCreatedOn(), sortedTasks.get(10).getCreatedOn()));
+        data = advanceVariableDataService.queryUserTasksByVariables(attributes, emptyList(), emptyList(), potOwners, queryContext);
+        assertThat(data.size(), is(11));
+
+        // Greater than
+        attributes = list(greaterThan(column, sortedTasks.get(1).getCreatedOn()));
+        data = advanceVariableDataService.queryUserTasksByVariables(attributes, emptyList(), emptyList(), potOwners, queryContext);
+        assertThat(data.size(), is(18));
+
+        // Greater or Equals to
+        attributes = list(greaterOrEqualTo(column, sortedTasks.get(1).getCreatedOn()));
+        data = advanceVariableDataService.queryUserTasksByVariables(attributes, emptyList(), emptyList(), potOwners, queryContext);
+        assertThat(data.size(), is(19));
+
+        // Lower than
+        attributes = list(lowerThan(column, sortedTasks.get(10).getCreatedOn()));
+        data = advanceVariableDataService.queryUserTasksByVariables(attributes, emptyList(), emptyList(), potOwners, queryContext);
+        assertThat(data.size(), is(10));
+
+        // Lower or Equals to
+        attributes = list(lowerOrEqualTo(column, sortedTasks.get(10).getCreatedOn()));
+        data = advanceVariableDataService.queryUserTasksByVariables(attributes, emptyList(), emptyList(), potOwners, queryContext);
+        assertThat(data.size(), is(11));
     }
 
     @Test

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/AdvanceRuntimeDataServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/AdvanceRuntimeDataServiceImplTest.java
@@ -18,20 +18,16 @@ package org.jbpm.kie.services.test;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.jbpm.kie.services.impl.KModuleDeploymentUnit;
 import org.jbpm.kie.test.util.AbstractKieServicesBaseTest;
 import org.jbpm.services.api.AdvanceRuntimeDataService;


### PR DESCRIPTION
Signed-off-by: ruromero <rromerom@redhat.com>

**Thank you for submitting this pull request**

**JIRA**: 

[https://issues.redhat.com/browse/JBPM-9685](https://issues.redhat.com/browse/JBPM-9685)

In order to allow queries based on tasks by Date ranges I have added support for the following filters:

* GREATER_THAN
* GREATER_OR_EQUAL_TO
* LOWER_THAN
* LOWER_OR_EQUAL_TO
* BETWEEN

That will allow queries of this type:
```
new QueryParam("createdon", "BETWEEN", List.of(new Date(1616751677400L), new Date(1616751677500L)))
```