### PR TITLE
[JBPM-9878] Missing jakarta dependency for jdk11 workitems-bpmn2 tests

### DIFF
--- a/jbpm-workitems/jbpm-workitems-bpmn2/pom.xml
+++ b/jbpm-workitems/jbpm-workitems-bpmn2/pom.xml
@@ -153,6 +153,11 @@
        <artifactId>jaxb-xjc</artifactId>
        <scope>test</scope>
     </dependency>
+    <dependency>
+       <groupId>com.sun.activation</groupId>
+       <artifactId>jakarta.activation</artifactId>
+       <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
**JIRA**:  [JBPM-9878](https://issues.redhat.com/browse/JBPM-9878)

