### PR TITLE
[JBPM-9771] The STATEFULL_TYPE value in AbstractRuleTaskHandler is different from the accepted value in the "https://www.drools.org/xsd/kmodule_7_1.xsd"

### DIFF
--- a/jbpm-workitems/jbpm-workitems-bpmn2/src/main/java/org/jbpm/process/workitem/bpmn2/AbstractRuleTaskHandler.java
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/src/main/java/org/jbpm/process/workitem/bpmn2/AbstractRuleTaskHandler.java
@@ -89,6 +89,7 @@ public abstract class AbstractRuleTaskHandler extends AbstractLogOrThrowWorkItem
 
     protected static final String STATELESS_TYPE = "stateless";
     protected static final String STATEFULL_TYPE = "statefull";
+    protected static final String STATEFUL_TYPE = "stateful";
 
     protected static final String DRL_LANG = "DRL";
     protected static final String DMN_LANG = "DMN";
@@ -165,7 +166,8 @@ public abstract class AbstractRuleTaskHandler extends AbstractLogOrThrowWorkItem
             logger.debug("Facts to be inserted into working memory {}",
                          parameters);
             if (DRL_LANG.equalsIgnoreCase(language)) {
-                if (STATEFULL_TYPE.equalsIgnoreCase(kieSessionType)) {
+                if (STATEFULL_TYPE.equalsIgnoreCase(kieSessionType) || 
+                    STATEFUL_TYPE.equalsIgnoreCase(kieSessionType)) {
                     handleStatefull(workItem,
                                     kieSessionName,
                                     parameters,


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/JBPM-9771