### PR TITLE
[JBPM-9790] Enable Task audit on task admin operations

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/admin/commands/AddPeopleAssignmentsCommand.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/admin/commands/AddPeopleAssignmentsCommand.java
@@ -16,6 +16,9 @@
 
 package org.jbpm.kie.services.impl.admin.commands;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.jbpm.services.task.commands.TaskContext;
 import org.jbpm.services.task.commands.UserGroupCallbackTaskCommand;
 import org.jbpm.services.task.events.TaskEventSupport;
@@ -26,10 +29,9 @@ import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.Task;
 import org.kie.internal.task.api.model.InternalPeopleAssignments;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static org.jbpm.kie.services.impl.admin.UserTaskAdminServiceImpl.*;
+import static org.jbpm.kie.services.impl.admin.UserTaskAdminServiceImpl.ADMIN;
+import static org.jbpm.kie.services.impl.admin.UserTaskAdminServiceImpl.EXCL_OWNER;
+import static org.jbpm.kie.services.impl.admin.UserTaskAdminServiceImpl.POT_OWNER;
 
 
 public class AddPeopleAssignmentsCommand extends UserGroupCallbackTaskCommand<Void> {
@@ -91,6 +93,7 @@ public class AddPeopleAssignmentsCommand extends UserGroupCallbackTaskCommand<Vo
         }
         taskEventSupport.fireBeforeTaskAssignmentsAddedEvent(task, context, assignmentType, entityList);
         doCallbackOperationForPeopleAssignments(((InternalPeopleAssignments)task.getPeopleAssignments()), context);
+        context.getPersistenceContext().updateTask(task);
         taskEventSupport.fireAfterTaskAssignmentsAddedEvent(task, context, assignmentType, entityList);
         return null;
     }

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/admin/commands/RemovePeopleAssignmentsCommand.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/admin/commands/RemovePeopleAssignmentsCommand.java
@@ -16,6 +16,9 @@
 
 package org.jbpm.kie.services.impl.admin.commands;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.jbpm.services.task.commands.TaskContext;
 import org.jbpm.services.task.commands.UserGroupCallbackTaskCommand;
 import org.jbpm.services.task.events.TaskEventSupport;
@@ -26,10 +29,9 @@ import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.Task;
 import org.kie.internal.task.api.model.InternalPeopleAssignments;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static org.jbpm.kie.services.impl.admin.UserTaskAdminServiceImpl.*;
+import static org.jbpm.kie.services.impl.admin.UserTaskAdminServiceImpl.ADMIN;
+import static org.jbpm.kie.services.impl.admin.UserTaskAdminServiceImpl.EXCL_OWNER;
+import static org.jbpm.kie.services.impl.admin.UserTaskAdminServiceImpl.POT_OWNER;
 
 
 public class RemovePeopleAssignmentsCommand extends UserGroupCallbackTaskCommand<Void> {
@@ -82,6 +84,7 @@ public class RemovePeopleAssignmentsCommand extends UserGroupCallbackTaskCommand
             default:
                 break;
         }
+        context.getPersistenceContext().updateTask(task);
         taskEventSupport.fireAfterTaskAssignmentsRemovedEvent(task, context, assignmentType, entityList);
         return null;
     }


### PR DESCRIPTION
Admin operations that modifies list of users now call event emitter. 

@elguardian  Contrary what the original test of the JIRA mention, TaskEvent is already updated. What is not there is the AuditTaskEvent. Should we add it too? 

**JIRA**: 

[link](https://issues.redhat.com/browse/JBPM-9790)
