### PR TITLE
[DROOLS-6231] Review drools-mvel test leftovers : 2nd round

### DIFF
--- a/jbpm-flow-builder/pom.xml
+++ b/jbpm-flow-builder/pom.xml
@@ -110,7 +110,7 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-mvel</artifactId>
+      <artifactId>drools-legacy-test-util</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
- Moving drools-mvel test-jar dependency to drools-legacy-test-util test-jar dependency

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6231

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
