### PR TITLE
JBPM-9698 - Remove jbpm-test-util from dependencyManagement section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,11 +155,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jbpm</groupId>
-                <artifactId>jbpm-test-util</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>simple-jndi</groupId>
                 <artifactId>simple-jndi</artifactId>
                 <version>0.11.4.1</version>


### PR DESCRIPTION
jbpm-test-util is already present in the [jbpm-bom](https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/9ceebd82ff4d03bd14bd8db38463d7c8fd8adcef/jbpm-bom/pom.xml#L643-L653).

[JBPM-9698](https://issues.redhat.com/browse/JBPM-9698)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
