### PR TITLE
[JBPM-9738] Adding support for headers in WebServiceWorkItemHandler

### DIFF
--- a/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WorkItemHeaderInfo.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WorkItemHeaderInfo.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.core.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class WorkItemHeaderInfo {
+
+    private final String name;
+    private final Object content;
+    private final Map<String, Object> params;
+
+    public static class Builder {
+
+        private final String name;
+        private Object content;
+        private Map<String, Object> parameters;
+
+        private Builder(String name) {
+            this.name = name;
+            this.parameters = new HashMap<>();
+        }
+
+        public static Builder of(String name) {
+            return new Builder(name);
+        }
+
+        public Builder withContent(Object content) {
+            this.content = content;
+            return this;
+        }
+
+        public Builder withParam(String key, Object value) {
+            parameters.put(key, value);
+            return this;
+        }
+
+        public WorkItemHeaderInfo build() {
+            return new WorkItemHeaderInfo(name, content, parameters);
+        }
+    }
+
+    private WorkItemHeaderInfo(String name, Object content, Map<String, Object> params) {
+        this.name = name;
+        this.content = content;
+        this.params = params;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Object getContent() {
+        return content;
+    }
+
+    public Object getParam(String key) {
+        return params.get(key);
+    }
+
+    @Override
+    public String toString() {
+        return "WorkItemHeaderInfo [name=" + name + ", content=" + content + ", params=" + params + "]";
+    }
+}

--- a/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WorkItemHeaderUtils.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/main/java/org/jbpm/process/workitem/core/util/WorkItemHeaderUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.core.util;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import org.jbpm.process.workitem.core.util.WorkItemHeaderInfo.Builder;
+import org.kie.api.runtime.process.WorkItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WorkItemHeaderUtils {
+
+    private WorkItemHeaderUtils() {}
+
+    private static final String CONTENT_PREFIX = "HEADER_";
+    private static final String PARAM_PREFIX = "HEADER_PARAM_";
+    static final String SEPARATOR_PROP = "org.kie.workitem.ws.header.separator";
+
+    private static final Logger logger = LoggerFactory.getLogger(WorkItemHeaderUtils.class);
+
+    public static Collection<WorkItemHeaderInfo> getHeaderInfo(WorkItem workItem) {
+        final String separator = System.getProperty(SEPARATOR_PROP, "_");
+        Map<String, WorkItemHeaderInfo.Builder> map = new HashMap<>();
+        for (Entry<String, Object> param : workItem.getParameters().entrySet()) {
+            String key = param.getKey().toUpperCase();
+            if (key.startsWith(PARAM_PREFIX)) {
+                key = param.getKey().substring(PARAM_PREFIX.length());
+                int indexOf = key.indexOf(separator);
+                if (indexOf != -1) {
+                    map.computeIfAbsent(key.substring(indexOf + separator.length()), Builder::of)
+                       .withParam(key.substring(0, indexOf), param.getValue());
+                } else {
+                    logger.warn("Wrong parameter name {}. It expects at least one {} in {}", param.getKey(), separator,
+                                key);
+                }
+            } else if (key.startsWith(CONTENT_PREFIX)) {
+                map.computeIfAbsent(param.getKey().substring(CONTENT_PREFIX.length()), Builder::of)
+                   .withContent(param.getValue());
+            }
+        }
+        return map.values().stream().map(Builder::build).collect(Collectors.toList());
+    }
+
+}

--- a/jbpm-workitems/jbpm-workitems-core/src/test/java/org/jbpm/process/workitem/core/util/WorkItemHeaderUtilsTest.java
+++ b/jbpm-workitems/jbpm-workitems-core/src/test/java/org/jbpm/process/workitem/core/util/WorkItemHeaderUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.workitem.core.util;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.kie.api.runtime.process.WorkItem;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class WorkItemHeaderUtilsTest {
+
+	@Test
+	public void testBuildHeaderList() {
+		WorkItem workItem = mock(WorkItem.class);
+		Map<String, Object> map = new HashMap<>();
+		map.put("HEADER_Pepito_Grillo", "fulanito");
+		map.put("header_param_NS_Pepito_Grillo", "http://pepito.com");
+		map.put("mamotreco", "power");
+		when(workItem.getParameters()).thenReturn(map);
+		Collection<WorkItemHeaderInfo> headers = WorkItemHeaderUtils.getHeaderInfo(workItem);
+		assertEquals(1, headers.size());
+		WorkItemHeaderInfo header = headers.iterator().next();
+		assertEquals("Pepito_Grillo", header.getName());
+		assertEquals("fulanito", header.getContent());
+		assertEquals("http://pepito.com", header.getParam("NS"));
+	}
+
+	@Test
+	public void testBuildHeaderListWithCustomSeparator() {
+		System.setProperty(WorkItemHeaderUtils.SEPARATOR_PROP, "//");
+		try {
+			WorkItem workItem = mock(WorkItem.class);
+			Map<String, Object> map = new HashMap<>();
+			map.put("HEADER_Pepito_Grillo", "fulanito");
+			map.put("header_param_NS_232//Pepito_Grillo", "http://pepito.com");
+			map.put("mamotreco", "power");
+			when(workItem.getParameters()).thenReturn(map);
+			Collection<WorkItemHeaderInfo> headers = WorkItemHeaderUtils.getHeaderInfo(workItem);
+			assertEquals(1, headers.size());
+			WorkItemHeaderInfo header = headers.iterator().next();
+			assertEquals("Pepito_Grillo", header.getName());
+			assertEquals("fulanito", header.getContent());
+			assertEquals("http://pepito.com", header.getParam("NS_232"));
+		} finally {
+			System.clearProperty(WorkItemHeaderUtils.SEPARATOR_PROP);
+		}
+	}
+
+}

--- a/jbpm-workitems/jbpm-workitems-webservice/src/test/java/org/jbpm/process/workitem/webservice/WebServiceWorkItemHandlerTest.java
+++ b/jbpm-workitems/jbpm-workitems-webservice/src/test/java/org/jbpm/process/workitem/webservice/WebServiceWorkItemHandlerTest.java
@@ -16,6 +16,16 @@
 
 package org.jbpm.process.workitem.webservice;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -30,6 +40,7 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.transport.http.HTTPConduit;
 import org.drools.core.process.instance.impl.WorkItemImpl;
 import org.jbpm.process.workitem.core.TestWorkItemManager;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.runtime.KieSession;
@@ -37,16 +48,6 @@ import org.kie.api.runtime.process.ProcessWorkItemHandlerException;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class WebServiceWorkItemHandlerTest {
@@ -60,12 +61,15 @@ public class WebServiceWorkItemHandlerTest {
     @Mock
     ConcurrentHashMap<String, Client> clients;
 
+    @Before
+    public void setUp() {
+        when(clients.computeIfAbsent(any(), any())).thenReturn(client);
+    }
+
     @Test
     public void testExecuteSyncOperation() throws Exception {
 
-        when(clients.containsKey(any())).thenReturn(true);
-        when(clients.get(any())).thenReturn(client);
-
+   
         TestWorkItemManager manager = new TestWorkItemManager();
         WorkItemImpl workItem = new WorkItemImpl();
         workItem.setParameter("Interface",
@@ -91,8 +95,6 @@ public class WebServiceWorkItemHandlerTest {
     @Test
     public void testExecuteWrappedModeSync() throws Exception {
 
-        when(clients.containsKey(any())).thenReturn(true);
-        when(clients.get(any())).thenReturn(client);
         Endpoint endpoint = mock(Endpoint.class);
         when(client.getEndpoint()).thenReturn(endpoint);
         ArrayList<Interceptor<? extends Message>> interceptors = new ArrayList<>();
@@ -129,8 +131,6 @@ public class WebServiceWorkItemHandlerTest {
     @Test
     public void testExecuteWrappedModeOneWay() throws Exception {
 
-        when(clients.containsKey(any())).thenReturn(true);
-        when(clients.get(any())).thenReturn(client);
         Endpoint endpoint = mock(Endpoint.class);
         when(client.getEndpoint()).thenReturn(endpoint);
         ArrayList<Interceptor<? extends Message>> interceptors = new ArrayList<>();
@@ -164,8 +164,6 @@ public class WebServiceWorkItemHandlerTest {
     @Test
     public void testExecuteWrappedModeAsync() throws Exception {
 
-        when(clients.containsKey(any())).thenReturn(true);
-        when(clients.get(any())).thenReturn(client);
         Endpoint endpoint = mock(Endpoint.class);
         when(client.getEndpoint()).thenReturn(endpoint);
         ArrayList<Interceptor<? extends Message>> interceptors = new ArrayList<>();
@@ -202,8 +200,6 @@ public class WebServiceWorkItemHandlerTest {
         HTTPConduit http = Mockito.mock(HTTPConduit.class,
                                         Mockito.CALLS_REAL_METHODS);
 
-        when(clients.containsKey(any())).thenReturn(true);
-        when(clients.get(any())).thenReturn(client);
         when(client.getConduit()).thenReturn(http);
 
         TestWorkItemManager manager = new TestWorkItemManager();
@@ -241,10 +237,7 @@ public class WebServiceWorkItemHandlerTest {
     
     @Test
     public void testExecuteSyncOperationHandlingException() throws Exception {
-
-        when(clients.containsKey(any())).thenReturn(true);
-        when(clients.get(any())).thenReturn(null);
-
+        when(clients.computeIfAbsent(any(), any())).thenReturn(null);
         TestWorkItemManager manager = new TestWorkItemManager();
         WorkItemImpl workItem = new WorkItemImpl();
         workItem.setParameter("Interface",


### PR DESCRIPTION
Supporting `WebServiceWorkItemHandler` parameters of the form HEADER_xxxx and HEADER_xxxx_NS, where xxxx is the name of the header and value is the content and the namespace of the soap header to be added

**JIRA**: 

[link](https://issues.redhat.com/browse/JBPM-9738)

**referenced Pull Requests**: 
https://github.com/kiegroup/droolsjbpm-integration/pull/2566