### PR TITLE
JBPM-9910 - jbpm-container tests error on Tomcat after update to Wild…

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-integration-deps/rest/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-integration-deps/rest/pom.xml
@@ -25,6 +25,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+    </dependency>
     <!-- Replacement for above excluded 'commons-logging:commons-logging' -->
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
…Fly 23

**JIRA**: [JBPM-9910](https://issues.redhat.com/browse/JBPM-9910)

@gmunozfe FYI this will only apply for the RestServiceInvokeTest which is the only one deploying the RegisterRestService archive. And only that archive uses `rest` profile:

https://github.com/kiegroup/jbpm/blob/f0a53937a90c7be92c32503ea13c596c60b443a4/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/archive/RegisterRestService.java#L61

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
