### PR TITLE
[7.59.x] JBPM-9910 - jbpm-container tests error on Tomcat after update to Wild…

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-integration-deps/rest/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-integration-deps/rest/pom.xml
@@ -25,6 +25,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+    </dependency>
     <!-- Replacement for above excluded 'commons-logging:commons-logging' -->
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
…Fly 23

**JIRA**: **JIRA**: [JBPM-9910](https://issues.redhat.com/browse/JBPM-9910)

Backport of #2035 for 7.59.x.
<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
