### PR TITLE
[JBPM-9817] Adding IDX_TaskEvent_processInstance

### DIFF
--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/db2/db2-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/db2/db2-jbpm-schema.sql
@@ -768,6 +768,7 @@
     create index IDX_EventTypes_element ON EventTypes(element);
 
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+    create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
     create index IDX_CMI_Context ON ContextMappingInfo(CONTEXT_ID);    
     create index IDX_CMI_KSession ON ContextMappingInfo(KSESSION_ID);    

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/derby/derby-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/derby/derby-jbpm-schema.sql
@@ -767,6 +767,7 @@
     create index IDX_Task_workItemId on Task(workItemId);
 
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+    create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
     create index IDX_EventTypes_element ON EventTypes(element);
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/h2/h2-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/h2/h2-jbpm-schema.sql
@@ -769,6 +769,7 @@
     create index IDX_Task_workItemId on Task(workItemId);
 
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+    create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
     create index IDX_EventTypes_element ON EventTypes(element);
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/hsqldb/hsqldb-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/hsqldb/hsqldb-jbpm-schema.sql
@@ -770,6 +770,7 @@
     create index IDX_Task_workItemId on Task(workItemId);
 
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+    create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
     create index IDX_EventTypes_element ON EventTypes(element);
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
@@ -787,6 +787,7 @@
     create index IDX_Task_workItemId on Task(workItemId);
 
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+    create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
     create index IDX_EventTypes_element ON EventTypes(element);
     create index IDX_EventTypes_compound ON EventTypes(InstanceId, element);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysqlinnodb/mysql-innodb-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysqlinnodb/mysql-innodb-jbpm-schema.sql
@@ -790,6 +790,7 @@
     create index IDX_Task_workItemId on Task(workItemId);
 
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+    create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
     create index IDX_EventTypes_element ON EventTypes(element);
     create index IDX_EventTypes_compound ON EventTypes(InstanceId, element);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/oracle/oracle-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/oracle/oracle-jbpm-schema.sql
@@ -835,6 +835,7 @@
     create index IDX_Task_workItemId on Task(workItemId);
 
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+    create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
     create index IDX_EventTypes_element ON EventTypes(element);
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/oracle/oracle-springboot-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/oracle/oracle-springboot-jbpm-schema.sql
@@ -170,6 +170,7 @@ create index IDX_Task_workItemId on Task (workItemId);
 create index IDX_TaskComments_CreatedBy on task_comment (addedBy_id);
 create index IDX_TaskComments_Id on task_comment (TaskData_Comments_Id);
 create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 create index IDX_TaskVariableImpl_taskId on TaskVariableImpl (taskId);
 create index IDX_TaskVariableImpl_pInstId on TaskVariableImpl (processInstanceId);
 create index IDX_TaskVariableImpl_processId on TaskVariableImpl (processId);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-bytea-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-bytea-jbpm-schema.sql
@@ -170,6 +170,7 @@ create index IDX_Task_workItemId on Task (workItemId);
 create index IDX_TaskComments_CreatedBy on task_comment (addedBy_id);
 create index IDX_TaskComments_Id on task_comment (TaskData_Comments_Id);
 create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 create index IDX_TaskVariableImpl_taskId on TaskVariableImpl (taskId);
 create index IDX_TaskVariableImpl_pInstId on TaskVariableImpl (processInstanceId);
 create index IDX_TaskVariableImpl_processId on TaskVariableImpl (processId);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-jbpm-schema.sql
@@ -836,6 +836,7 @@
     create index IDX_Task_workItemId on Task(workItemId);
 
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+    create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
     create index IDX_EventTypes_element ON EventTypes(element);
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-springboot-bytea-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-springboot-bytea-jbpm-schema.sql
@@ -170,6 +170,7 @@ create index IDX_Task_workItemId on Task (workItemId);
 create index IDX_TaskComments_CreatedBy on task_comment (addedBy_id);
 create index IDX_TaskComments_Id on task_comment (TaskData_Comments_Id);
 create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 create index IDX_TaskVariableImpl_taskId on TaskVariableImpl (taskId);
 create index IDX_TaskVariableImpl_pInstId on TaskVariableImpl (processInstanceId);
 create index IDX_TaskVariableImpl_processId on TaskVariableImpl (processId);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-springboot-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-springboot-jbpm-schema.sql
@@ -170,6 +170,7 @@ create index IDX_Task_workItemId on Task (workItemId);
 create index IDX_TaskComments_CreatedBy on task_comment (addedBy_id);
 create index IDX_TaskComments_Id on task_comment (TaskData_Comments_Id);
 create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 create index IDX_TaskVariableImpl_taskId on TaskVariableImpl (taskId);
 create index IDX_TaskVariableImpl_pInstId on TaskVariableImpl (processInstanceId);
 create index IDX_TaskVariableImpl_processId on TaskVariableImpl (processId);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver/sqlserver-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver/sqlserver-jbpm-schema.sql
@@ -770,6 +770,7 @@
     create index IDX_Task_workItemId on Task(workItemId);
 
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+    create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
     create index IDX_EventTypes_element ON EventTypes(element);
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver2008/sqlserver2008-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver2008/sqlserver2008-jbpm-schema.sql
@@ -770,6 +770,7 @@
     create index IDX_Task_workItemId on Task(workItemId);
 
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
+    create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
     create index IDX_EventTypes_element ON EventTypes(element);
 

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sybase/sybase-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sybase/sybase-jbpm-schema.sql
@@ -914,6 +914,9 @@
     create index IDX_TaskEvent_taskId on TaskEvent (taskId)
     go
 
+    create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId)
+    go
+
     create index IDX_EventTypes_element ON EventTypes(element)
     go
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/db2/jbpm-7.56-to-7.57.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/db2/jbpm-7.56-to-7.57.sql
@@ -3,5 +3,5 @@ alter table BAMTaskSummary add column end_date timestamp;
 alter table TaskEvent add column end_date timestamp;
 alter table NodeInstanceLog add column end_date timestamp;
 alter table VariableInstanceLog add column end_date timestamp;
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/db2/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/db2/rhpam-7.11-to-7.12.sql
@@ -3,5 +3,6 @@ alter table BAMTaskSummary add column end_date timestamp;
 alter table TaskEvent add column end_date timestamp;
 alter table NodeInstanceLog add column end_date timestamp;
 alter table VariableInstanceLog add column end_date timestamp;
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/jbpm-7.56-to-7.57.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/jbpm-7.56-to-7.57.sql
@@ -3,5 +3,5 @@ alter table BAMTaskSummary add column end_date timestamp;
 alter table TaskEvent add column end_date timestamp;
 alter table NodeInstanceLog add column end_date timestamp;
 alter table VariableInstanceLog add column end_date timestamp;
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/rhpam-7.11-to-7.12.sql
@@ -3,5 +3,6 @@ alter table BAMTaskSummary add column end_date timestamp;
 alter table TaskEvent add column end_date timestamp;
 alter table NodeInstanceLog add column end_date timestamp;
 alter table VariableInstanceLog add column end_date timestamp;
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/jbpm-7.56-to-7.57.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/jbpm-7.56-to-7.57.sql
@@ -3,5 +3,5 @@ alter table BAMTaskSummary add column end_date timestamp;
 alter table TaskEvent add column end_date timestamp;
 alter table NodeInstanceLog add column end_date timestamp;
 alter table VariableInstanceLog add column end_date timestamp;
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/rhpam-7.11-to-7.12.sql
@@ -3,5 +3,6 @@ alter table BAMTaskSummary add column end_date timestamp;
 alter table TaskEvent add column end_date timestamp;
 alter table NodeInstanceLog add column end_date timestamp;
 alter table VariableInstanceLog add column end_date timestamp;
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/jbpm-7.56-to-7.57.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/jbpm-7.56-to-7.57.sql
@@ -3,5 +3,4 @@ alter table BAMTaskSummary add column end_date timestamp;
 alter table TaskEvent add column end_date timestamp;
 alter table NodeInstanceLog add column end_date timestamp;
 alter table VariableInstanceLog add column end_date timestamp;
-
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/rhpam-7.11-to-7.12.sql
@@ -3,5 +3,4 @@ alter table BAMTaskSummary add column end_date timestamp;
 alter table TaskEvent add column end_date timestamp;
 alter table NodeInstanceLog add column end_date timestamp;
 alter table VariableInstanceLog add column end_date timestamp;
-
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/jbpm-7.56-to-7.57.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/jbpm-7.56-to-7.57.sql
@@ -3,5 +3,4 @@ alter table BAMTaskSummary add column end_date datetime;
 alter table TaskEvent add column end_date datetime;
 alter table NodeInstanceLog add column end_date datetime;
 alter table VariableInstanceLog add column end_date datetime;
-
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/rhpam-7.11-to-7.12.sql
@@ -3,5 +3,4 @@ alter table BAMTaskSummary add column end_date datetime;
 alter table TaskEvent add column end_date datetime;
 alter table NodeInstanceLog add column end_date datetime;
 alter table VariableInstanceLog add column end_date datetime;
-
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/jbpm-7.56-to-7.57.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/jbpm-7.56-to-7.57.sql
@@ -3,5 +3,4 @@ alter table BAMTaskSummary add column end_date datetime;
 alter table TaskEvent add column end_date datetime;
 alter table NodeInstanceLog add column end_date datetime;
 alter table VariableInstanceLog add column end_date datetime;
-
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/rhpam-7.11-to-7.12.sql
@@ -3,5 +3,4 @@ alter table BAMTaskSummary add column end_date datetime;
 alter table TaskEvent add column end_date datetime;
 alter table NodeInstanceLog add column end_date datetime;
 alter table VariableInstanceLog add column end_date datetime;
-
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/jbpm-7.56-to-7.57.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/jbpm-7.56-to-7.57.sql
@@ -3,5 +3,5 @@ alter table BAMTaskSummary add end_date timestamp;
 alter table TaskEvent add end_date timestamp;
 alter table NodeInstanceLog add end_date timestamp;
 alter table VariableInstanceLog add end_date timestamp;
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/rhpam-7.11-to-7.12.sql
@@ -3,5 +3,5 @@ alter table BAMTaskSummary add end_date timestamp;
 alter table TaskEvent add end_date timestamp;
 alter table NodeInstanceLog add end_date timestamp;
 alter table VariableInstanceLog add end_date timestamp;
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/jbpm-7.56-to-7.57.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/jbpm-7.56-to-7.57.sql
@@ -3,5 +3,5 @@ alter table BAMTaskSummary add column end_date timestamp;
 alter table TaskEvent add column end_date timestamp;
 alter table NodeInstanceLog add column end_date timestamp;
 alter table VariableInstanceLog add column end_date timestamp;
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/rhpam-7.11-to-7.12.sql
@@ -3,5 +3,6 @@ alter table BAMTaskSummary add column end_date timestamp;
 alter table TaskEvent add column end_date timestamp;
 alter table NodeInstanceLog add column end_date timestamp;
 alter table VariableInstanceLog add column end_date timestamp;
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/jbpm-7.56-to-7.57.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/jbpm-7.56-to-7.57.sql
@@ -3,5 +3,7 @@ alter table BAMTaskSummary add end_date datetime;
 alter table TaskEvent add end_date datetime;
 alter table NodeInstanceLog add end_date datetime;
 alter table VariableInstanceLog add end_date datetime;
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
+
 
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/rhpam-7.11-to-7.12.sql
@@ -3,5 +3,7 @@ alter table BAMTaskSummary add end_date datetime;
 alter table TaskEvent add end_date datetime;
 alter table NodeInstanceLog add end_date datetime;
 alter table VariableInstanceLog add end_date datetime;
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
+
 
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/jbpm-7.56-to-7.57.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/jbpm-7.56-to-7.57.sql
@@ -3,5 +3,5 @@ alter table BAMTaskSummary add end_date datetime;
 alter table TaskEvent add end_date datetime;
 alter table NodeInstanceLog add end_date datetime;
 alter table VariableInstanceLog add end_date datetime;
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/rhpam-7.11-to-7.12.sql
@@ -3,5 +3,6 @@ alter table BAMTaskSummary add end_date datetime;
 alter table TaskEvent add end_date datetime;
 alter table NodeInstanceLog add end_date datetime;
 alter table VariableInstanceLog add end_date datetime;
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/jbpm-7.56-to-7.57.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/jbpm-7.56-to-7.57.sql
@@ -8,5 +8,6 @@ alter table NodeInstanceLog add column end_date datetime
 go
 alter table VariableInstanceLog add column end_date datetime
 go
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId)
+go
 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/rhpam-7.11-to-7.12.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/rhpam-7.11-to-7.12.sql
@@ -8,5 +8,6 @@ alter table NodeInstanceLog add column end_date datetime
 go
 alter table VariableInstanceLog add column end_date datetime
 go
-
+create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId)
+go
 

--- a/jbpm-human-task/jbpm-human-task-audit/src/main/java/org/jbpm/services/task/audit/impl/model/TaskEventImpl.java
+++ b/jbpm-human-task/jbpm-human-task-audit/src/main/java/org/jbpm/services/task/audit/impl/model/TaskEventImpl.java
@@ -44,7 +44,7 @@ import org.kie.internal.task.api.model.TaskEvent;
  *
  */
 @Entity
-@Table(name = "TaskEvent", indexes = {@Index(name = "IDX_TaskEvent_taskId", columnList = "taskId")})
+@Table(name = "TaskEvent", indexes = {@Index(name = "IDX_TaskEvent_taskId", columnList = "taskId"), @Index(name = "IDX_AuditTaskImpl_pInstId", columnList = "processInstanceId")})
 @SequenceGenerator(name = "taskEventIdSeq", sequenceName = "TASK_EVENT_ID_SEQ")
 public class TaskEventImpl implements TaskEvent, Serializable {
 


### PR DESCRIPTION
Adding IDX_TaskEvent_processInstance to db schema and the TaskEvent class definition to showcase preventing sequential scan resulting in timeout in JBPM performance tests
**JIRA**: [link](https://issues.redhat.com/browse/JBPM-9817)