### PR TITLE
 [BAPL-2054] Update MockProducer usage related to Kafka 2.8.0 upgrade

### DIFF
--- a/jbpm-event-emitters/jbpm-event-emitters-kafka/src/test/java/org/jbpm/event/emitters/kafka/KafkaEventEmitterTest.java
+++ b/jbpm-event-emitters/jbpm-event-emitters-kafka/src/test/java/org/jbpm/event/emitters/kafka/KafkaEventEmitterTest.java
@@ -36,6 +36,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.jbpm.persistence.api.integration.EventEmitter;
 import org.jbpm.persistence.api.integration.InstanceView;
 import org.jbpm.persistence.api.integration.model.CaseInstanceView;
@@ -57,7 +59,7 @@ public class KafkaEventEmitterTest {
 
     @Before
     public void setup() {
-        producer = new MockProducer<>();
+        producer = new MockProducer<>(false, new StringSerializer(), new ByteArraySerializer());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
**JIRA**:  [BAPL-2054](https://issues.redhat.com/browse/BAPL-2054)

Update Kafka to version 2.8.0

PRs:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1714
- https://github.com/kiegroup/droolsjbpm-integration/pull/2568
- https://github.com/kiegroup/jbpm/pull/1996

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
