### PR TITLE
[JBPM-9786] Add REST Endpoint for claiming tasks in bulk

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/UserTaskServiceImpl.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/UserTaskServiceImpl.java
@@ -17,6 +17,7 @@
 package org.jbpm.kie.services.impl;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -192,6 +193,17 @@ public class UserTaskServiceImpl implements UserTaskService, VariablesAware {
 		}
 
 	}
+
+    @Override
+    public void claim(String deploymentId, Collection<Long> taskIds, String userId) {
+        taskIds.forEach(taskId -> {
+            try {
+                claim(deploymentId, taskId, userId);
+            } catch (TaskNotFoundException | PermissionDeniedException e) {
+                logger.warn("Problem claiming task id {}", taskId, e);
+            }
+        });
+    }
 
 	@Override
     public void complete(Long taskId, String userId, Map<String, Object> params) {
@@ -719,7 +731,7 @@ public class UserTaskServiceImpl implements UserTaskService, VariablesAware {
 		try {
 			TaskService taskService = engine.getTaskService();
 			// perform actual operation
-            return ((InternalTaskService) taskService).addContentFromUser(taskId, userId, (Map<String, Object>) values);
+            return ((InternalTaskService) taskService).addContentFromUser(taskId, userId, values);
 		} finally {
 			disposeRuntimeEngine(manager, engine);
 		}

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/UserTaskServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/UserTaskServiceImplTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -184,6 +185,28 @@ private static final Logger logger = LoggerFactory.getLogger(KModuleDeploymentSe
     	task = runtimeDataService.getTaskById(taskId);
     	assertNotNull(task);
     	assertEquals(Status.Reserved.toString(), task.getStatus());
+    }
+    
+    
+    @Test
+    public void testReleaseAndBulkClaim() {
+        processInstanceId = processService.startProcess(deploymentUnit.getIdentifier(), "org.jbpm.writedocument");
+        assertNotNull(processInstanceId);
+        List<Long> taskIds = runtimeDataService.getTasksByProcessInstanceId(processInstanceId);
+        assertNotNull(taskIds);
+        assertEquals(1, taskIds.size());
+        
+        Long taskId = taskIds.get(0);
+        
+        userTaskService.release(taskId, "salaboy");
+        UserTaskInstanceDesc task = runtimeDataService.getTaskById(taskId);
+        assertNotNull(task);
+        assertEquals(Status.Ready.toString(), task.getStatus());
+        
+        userTaskService.claim(null, Collections.singletonList(taskId), "salaboy");
+        task = runtimeDataService.getTaskById(taskId);
+        assertNotNull(task);
+        assertEquals(Status.Reserved.toString(), task.getStatus());
     }
     
     @Test

--- a/jbpm-services/jbpm-services-api/src/build/revapi-config.json
+++ b/jbpm-services/jbpm-services-api/src/build/revapi-config.json
@@ -26,6 +26,15 @@
                     "methodName": "getTagsInfo",
                     "elementKind": "method",
                     "justification": "[AF-2811] Required Process Variable Tags shouldn't be accepted in forms when empty"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method void org.jbpm.services.api.UserTaskService::claim(java.lang.String, java.util.Collection<java.lang.Long>, java.lang.String)",
+                    "package": "org.jbpm.services.api",
+                    "classSimpleName": "UserTaskService",
+                    "methodName": "claim",
+                    "elementKind": "method",
+                    "justification": "https://issues.redhat.com/browse/JBPM-9786"
                 }
             ]
         }

--- a/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/UserTaskService.java
+++ b/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/UserTaskService.java
@@ -16,6 +16,7 @@
 
 package org.jbpm.services.api;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -60,7 +61,16 @@ public interface UserTaskService {
 	 */
 	void claim(Long taskId, String userId);
 	
-	/**
+    /**
+     * Claim responsibility for a list of tasks, i.e. set the tasks to status Reserved
+     * 
+     * @param deploymentId
+     * @param taskIds list of task to be claimed 
+     * @param userId
+     */
+    void claim(String deploymentId, Collection<Long> taskIds, String userId);
+
+    /**
      * Claim responsibility for a task, i.e. set the task to status Reserved
      * 
      * @param deploymentId


### PR DESCRIPTION
Bulk method implementation.
I followed the same approach that was used for other bulk methods,
meaning that any not id found exception is ignored.

**JIRA**: 

[link](https://issues.redhat.com/browse/JBPM-9786)

**referenced Pull Requests**: 
https://github.com/kiegroup/droolsjbpm-integration/pull/2518