### PR TITLE
[JBPM-9925] - DB scripts tests fail in drop statements

### DIFF
--- a/jbpm-test-util/src/main/java/org/jbpm/test/persistence/scripts/TestPersistenceContextBase.java
+++ b/jbpm-test-util/src/main/java/org/jbpm/test/persistence/scripts/TestPersistenceContextBase.java
@@ -158,9 +158,9 @@ public class TestPersistenceContextBase {
                     logger.debug("query {} ", command);
                     final PreparedStatement statement = preparedStatement(connection, command);
                     executeStatement(scriptFilter.hasOption(Option.THROW_ON_SCRIPT_ERROR), statement);
+                    connection.commit();
                 }
             }
-            connection.commit();
         } catch (SQLException ex) {
             connection.rollback();
             throw new RuntimeException(ex.getMessage(), ex);


### PR DESCRIPTION
**[JBPM-9925](https://issues.redhat.com/browse/JBPM-9925)**: DB scripts tests fail in drop statements

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
