### PR TITLE
[JBPM-9902] RestServiceInvokeTest failing for Tomcat after migrating to jakarta

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
@@ -765,6 +765,14 @@
                       <groupId>org.jboss.logging</groupId>
                       <artifactId>jboss-logging</artifactId>
                     </dependency>
+                    <dependency>
+                      <groupId>jakarta.ws.rs</groupId>
+                      <artifactId>jakarta.ws.rs-api</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>jakarta.xml.bind</groupId>
+                      <artifactId>jakarta.xml.bind-api</artifactId>
+                    </dependency>
                   </dependencies>
                 </container>
                 <configuration>


### PR DESCRIPTION
**JIRA**: [JBPM-9902](https://issues.redhat.com/browse/JBPM-9902)

