### PR TITLE
[JBPM-9928] ProcessServiceImpl.getAvailableSignals should obtain ProcessInstance in read-only mode to avoid race condition

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/ProcessServiceImpl.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/ProcessServiceImpl.java
@@ -615,7 +615,7 @@ public class ProcessServiceImpl implements ProcessService, VariablesAware {
         RuntimeEngine engine = manager.getRuntimeEngine(ProcessInstanceIdContext.get(processInstanceId));
         try {
             KieSession ksession = engine.getKieSession();
-            ProcessInstance processInstance = ksession.getProcessInstance(processInstanceId);
+            ProcessInstance processInstance = ksession.getProcessInstance(processInstanceId, true);
             Collection<String> activeSignals = new ArrayList<>();
 
             if (processInstance != null) {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/JBPM-9928