### PR TITLE
[JBPM-9746] Precision time (milliseconds) for datime columns should be taken into account for MySQL and MariaDB

### DIFF
--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
@@ -1,8 +1,7 @@
     create table Attachment (
         id bigint not null auto_increment,
         accessType integer,
-        attachedAt datetime,
-        -- attachedAt datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        attachedAt datetime(6),
         attachmentContentId bigint not null,
         contentType varchar(255),
         name varchar(255),
@@ -14,16 +13,13 @@
 
     create table AuditTaskImpl (
         id bigint not null auto_increment,
-        activationTime datetime,
-        -- activationTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        activationTime datetime(6),
         actualOwner varchar(255),
         createdBy varchar(255),
-        createdOn datetime,
-        -- createdOn datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        createdOn datetime(6),
         deploymentId varchar(255),
         description varchar(255),
-        dueDate datetime,
-        -- dueDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        dueDate datetime(6),
         name varchar(255),
         parentId bigint not null,
         priority integer not null,
@@ -33,27 +29,24 @@
         status varchar(255),
         taskId bigint,
         workItemId bigint,
-        lastModificationDate datetime,
-        end_date datetime,
+        lastModificationDate datetime(6),
+        end_date datetime(6),
         primary key (id)
     );
 
     create table BAMTaskSummary (
         pk bigint not null auto_increment,
-        createdDate datetime,
-        -- createdDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        createdDate datetime(6),
         duration bigint,
-        endDate datetime,
-        -- endDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        endDate datetime(6),
         processInstanceId bigint not null,
-        startDate datetime,
-        -- startDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        startDate datetime(6),
         status varchar(255),
         taskId bigint not null,
         taskName varchar(255),
         userId varchar(255),
         OPTLOCK integer,
-        end_date datetime,
+        end_date datetime(6),
         primary key (pk)
     );
 
@@ -79,7 +72,7 @@
         itemName varchar(255),
         itemType varchar(255),
         itemValue varchar(255),
-        lastModified datetime,
+        lastModified datetime(6),
         lastModifiedBy varchar(255),
         primary key (id)
     );
@@ -128,8 +121,7 @@
 
     create table Deadline (
         id bigint not null auto_increment,
-        deadline_date datetime,
-        -- deadline_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        deadline_date datetime(6),
         escalated smallint,
         Deadlines_StartDeadLine_Id bigint,
         Deadlines_EndDeadLine_Id bigint,
@@ -147,8 +139,7 @@
         DEPLOYMENT_ID varchar(255),
         deploymentUnit longtext,
         state integer,
-        updateDate datetime,
-        -- updateDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        updateDate datetime(6),
         primary key (id)
     );
 
@@ -156,8 +147,7 @@
         id bigint not null auto_increment,
         message varchar(255),
         stacktrace varchar(5000),
-        timestamp datetime,
-        -- timestamp datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        timestamp datetime(6),
         REQUEST_ID bigint not null,
         primary key (id)
     );
@@ -177,13 +167,13 @@
     create table ExecutionErrorInfo (
         id bigint not null auto_increment,
         ERROR_ACK smallint,
-        ERROR_ACK_AT datetime,
+        ERROR_ACK_AT datetime(6),
         ERROR_ACK_BY varchar(255),
         ACTIVITY_ID bigint,
         ACTIVITY_NAME varchar(255),
         DEPLOYMENT_ID varchar(255),
         ERROR_INFO longtext,
-        ERROR_DATE datetime,
+        ERROR_DATE datetime(6),
         ERROR_ID varchar(255),
         ERROR_MSG varchar(255),
         INIT_ACTIVITY_ID bigint,
@@ -214,8 +204,7 @@
     create table NodeInstanceLog (
         id bigint not null auto_increment,
         connection varchar(255),
-        log_date datetime,
-        -- log_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        log_date datetime(6),
         externalId varchar(255),
         nodeId varchar(255),
         nodeInstanceId varchar(255),
@@ -223,14 +212,13 @@
         nodeType varchar(255),
         processId varchar(255),
         processInstanceId bigint not null,
-        sla_due_date datetime,
-        -- sla_due_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        sla_due_date datetime(6),
         slaCompliance integer,
         type integer not null,
         workItemId bigint,
         nodeContainerId varchar(255),
         referenceId bigint,
-        end_date datetime,th
+        end_date datetime(6),
         primary key (id)
     );
 
@@ -292,14 +280,11 @@
 
     create table ProcessInstanceInfo (
         InstanceId bigint not null auto_increment,
-        lastModificationDate datetime,
-        -- lastModificationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
-        lastReadDate datetime,
-        -- lastReadDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        lastModificationDate datetime(6),
+        lastReadDate datetime(6),
         processId varchar(255),
         processInstanceByteArray longblob,
-        startDate datetime,
-        -- startDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        startDate datetime(6),
         state integer not null,
         OPTLOCK integer,
         primary key (InstanceId)
@@ -309,8 +294,7 @@
         id bigint not null auto_increment,
         correlationKey varchar(255),
         duration bigint,
-        end_date datetime,
-        -- end_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        end_date datetime(6),
         externalId varchar(255),
         user_identity varchar(255),
         outcome varchar(255),
@@ -321,11 +305,9 @@
         processName varchar(255),
         processType integer,
         processVersion varchar(255),
-        sla_due_date datetime,
-        -- sla_due_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        sla_due_date datetime(6),
         slaCompliance integer,
-        start_date datetime,
-        -- start_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        start_date datetime(6),
         status integer,
         primary key (id)
     );
@@ -364,18 +346,15 @@
         responseData longblob,
         retries integer not null,
         status varchar(255),
-        timestamp datetime,
-        -- timestamp datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        timestamp datetime(6),
         primary key (id)
     );
 
     create table SessionInfo (
         id bigint not null auto_increment,
-        lastModificationDate datetime,
-        -- lastModificationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        lastModificationDate datetime(6),
         rulesByteArray longblob,
-        startDate datetime,
-        -- startDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        startDate datetime(6),
         OPTLOCK integer,
         primary key (id)
     );
@@ -390,16 +369,13 @@
         priority integer not null,
         subTaskStrategy varchar(255),
         subject varchar(255),
-        activationTime datetime,
-        -- activationTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
-        createdOn datetime,
-        -- createdOn datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        activationTime datetime(6),
+        createdOn datetime(6),
         deploymentId varchar(255),
         documentAccessType integer,
         documentContentId bigint not null,
         documentType varchar(255),
-        expirationTime datetime,
-        -- expirationTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        expirationTime datetime(6),
         faultAccessType integer,
         faultContentId bigint not null,
         faultName varchar(255),
@@ -432,8 +408,7 @@
 
     create table TaskEvent (
         id bigint not null auto_increment,
-        logTime datetime,
-        -- logTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        logTime datetime(6),
         message varchar(255),
         processInstanceId bigint,
         taskId bigint,
@@ -443,14 +418,13 @@
         workItemId bigint,
         correlationKey varchar(255),
         processType integer,
-        end_date datetime,
+        end_date datetime(6),
         primary key (id)
     );
 
     create table TaskVariableImpl (
         id bigint not null auto_increment,
-        modificationDate datetime,
-        -- modificationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        modificationDate datetime(6),
         name varchar(255),
         processId varchar(255),
         processInstanceId bigint,
@@ -462,8 +436,7 @@
 
     create table VariableInstanceLog (
         id bigint not null auto_increment,
-        log_date datetime,
-        -- log_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        log_date datetime(6),
         externalId varchar(255),
         oldValue varchar(255),
         processId varchar(255),
@@ -471,14 +444,13 @@
         value varchar(255),
         variableId varchar(255),
         variableInstanceId varchar(255),
-        end_date datetime,
+        end_date datetime(6),
         primary key (id)
     );
 
     create table WorkItemInfo (
         workItemId bigint not null auto_increment,
-        creationDate datetime,
-        -- creationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        creationDate datetime(6),
         name varchar(255),
         processInstanceId bigint not null,
         state bigint not null,
@@ -499,8 +471,7 @@
 
     create table task_comment (
         id bigint not null auto_increment,
-        addedAt datetime,
-        -- addedAt datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        addedAt datetime(6),
         text longtext,
         addedBy_id varchar(255),
         TaskData_Comments_Id bigint,

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysql5/task_assigning_tables_mysql.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysql5/task_assigning_tables_mysql.sql
@@ -3,7 +3,7 @@
         OPTLOCK integer,
         assignedUser varchar(255),
         taskIndex integer not null,
-        lastModificationDate datetime,
+        lastModificationDate datetime(6),
         published smallint not null,
         primary key (taskId)
     );

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysqlinnodb/mysql-innodb-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysqlinnodb/mysql-innodb-jbpm-schema.sql
@@ -1,8 +1,7 @@
     create table Attachment (
         id bigint not null auto_increment,
         accessType integer,
-        attachedAt datetime,
-        -- attachedAt datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        attachedAt datetime(6),
         attachmentContentId bigint not null,
         contentType varchar(255),
         name varchar(255),
@@ -14,16 +13,13 @@
 
     create table AuditTaskImpl (
         id bigint not null auto_increment,
-        activationTime datetime,
-        -- activationTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        activationTime datetime(6),
         actualOwner varchar(255),
         createdBy varchar(255),
-        createdOn datetime,
-        -- createdOn datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        createdOn datetime(6),
         deploymentId varchar(255),
         description varchar(255),
-        dueDate datetime,
-        -- dueDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        dueDate datetime(6),
         name varchar(255),
         parentId bigint not null,
         priority integer not null,
@@ -33,27 +29,24 @@
         status varchar(255),
         taskId bigint,
         workItemId bigint,
-        lastModificationDate datetime,
-        end_date datetime,
+        lastModificationDate datetime(6),
+        end_date datetime(6),
         primary key (id)
     ) ENGINE=InnoDB;
 
     create table BAMTaskSummary (
         pk bigint not null auto_increment,
-        createdDate datetime,
-        -- createdDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        createdDate datetime(6),
         duration bigint,
-        endDate datetime,
-        -- endDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        endDate datetime(6),
         processInstanceId bigint not null,
-        startDate datetime,
-        -- startDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        startDate datetime(6),
         status varchar(255),
         taskId bigint not null,
         taskName varchar(255),
         userId varchar(255),
         OPTLOCK integer,
-        end_date datetime,
+        end_date datetime(6),
         primary key (pk)
     ) ENGINE=InnoDB;
 
@@ -79,8 +72,7 @@
         itemName varchar(255),
         itemType varchar(255),
         itemValue varchar(255),
-        lastModified datetime,
-        -- lastModified datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        lastModified datetime(6),
         lastModifiedBy varchar(255),
         primary key (id)
     ) ENGINE=InnoDB;
@@ -129,8 +121,7 @@
 
     create table Deadline (
         id bigint not null auto_increment,
-        deadline_date datetime,
-        -- deadline_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        deadline_date datetime(6),
         escalated smallint,
         Deadlines_StartDeadLine_Id bigint,
         Deadlines_EndDeadLine_Id bigint,
@@ -148,8 +139,7 @@
         DEPLOYMENT_ID varchar(255),
         deploymentUnit longtext,
         state integer,
-        updateDate datetime,
-        -- updateDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        updateDate datetime(6),
         primary key (id)
     ) ENGINE=InnoDB;
 
@@ -157,8 +147,7 @@
         id bigint not null auto_increment,
         message varchar(255),
         stacktrace varchar(5000),
-        timestamp datetime,
-        -- timestamp datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        timestamp datetime(6),
         REQUEST_ID bigint not null,
         primary key (id)
     ) ENGINE=InnoDB;
@@ -178,15 +167,13 @@
     create table ExecutionErrorInfo (
         id bigint not null auto_increment,
         ERROR_ACK smallint,
-        ERROR_ACK_AT datetime,
-        -- ERROR_ACK_AT datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        ERROR_ACK_AT datetime(6),
         ERROR_ACK_BY varchar(255),
         ACTIVITY_ID bigint,
         ACTIVITY_NAME varchar(255),
         DEPLOYMENT_ID varchar(255),
         ERROR_INFO longtext,
-        ERROR_DATE datetime,
-        -- ERROR_DATE datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        ERROR_DATE datetime(6),
         ERROR_ID varchar(255),
         ERROR_MSG varchar(255),
         INIT_ACTIVITY_ID bigint,
@@ -217,8 +204,7 @@
     create table NodeInstanceLog (
         id bigint not null auto_increment,
         connection varchar(255),
-        log_date datetime,
-        -- log_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        log_date datetime(6),
         externalId varchar(255),
         nodeId varchar(255),
         nodeInstanceId varchar(255),
@@ -226,14 +212,13 @@
         nodeType varchar(255),
         processId varchar(255),
         processInstanceId bigint not null,
-        sla_due_date datetime,
-        -- sla_due_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        sla_due_date datetime(6),
         slaCompliance integer,
         type integer not null,
         workItemId bigint,
         nodeContainerId varchar(255),
         referenceId bigint,
-        end_date datetime,
+        end_date datetime(6),
         primary key (id)
     ) ENGINE=InnoDB;
 
@@ -295,14 +280,11 @@
 
     create table ProcessInstanceInfo (
         InstanceId bigint not null auto_increment,
-        lastModificationDate datetime,
-        -- lastModificationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
-        lastReadDate datetime,
-        -- lastReadDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        lastModificationDate datetime(6),
+        lastReadDate datetime(6),
         processId varchar(255),
         processInstanceByteArray longblob,
-        startDate datetime,
-        -- startDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        startDate datetime(6),
         state integer not null,
         OPTLOCK integer,
         primary key (InstanceId)
@@ -312,8 +294,7 @@
         id bigint not null auto_increment,
         correlationKey varchar(255),
         duration bigint,
-        end_date datetime,
-        -- end_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        end_date datetime(6),
         externalId varchar(255),
         user_identity varchar(255),
         outcome varchar(255),
@@ -324,11 +305,9 @@
         processName varchar(255),
         processType integer,
         processVersion varchar(255),
-        sla_due_date datetime,
-        -- sla_due_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        sla_due_date datetime(6),
         slaCompliance integer,
-        start_date datetime,
-        -- start_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        start_date datetime(6),
         status integer,
         primary key (id)
     ) ENGINE=InnoDB;
@@ -367,18 +346,15 @@
         responseData longblob,
         retries integer not null,
         status varchar(255),
-        timestamp datetime,
-        -- timestamp datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        timestamp datetime(6),
         primary key (id)
     ) ENGINE=InnoDB;
 
     create table SessionInfo (
         id bigint not null auto_increment,
-        lastModificationDate datetime,
-        -- lastModificationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        lastModificationDate datetime(6),
         rulesByteArray longblob,
-        startDate datetime,
-        -- startDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        startDate datetime(6),
         OPTLOCK integer,
         primary key (id)
     ) ENGINE=InnoDB;
@@ -393,16 +369,13 @@
         priority integer not null,
         subTaskStrategy varchar(255),
         subject varchar(255),
-        activationTime datetime,
-        -- activationTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
-        createdOn datetime,
-        -- createdOn datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        activationTime datetime(6),
+        createdOn datetime(6),
         deploymentId varchar(255),
         documentAccessType integer,
         documentContentId bigint not null,
         documentType varchar(255),
-        expirationTime datetime,
-        -- expirationTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        expirationTime datetime(6),
         faultAccessType integer,
         faultContentId bigint not null,
         faultName varchar(255),
@@ -435,8 +408,7 @@
 
     create table TaskEvent (
         id bigint not null auto_increment,
-        logTime datetime,
-        -- logTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        logTime datetime(6),
         message varchar(255),
         processInstanceId bigint,
         taskId bigint,
@@ -446,14 +418,13 @@
         workItemId bigint,
         correlationKey varchar(255),
         processType integer,
-        end_date datetime,
+        end_date datetime(6),
         primary key (id)
     );
 
     create table TaskVariableImpl (
         id bigint not null auto_increment,
-        modificationDate datetime,
-        -- modificationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        modificationDate datetime(6),
         name varchar(255),
         processId varchar(255),
         processInstanceId bigint,
@@ -465,8 +436,7 @@
 
     create table VariableInstanceLog (
         id bigint not null auto_increment,
-        log_date datetime,
-        -- log_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        log_date datetime(6),
         externalId varchar(255),
         oldValue varchar(255),
         processId varchar(255),
@@ -474,14 +444,13 @@
         value varchar(255),
         variableId varchar(255),
         variableInstanceId varchar(255),
-        end_date datetime,
+        end_date datetime(6),
         primary key (id)
     ) ENGINE=InnoDB;
 
     create table WorkItemInfo (
         workItemId bigint not null auto_increment,
-        creationDate datetime,
-        -- creationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        creationDate datetime(6),
         name varchar(255),
         processInstanceId bigint not null,
         state bigint not null,
@@ -502,8 +471,7 @@
 
     create table task_comment (
         id bigint not null auto_increment,
-        addedAt datetime,
-        -- addedAt datetime(6), to be used with mysql 5.6.4 that supports millis precision
+        addedAt datetime(6),
         text longtext,
         addedBy_id varchar(255),
         TaskData_Comments_Id bigint,

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysqlinnodb/task_assigning_tables_mysql_innodb.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysqlinnodb/task_assigning_tables_mysql_innodb.sql
@@ -3,7 +3,7 @@
         OPTLOCK integer,
         assignedUser varchar(255),
         taskIndex integer not null,
-        lastModificationDate datetime,
+        lastModificationDate datetime(6),
         published smallint not null,
         primary key (taskId)
     ) ENGINE=InnoDB;

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/jbpm-7.58-to-7.59-task_assigning_tables.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/jbpm-7.58-to-7.59-task_assigning_tables.sql
@@ -1,0 +1,1 @@
+alter table PlanningTask modify lastModificationDate DATETIME(6);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/jbpm-7.58-to-7.59.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/jbpm-7.58-to-7.59.sql
@@ -1,3 +1,55 @@
+alter table Attachment modify attachedAt DATETIME(6);
+
+alter table AuditTaskImpl modify activationTime DATETIME(6);
+alter table AuditTaskImpl modify createdOn DATETIME(6);
+alter table AuditTaskImpl modify dueDate DATETIME(6);
+alter table AuditTaskImpl modify lastModificationDate DATETIME(6);
+
+alter table BAMTaskSummary modify createdDate DATETIME(6);
+alter table BAMTaskSummary modify endDate DATETIME(6);
+alter table BAMTaskSummary modify startDate DATETIME(6);
+
+alter table CaseFileDataLog modify lastModified DATETIME(6);
+
+alter table Deadline modify deadline_date DATETIME(6);
+
+alter table DeploymentStore modify updateDate DATETIME(6);
+
+alter table ErrorInfo modify timestamp DATETIME(6);
+
+alter table ExecutionErrorInfo modify ERROR_ACK_AT DATETIME(6);
+alter table ExecutionErrorInfo modify ERROR_DATE DATETIME(6);
+
+alter table NodeInstanceLog modify log_date DATETIME(6);
+alter table NodeInstanceLog modify sla_due_date DATETIME(6);
+
+alter table ProcessInstanceInfo modify lastModificationDate DATETIME(6);
+alter table ProcessInstanceInfo modify lastReadDate DATETIME(6);
+alter table ProcessInstanceInfo modify startDate DATETIME(6);
+
+alter table ProcessInstanceLog modify end_date DATETIME(6);
+alter table ProcessInstanceLog modify sla_due_date DATETIME(6);
+alter table ProcessInstanceLog modify start_date DATETIME(6);
+
+alter table RequestInfo modify timestamp DATETIME(6);
+
+alter table SessionInfo modify lastModificationDate DATETIME(6);
+alter table SessionInfo modify startDate DATETIME(6);
+
+alter table Task modify activationTime DATETIME(6);
+alter table Task modify createdOn DATETIME(6);
+alter table Task modify expirationTime DATETIME(6);
+
+alter table TaskEvent modify logTime DATETIME(6);
+
+alter table TaskVariableImpl modify modificationDate DATETIME(6);
+
+alter table VariableInstanceLog modify log_date DATETIME(6);
+
+alter table WorkItemInfo modify creationDate DATETIME(6);
+
+alter table task_comment modify addedAt DATETIME(6);
+
 create index IDX_CaseRoleAssignLog_caseId on CaseRoleAssignmentLog(caseId);
 create index IDX_CaseRoleAssignLog_processInstanceId on CaseRoleAssignmentLog(processInstanceId);
 create index IDX_CaseFileDataLog_caseId on CaseFileDataLog(caseId);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/rhpam-7.11-to-7.12-task_assigning_tables.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/rhpam-7.11-to-7.12-task_assigning_tables.sql
@@ -1,0 +1,1 @@
+alter table PlanningTask modify lastModificationDate DATETIME(6);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/rhpam-7.11-to-7.12.sql
@@ -1,8 +1,61 @@
-alter table AuditTaskImpl add column end_date datetime;
-alter table BAMTaskSummary add column end_date datetime;
-alter table TaskEvent add column end_date datetime;
-alter table NodeInstanceLog add column end_date datetime;
-alter table VariableInstanceLog add column end_date datetime;
+alter table Attachment modify attachedAt DATETIME(6);
+
+alter table AuditTaskImpl modify activationTime DATETIME(6);
+alter table AuditTaskImpl modify createdOn DATETIME(6);
+alter table AuditTaskImpl modify dueDate DATETIME(6);
+alter table AuditTaskImpl modify lastModificationDate DATETIME(6);
+
+alter table BAMTaskSummary modify createdDate DATETIME(6);
+alter table BAMTaskSummary modify endDate DATETIME(6);
+alter table BAMTaskSummary modify startDate DATETIME(6);
+
+alter table CaseFileDataLog modify lastModified DATETIME(6);
+
+alter table Deadline modify deadline_date DATETIME(6);
+
+alter table DeploymentStore modify updateDate DATETIME(6);
+
+alter table ErrorInfo modify timestamp DATETIME(6);
+
+alter table ExecutionErrorInfo modify ERROR_ACK_AT DATETIME(6);
+alter table ExecutionErrorInfo modify ERROR_DATE DATETIME(6);
+
+alter table NodeInstanceLog modify log_date DATETIME(6);
+alter table NodeInstanceLog modify sla_due_date DATETIME(6);
+
+alter table ProcessInstanceInfo modify lastModificationDate DATETIME(6);
+alter table ProcessInstanceInfo modify lastReadDate DATETIME(6);
+alter table ProcessInstanceInfo modify startDate DATETIME(6);
+
+alter table ProcessInstanceLog modify end_date DATETIME(6);
+alter table ProcessInstanceLog modify sla_due_date DATETIME(6);
+alter table ProcessInstanceLog modify start_date DATETIME(6);
+
+alter table RequestInfo modify timestamp DATETIME(6);
+
+alter table SessionInfo modify lastModificationDate DATETIME(6);
+alter table SessionInfo modify startDate DATETIME(6);
+
+alter table Task modify activationTime DATETIME(6);
+alter table Task modify createdOn DATETIME(6);
+alter table Task modify expirationTime DATETIME(6);
+
+alter table TaskEvent modify logTime DATETIME(6);
+
+alter table TaskVariableImpl modify modificationDate DATETIME(6);
+
+alter table VariableInstanceLog modify log_date DATETIME(6);
+
+alter table WorkItemInfo modify creationDate DATETIME(6);
+
+alter table task_comment modify addedAt DATETIME(6);
+
+alter table AuditTaskImpl add column end_date DATETIME(6);
+alter table BAMTaskSummary add column end_date DATETIME(6);
+alter table TaskEvent add column end_date DATETIME(6);
+alter table NodeInstanceLog add column end_date DATETIME(6);
+alter table VariableInstanceLog add column end_date DATETIME(6);
+
 create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 create index IDX_CaseRoleAssignLog_caseId on CaseRoleAssignmentLog(caseId);
 create index IDX_CaseRoleAssignLog_processInstanceId on CaseRoleAssignmentLog(processInstanceId);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/jbpm-7.58-to-7.59-task_assigning_tables.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/jbpm-7.58-to-7.59-task_assigning_tables.sql
@@ -1,0 +1,1 @@
+alter table PlanningTask modify lastModificationDate DATETIME(6);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/jbpm-7.58-to-7.59.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/jbpm-7.58-to-7.59.sql
@@ -1,3 +1,55 @@
+alter table Attachment modify attachedAt DATETIME(6);
+
+alter table AuditTaskImpl modify activationTime DATETIME(6);
+alter table AuditTaskImpl modify createdOn DATETIME(6);
+alter table AuditTaskImpl modify dueDate DATETIME(6);
+alter table AuditTaskImpl modify lastModificationDate DATETIME(6);
+
+alter table BAMTaskSummary modify createdDate DATETIME(6);
+alter table BAMTaskSummary modify endDate DATETIME(6);
+alter table BAMTaskSummary modify startDate DATETIME(6);
+
+alter table CaseFileDataLog modify lastModified DATETIME(6);
+
+alter table Deadline modify deadline_date DATETIME(6);
+
+alter table DeploymentStore modify updateDate DATETIME(6);
+
+alter table ErrorInfo modify timestamp DATETIME(6);
+
+alter table ExecutionErrorInfo modify ERROR_ACK_AT DATETIME(6);
+alter table ExecutionErrorInfo modify ERROR_DATE DATETIME(6);
+
+alter table NodeInstanceLog modify log_date DATETIME(6);
+alter table NodeInstanceLog modify sla_due_date DATETIME(6);
+
+alter table ProcessInstanceInfo modify lastModificationDate DATETIME(6);
+alter table ProcessInstanceInfo modify lastReadDate DATETIME(6);
+alter table ProcessInstanceInfo modify startDate DATETIME(6);
+
+alter table ProcessInstanceLog modify end_date DATETIME(6);
+alter table ProcessInstanceLog modify sla_due_date DATETIME(6);
+alter table ProcessInstanceLog modify start_date DATETIME(6);
+
+alter table RequestInfo modify timestamp DATETIME(6);
+
+alter table SessionInfo modify lastModificationDate DATETIME(6);
+alter table SessionInfo modify startDate DATETIME(6);
+
+alter table Task modify activationTime DATETIME(6);
+alter table Task modify createdOn DATETIME(6);
+alter table Task modify expirationTime DATETIME(6);
+
+alter table TaskEvent modify logTime DATETIME(6);
+
+alter table TaskVariableImpl modify modificationDate DATETIME(6);
+
+alter table VariableInstanceLog modify log_date DATETIME(6);
+
+alter table WorkItemInfo modify creationDate DATETIME(6);
+
+alter table task_comment modify addedAt DATETIME(6);
+
 create index IDX_CaseRoleAssignLog_caseId on CaseRoleAssignmentLog(caseId);
 create index IDX_CaseRoleAssignLog_processInstanceId on CaseRoleAssignmentLog(processInstanceId);
 create index IDX_CaseFileDataLog_caseId on CaseFileDataLog(caseId);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/rhpam-7.11-to-7.12-task_assigning_tables.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/rhpam-7.11-to-7.12-task_assigning_tables.sql
@@ -1,0 +1,1 @@
+alter table PlanningTask modify lastModificationDate DATETIME(6);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/rhpam-7.11-to-7.12.sql
@@ -1,8 +1,61 @@
-alter table AuditTaskImpl add column end_date datetime;
-alter table BAMTaskSummary add column end_date datetime;
-alter table TaskEvent add column end_date datetime;
-alter table NodeInstanceLog add column end_date datetime;
-alter table VariableInstanceLog add column end_date datetime;
+alter table Attachment modify attachedAt DATETIME(6);
+
+alter table AuditTaskImpl modify activationTime DATETIME(6);
+alter table AuditTaskImpl modify createdOn DATETIME(6);
+alter table AuditTaskImpl modify dueDate DATETIME(6);
+alter table AuditTaskImpl modify lastModificationDate DATETIME(6);
+
+alter table BAMTaskSummary modify createdDate DATETIME(6);
+alter table BAMTaskSummary modify endDate DATETIME(6);
+alter table BAMTaskSummary modify startDate DATETIME(6);
+
+alter table CaseFileDataLog modify lastModified DATETIME(6);
+
+alter table Deadline modify deadline_date DATETIME(6);
+
+alter table DeploymentStore modify updateDate DATETIME(6);
+
+alter table ErrorInfo modify timestamp DATETIME(6);
+
+alter table ExecutionErrorInfo modify ERROR_ACK_AT DATETIME(6);
+alter table ExecutionErrorInfo modify ERROR_DATE DATETIME(6);
+
+alter table NodeInstanceLog modify log_date DATETIME(6);
+alter table NodeInstanceLog modify sla_due_date DATETIME(6);
+
+alter table ProcessInstanceInfo modify lastModificationDate DATETIME(6);
+alter table ProcessInstanceInfo modify lastReadDate DATETIME(6);
+alter table ProcessInstanceInfo modify startDate DATETIME(6);
+
+alter table ProcessInstanceLog modify end_date DATETIME(6);
+alter table ProcessInstanceLog modify sla_due_date DATETIME(6);
+alter table ProcessInstanceLog modify start_date DATETIME(6);
+
+alter table RequestInfo modify timestamp DATETIME(6);
+
+alter table SessionInfo modify lastModificationDate DATETIME(6);
+alter table SessionInfo modify startDate DATETIME(6);
+
+alter table Task modify activationTime DATETIME(6);
+alter table Task modify createdOn DATETIME(6);
+alter table Task modify expirationTime DATETIME(6);
+
+alter table TaskEvent modify logTime DATETIME(6);
+
+alter table TaskVariableImpl modify modificationDate DATETIME(6);
+
+alter table VariableInstanceLog modify log_date DATETIME(6);
+
+alter table WorkItemInfo modify creationDate DATETIME(6);
+
+alter table task_comment modify addedAt DATETIME(6);
+
+alter table AuditTaskImpl add column end_date DATETIME(6);
+alter table BAMTaskSummary add column end_date DATETIME(6);
+alter table TaskEvent add column end_date DATETIME(6);
+alter table NodeInstanceLog add column end_date DATETIME(6);
+alter table VariableInstanceLog add column end_date DATETIME(6);
+
 create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 create index IDX_CaseRoleAssignLog_caseId on CaseRoleAssignmentLog(caseId);
 create index IDX_CaseRoleAssignLog_processInstanceId on CaseRoleAssignmentLog(processInstanceId);

--- a/jbpm-db-scripts/src/test/java/org/jbpm/persistence/scripts/DDLScriptsTest.java
+++ b/jbpm-db-scripts/src/test/java/org/jbpm/persistence/scripts/DDLScriptsTest.java
@@ -16,7 +16,6 @@
 
 package org.jbpm.persistence.scripts;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,19 +25,21 @@ import org.jbpm.test.persistence.scripts.PersistenceUnit;
 import org.jbpm.test.persistence.scripts.ScriptsBase;
 import org.jbpm.test.persistence.scripts.TestPersistenceContextBase;
 import org.jbpm.test.persistence.scripts.util.ScriptFilter;
+import org.jbpm.test.persistence.scripts.util.ScriptFilter.Filter;
 import org.jbpm.test.persistence.scripts.util.ScriptFilter.Option;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import static java.util.Arrays.asList;
 import static org.jbpm.persistence.scripts.TestPersistenceContext.createAndInitContext;
 import static org.jbpm.test.persistence.scripts.PersistenceUnit.DB_QUARTZ_VALIDATE;
 import static org.jbpm.test.persistence.scripts.PersistenceUnit.DB_TESTING_VALIDATE;
 import static org.jbpm.test.persistence.scripts.util.ScriptFilter.filter;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -56,7 +57,7 @@ public class DDLScriptsTest extends ScriptsBase {
 
         ScriptFilter[] sbPg = new ScriptFilter[]{filter("postgresql-springboot-jbpm-schema.sql",
                                                         "quartz_tables_postgres.sql").setSupportedDatabase(DatabaseType.POSTGRESQL)
-                                                                                     .setOptions(Option.DISALLOW_EMTPY_RESULTS, Option.THROW_ON_SCRIPT_ERROR),
+                                                                                     .setOptions(Option.DISALLOW_EMPTY_RESULTS, Option.THROW_ON_SCRIPT_ERROR),
                                                  filter("postgresql-springboot-jbpm-drop-schema.sql",
                                                         "quartz_tables_drop_postgres.sql")};
 
@@ -64,7 +65,7 @@ public class DDLScriptsTest extends ScriptsBase {
         ScriptFilter[] pqlBytea = new ScriptFilter[]{filter("postgresql-bytea-jbpm-schema.sql",
                                                             "quartz_tables_postgres.sql")
                                                                  .setSupportedDatabase(DatabaseType.POSTGRESQL)
-                                                                                         .setOptions(Option.DISALLOW_EMTPY_RESULTS, Option.THROW_ON_SCRIPT_ERROR)
+                                                                                         .setOptions(Option.DISALLOW_EMPTY_RESULTS, Option.THROW_ON_SCRIPT_ERROR)
                                                                                          .env("org.kie.persistence.postgresql.useBytea", "true"),
                                                      filter("postgresql-bytea-jbpm-drop-schema.sql",
                                                             "quartz_tables_drop_postgres.sql")};
@@ -72,18 +73,24 @@ public class DDLScriptsTest extends ScriptsBase {
         ScriptFilter[] pqlSpringBootBytea = new ScriptFilter[]{filter("postgresql-springboot-bytea-jbpm-schema.sql",
                                                                       "quartz_tables_postgres.sql")
                                                                            .setSupportedDatabase(DatabaseType.POSTGRESQL)
-                                                                                                   .setOptions(Option.DISALLOW_EMTPY_RESULTS, Option.THROW_ON_SCRIPT_ERROR)
+                                                                                                   .setOptions(Option.DISALLOW_EMPTY_RESULTS, Option.THROW_ON_SCRIPT_ERROR)
                                                                                                    .env("org.kie.persistence.postgresql.useBytea", "true"),
                                                                filter("postgresql-springboot-bytea-jbpm-drop-schema.sql",
                                                                       "quartz_tables_drop_postgres.sql")};
 
         ScriptFilter[] sbOracle = new ScriptFilter[]{filter("oracle-springboot-jbpm-schema.sql",
                                                             "quartz_tables_oracle.sql").setSupportedDatabase(DatabaseType.ORACLE)
-                                                                                       .setOptions(Option.DISALLOW_EMTPY_RESULTS, Option.THROW_ON_SCRIPT_ERROR),
+                                                                                       .setOptions(Option.DISALLOW_EMPTY_RESULTS, Option.THROW_ON_SCRIPT_ERROR),
                                                      filter("oracle-springboot-jbpm-drop-schema.sql",
                                                             "quartz_tables_drop_oracle.sql")};
 
-        return Arrays.asList(standard, sbPg, pqlBytea, pqlSpringBootBytea, sbOracle);
+        ScriptFilter[] taskAssigningTables = new ScriptFilter[]{filter(Filter.OUT, "drop", "bytea", "springboot")
+                                                                .setOptions(Option.DISALLOW_EMPTY_RESULTS, Option.THROW_ON_SCRIPT_ERROR),
+                                                                filter("jbpm-drop-schema.sql",
+                                                                       "quartz_tables_drop_",
+                                                                       "task_assigning_tables_drop_")};
+
+        return asList(standard, sbPg, pqlBytea, pqlSpringBootBytea, sbOracle, taskAssigningTables);
     }
 
     private ScriptFilter createScript;
@@ -99,7 +106,7 @@ public class DDLScriptsTest extends ScriptsBase {
     @Before
     public void prepare() {
         oldEnvironment = new HashMap<>();
-        Map<String, Object> newEnvironment = createScript.getEnvironent();
+        Map<String, Object> newEnvironment = createScript.getEnvironment();
         for (Map.Entry<String, Object> entry : newEnvironment.entrySet()) {
             oldEnvironment.put(entry.getKey(), System.getProperty(entry.getKey()));
             System.setProperty(entry.getKey(), (String) entry.getValue());
@@ -135,7 +142,7 @@ public class DDLScriptsTest extends ScriptsBase {
         final TestPersistenceContext dbTestingContext = createAndInitContext(DB_TESTING_VALIDATE);
         try {
             dbTestingContext.startAndPersistSomeProcess(TEST_PROCESS_ID);
-            Assert.assertTrue(dbTestingContext.getStoredProcessesCount() == 1);
+            assertEquals(1, dbTestingContext.getStoredProcessesCount());
         } finally {
             dbTestingContext.clean();
         }

--- a/jbpm-db-scripts/src/test/java/org/jbpm/persistence/scripts/UpgradeScriptsTest.java
+++ b/jbpm-db-scripts/src/test/java/org/jbpm/persistence/scripts/UpgradeScriptsTest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.text.ParseException;
-import java.util.Arrays;
 import java.util.Collection;
 
 import org.jbpm.test.persistence.scripts.DatabaseType;
@@ -39,9 +38,13 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.util.Arrays.asList;
 import static org.jbpm.persistence.scripts.TestPersistenceContext.createAndInitContext;
 import static org.jbpm.test.persistence.scripts.DatabaseType.DB2;
 import static org.jbpm.test.persistence.scripts.DatabaseType.SYBASE;
+import static org.jbpm.test.persistence.scripts.util.ScriptFilter.filter;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -59,7 +62,7 @@ public class UpgradeScriptsTest extends ScriptsBase {
 
     @Parameters(name = "{0}")
     static public Collection<Object> distributionTypes() {
-        return Arrays.asList(DistributionType.COMMUNITY, DistributionType.PRODUCT);
+        return asList(DistributionType.COMMUNITY, DistributionType.PRODUCT);
     }
 
     private DistributionType distributionType;
@@ -105,11 +108,39 @@ public class UpgradeScriptsTest extends ScriptsBase {
         }
     }
 
+    /**
+     * Tests that DB schema is upgraded properly using database task_assigning_tables upgrade scripts.
+     * @throws IOException
+     * @throws SQLException
+     */
+    @Test
+    public void testTaskAssigningScripts() throws IOException, SQLException {
+        logger.info("entering testTaskAssigningScripts with type: {} ", distributionType);
+        try {
+            createSchema60UsingDDLs();
+            // We need to create optional table "PlanningTask" beforehand
+            ScriptFilter taskAssigningTable = filter("task_assigning_tables_")
+                                                .exclude("drop")
+                                                .setOptions(ScriptFilter.Option.DISALLOW_EMPTY_RESULTS, ScriptFilter.Option.THROW_ON_SCRIPT_ERROR);
+            executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, taskAssigningTable);
+            executeScriptRunner(DB_UPGRADE_SCRIPTS_RESOURCE_PATH, ScriptFilter.init(false, true).setDistribution(distributionType));
+            ScriptFilter scriptFilter = filter("task_assigning_tables.sql").
+                                        setDistribution(distributionType).
+                                        setOptions(ScriptFilter.Option.THROW_ON_SCRIPT_ERROR);
+            executeScriptRunner(DB_UPGRADE_SCRIPTS_RESOURCE_PATH, scriptFilter);
+            startAndPersistSomeProcess();
+        } finally {
+            dropFinalSchemaAfterUpgradingUsingDDLs();
+            // Drop optional table "PlanningTask" if exists
+            executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, filter("task_assigning_tables_drop_"));
+        }
+    }
+
     private void startAndPersistSomeProcess() {
         final TestPersistenceContext dbTestingContext = createAndInitContext(PersistenceUnit.DB_TESTING_VALIDATE);
         try {
             dbTestingContext.startAndPersistSomeProcess(TEST_PROCESS_ID);
-            Assert.assertTrue(dbTestingContext.getStoredProcessesCount() == 1);
+            assertEquals(1, dbTestingContext.getStoredProcessesCount());
         } finally {
             dbTestingContext.clean();
         }
@@ -122,8 +153,7 @@ public class UpgradeScriptsTest extends ScriptsBase {
      * @throws SQLException
      */
     @Test
-
-    public void testPersistedProcess() throws IOException, ParseException, SQLException {
+    public void testPersistedProcess() throws IOException, SQLException {
         logger.debug("entering testPersistedProcess with type: {}", distributionType);
         try {
             createSchema60UsingDDLs();
@@ -151,29 +181,29 @@ public class UpgradeScriptsTest extends ScriptsBase {
         final TestPersistenceContext dbTestingContext = new TestPersistenceContext();
         dbTestingContext.init(PersistenceUnit.DB_TESTING_VALIDATE);
         try {
-            Assert.assertTrue(dbTestingContext.getStoredProcessesCount() == 1);
-            Assert.assertTrue(dbTestingContext.getStoredSessionsCount() == 1);
+            assertEquals(1, dbTestingContext.getStoredProcessesCount());
+            assertEquals(1, dbTestingContext.getStoredSessionsCount());
 
             final StatefulKnowledgeSession persistedSession = dbTestingContext.loadPersistedSession(
                     TEST_SESSION_ID.longValue(), TEST_PROCESS_ID);
-            Assert.assertNotNull(persistedSession);
+            assertNotNull(persistedSession);
 
             // Start another process.
             persistedSession.startProcess(TEST_PROCESS_ID);
-            Assert.assertTrue(dbTestingContext.getStoredProcessesCount() == 2);
+            assertEquals(2, dbTestingContext.getStoredProcessesCount());
 
             // Load old process instance.
             ProcessInstance processInstance = persistedSession.getProcessInstance(TEST_PROCESS_INSTANCE_ID);
-            Assert.assertNotNull(processInstance);
+            assertNotNull(processInstance);
 
             persistedSession.signalEvent("test", null);
             processInstance = persistedSession.getProcessInstance(TEST_PROCESS_INSTANCE_ID);
             Assert.assertNull(processInstance);
-            Assert.assertTrue(dbTestingContext.getStoredProcessesCount() == 0);
+            assertEquals(0, dbTestingContext.getStoredProcessesCount());
 
             persistedSession.dispose();
             persistedSession.destroy();
-            Assert.assertTrue(dbTestingContext.getStoredSessionsCount() == 0);
+            assertEquals(0, dbTestingContext.getStoredSessionsCount());
         } finally {
             dbTestingContext.clean();
         }

--- a/jbpm-test-util/src/main/java/org/jbpm/test/persistence/scripts/ScriptsBase.java
+++ b/jbpm-test-util/src/main/java/org/jbpm/test/persistence/scripts/ScriptsBase.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.jbpm.test.persistence.scripts.TestPersistenceContextBase.createAndInitContext;
+import static org.jbpm.test.persistence.scripts.util.ScriptFilter.filter;
 
 public class ScriptsBase {
 
@@ -56,6 +57,8 @@ public class ScriptsBase {
         logger.info("Running with Hibernate " + org.hibernate.Version.getVersionString());
         TestsUtil.clearSchema();
         executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, ScriptFilter.init(false, false));
+        // Drop optional table "PlanningTask" if exists
+        executeScriptRunner(DB_DDL_SCRIPTS_RESOURCE_PATH, filter("task_assigning_tables_drop_"));
     }
 
     public static void executeScriptRunner(String resourcePath, ScriptFilter scriptFilter) throws IOException, SQLException {

--- a/jbpm-test-util/src/main/java/org/jbpm/test/persistence/scripts/TestPersistenceContextBase.java
+++ b/jbpm-test-util/src/main/java/org/jbpm/test/persistence/scripts/TestPersistenceContextBase.java
@@ -141,7 +141,7 @@ public class TestPersistenceContextBase {
     public void executeScripts(final File scriptsRootFolder, ScriptFilter scriptFilter,
                                DataSource dataSource, String defaultSchema) throws IOException, SQLException {
         final File[] sqlScripts = TestsUtil.getDDLScriptFilesByDatabaseType(scriptsRootFolder, databaseType, scriptFilter);
-        if (sqlScripts.length == 0 && scriptFilter.hasOption(Option.DISALLOW_EMTPY_RESULTS)) {
+        if (sqlScripts.length == 0 && scriptFilter.hasOption(Option.DISALLOW_EMPTY_RESULTS)) {
             throw new RuntimeException("No create sql files found for db type "
                                                + databaseType + " in folder " + scriptsRootFolder.getAbsolutePath());
         }


### PR DESCRIPTION
**[JBPM-9746](https://issues.redhat.com/browse/JBPM-9746)**: Precision time (milliseconds) for datime columns should be taken into account for MySQL and MariaDB