### PR TITLE
[7.59.x] [JBPM-9920] Avoiding race condition between deployment and timer

### DIFF
--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/util/AbstractCaseServicesBaseTest.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/util/AbstractCaseServicesBaseTest.java
@@ -28,12 +28,11 @@ import org.jbpm.casemgmt.api.model.CaseStatus;
 import org.jbpm.casemgmt.api.model.instance.CaseInstance;
 import org.jbpm.casemgmt.api.model.instance.CommentInstance;
 import org.jbpm.casemgmt.impl.utils.DefaultCaseServiceConfigurator;
-import org.jbpm.runtime.manager.impl.jpa.EntityManagerFactoryManager;
 import org.jbpm.services.api.model.DeploymentUnit;
 import org.jbpm.test.services.AbstractCaseServicesTest;
-import org.kie.test.util.db.PoolingDataSourceWrapper;
 import org.kie.api.task.model.Status;
 import org.kie.api.task.model.TaskSummary;
+import org.kie.test.util.db.PoolingDataSourceWrapper;
 
 public abstract class AbstractCaseServicesBaseTest extends AbstractCaseServicesTest {
 
@@ -86,9 +85,7 @@ public abstract class AbstractCaseServicesBaseTest extends AbstractCaseServicesT
 
     protected void close() {
         DataSetCore.set(null);
-        caseConfigurator.close();
-        EntityManagerFactoryManager.get().clear();
-        closeDataSource();
+        super.close();
     }
 
     protected void prepareDocumentStorage() {

--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/AbstractEJBServicesTest.java
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/src/test/java/org/jbpm/test/container/AbstractEJBServicesTest.java
@@ -19,18 +19,20 @@ package org.jbpm.test.container;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.List;
+
 import javax.ejb.EJB;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
-import org.jbpm.test.container.archive.EJBService;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jbpm.services.api.model.DeploymentUnit;
 import org.jbpm.services.ejb.api.DeploymentServiceEJBLocal;
 import org.jbpm.services.ejb.api.RuntimeDataServiceEJBLocal;
+import org.jbpm.services.task.impl.TaskDeadlinesServiceImpl;
+import org.jbpm.test.container.archive.EJBService;
 import org.junit.After;
 import org.junit.Before;
 import org.slf4j.Logger;
@@ -95,6 +97,7 @@ public abstract class AbstractEJBServicesTest extends JbpmContainerTest {
                 new File(tempDir, file).delete();
             }
         }
+        TaskDeadlinesServiceImpl.dispose();
     }
  
     protected static Throwable catchRootCause(ThrowingCallable shouldRaiseThrowable) {

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/HumanTaskConfigurator.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/HumanTaskConfigurator.java
@@ -40,7 +40,6 @@ import org.kie.api.task.TaskService;
 import org.kie.api.task.UserGroupCallback;
 import org.kie.api.task.UserInfo;
 import org.kie.internal.task.api.EventService;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -160,11 +159,7 @@ public class HumanTaskConfigurator {
             if (AssignmentServiceProvider.get().isEnabled()) {
                 ((EventService<TaskLifeCycleEventListener>) service).registerTaskEventListener(new AssignmentTaskEventListener());
             }
-            
-            // initialize deadline service with command executor for processing
-            if (TaskDeadlinesServiceImpl.getInstance() == null) {
-            	TaskDeadlinesServiceImpl.initialize(commandExecutor);
-            }
+            TaskDeadlinesServiceImpl.setFallbackExecutor(commandExecutor);
         }
         return service;
    }

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/resources/META-INF/Taskorm.xml
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/resources/META-INF/Taskorm.xml
@@ -976,7 +976,27 @@
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
     </named-query>
-      
+    
+     <named-query name="UnescalatedEndDeadlinesByDeployment">
+        <query>
+            select
+            new org.jbpm.services.task.query.DeadlineSummaryImpl(
+            t.id,
+            d.id,
+            d.date)
+            from
+            TaskImpl t,
+            DeadlineImpl d
+            where
+            t.archived = 0 and
+            t.taskData.deploymentId = :deploymentId and
+            d in elements( t.deadlines.endDeadlines ) and
+            d.escalated = 0
+            order by
+            d.date
+        </query>
+        <!-- hint name="org.hibernate.timeout" value="200"/ -->
+    </named-query>
     <named-query name="UnescalatedStartDeadlines">
         <query>
             select
@@ -996,7 +1016,27 @@
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
     </named-query>
-       <named-query name="UnescalatedEndDeadlinesByTaskId">
+    <named-query name="UnescalatedStartDeadlinesByDeployment">
+        <query>
+            select
+            new org.jbpm.services.task.query.DeadlineSummaryImpl(
+            t.id,
+            d.id,
+            d.date)
+            from
+            TaskImpl t,
+            DeadlineImpl d
+            where
+            t.archived = 0 and
+            t.taskData.deploymentId = :deploymentId and
+            d in elements( t.deadlines.startDeadlines ) and
+            d.escalated = 0
+            order by
+            d.date
+        </query>
+        <!-- hint name="org.hibernate.timeout" value="200"/ -->
+    </named-query>
+    <named-query name="UnescalatedEndDeadlinesByTaskId">
         <query>
             select
             new org.jbpm.services.task.query.DeadlineSummaryImpl(

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/AbstractRuntimeManager.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/AbstractRuntimeManager.java
@@ -35,6 +35,8 @@ import org.jbpm.runtime.manager.impl.error.ExecutionErrorManagerImpl;
 import org.jbpm.runtime.manager.impl.lock.RuntimeManagerLockStrategyFactory;
 import org.jbpm.runtime.manager.impl.lock.RuntimeManagerLockWatcherSingletonService;
 import org.jbpm.runtime.manager.impl.tx.NoOpTransactionManager;
+import org.jbpm.runtime.manager.impl.tx.NoTransactionalTimerResourcesCleanupAwareSchedulerServiceInterceptor;
+import org.jbpm.runtime.manager.impl.tx.TransactionAwareSchedulerServiceInterceptor;
 import org.jbpm.runtime.manager.spi.RuntimeManagerLock;
 import org.jbpm.runtime.manager.spi.RuntimeManagerLockStrategy;
 import org.jbpm.services.task.impl.TaskContentRegistry;
@@ -57,8 +59,6 @@ import org.kie.internal.runtime.conf.DeploymentDescriptor;
 import org.kie.internal.runtime.error.ExecutionErrorManager;
 import org.kie.internal.runtime.error.ExecutionErrorStorage;
 import org.kie.internal.runtime.manager.CacheManager;
-import org.kie.internal.runtime.manager.Disposable;
-import org.kie.internal.runtime.manager.DisposeListener;
 import org.kie.internal.runtime.manager.InternalRegisterableItemsFactory;
 import org.kie.internal.runtime.manager.InternalRuntimeEngine;
 import org.kie.internal.runtime.manager.InternalRuntimeManager;
@@ -155,8 +155,31 @@ public abstract class AbstractRuntimeManager implements InternalRuntimeManager {
         } else {
             runtimeManagerLockStrategy = lockStrategyFactory.createLockStrategy(identifier);
         }
+        initTimerService();
 	}
-    
+	
+	protected void initTimerService() {
+        logger.trace("Initialize timer service for runtime {}", identifier);
+        if (environment instanceof SchedulerProvider) {
+            GlobalSchedulerService schedulerService = ((SchedulerProvider) environment).getSchedulerService();  
+            if (schedulerService != null) {
+                TimerService globalTs = new GlobalTimerService(this, schedulerService);
+                String timerServiceId = identifier  + TimerServiceRegistry.TIMER_SERVICE_SUFFIX;
+                // and register it in the registry under 'default' key
+                TimerServiceRegistry.getInstance().registerTimerService(timerServiceId, globalTs);
+                ((SimpleRuntimeEnvironment)environment).addToConfiguration("drools.timerService", 
+                        "new org.jbpm.process.core.timer.impl.RegisteredTimerServiceDelegate(\""+timerServiceId+"\")");
+                
+                if (!schedulerService.isTransactional()) {
+                    schedulerService.setInterceptor(new TransactionAwareSchedulerServiceInterceptor(environment, this, schedulerService));
+                } else {
+                    schedulerService.setInterceptor(new NoTransactionalTimerResourcesCleanupAwareSchedulerServiceInterceptor(environment, this, schedulerService));
+                }
+            }
+        }
+    }
+	
+	
 	protected void registerItems(RuntimeEngine runtime) {
         RegisterableItemsFactory factory = environment.getRegisterableItemsFactory();
         KieSession ksession = ((InternalRuntimeEngine) runtime).internalGetKieSession();
@@ -292,7 +315,6 @@ public abstract class AbstractRuntimeManager implements InternalRuntimeManager {
             ((CommandBasedTaskService) internalTaskService).getEnvironment().set(EnvironmentName.OBJECT_MARSHALLING_STRATEGIES, 
                                                                                  ((SimpleRuntimeEnvironment)environment).getEnvironmentTemplate().get(EnvironmentName.OBJECT_MARSHALLING_STRATEGIES));
         }
-        
         return internalTaskService;
     }
     

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/SingletonRuntimeManager.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/SingletonRuntimeManager.java
@@ -349,5 +349,4 @@ public class SingletonRuntimeManager extends AbstractRuntimeManager {
     public void setTaskServiceFactory(TaskServiceFactory taskServiceFactory) {
         this.taskServiceFactory = taskServiceFactory;
     }
-
 }

--- a/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/deploy/AbstractDeploymentDescriptorTest.java
+++ b/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/deploy/AbstractDeploymentDescriptorTest.java
@@ -16,6 +16,8 @@
 
 package org.jbpm.runtime.manager.impl.deploy;
 
+import static org.kie.scanner.KieMavenRepository.getKieMavenRepository;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.List;
@@ -38,14 +40,13 @@ import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.scanner.KieMavenRepository;
 
-import static org.kie.scanner.KieMavenRepository.getKieMavenRepository;
-
 public abstract class AbstractDeploymentDescriptorTest extends AbstractBaseTest {
 
 	@After
 	public void cleanup() {
 		// always reset location of the default deployment descriptors after
 		// each test
+	    super.cleanup();
 		System.clearProperty("org.kie.deployment.desc.location");
 	}
 	

--- a/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/migration/TimerMigrationManagerTest.java
+++ b/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/migration/TimerMigrationManagerTest.java
@@ -16,6 +16,13 @@
 
 package org.jbpm.runtime.manager.impl.migration;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE;
+import static org.kie.api.runtime.process.ProcessInstance.STATE_COMPLETED;
+
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
@@ -32,6 +39,7 @@ import org.jbpm.runtime.manager.impl.DefaultRegisterableItemsFactory;
 import org.jbpm.runtime.manager.impl.jpa.EntityManagerFactoryManager;
 import org.jbpm.runtime.manager.util.TestUtil;
 import org.jbpm.services.task.identity.JBossUserGroupCallbackImpl;
+import org.jbpm.services.task.impl.TaskDeadlinesServiceImpl;
 import org.jbpm.test.listener.process.NodeLeftCountDownProcessEventListener;
 import org.jbpm.test.util.AbstractBaseTest;
 import org.junit.After;
@@ -58,13 +66,6 @@ import org.kie.internal.runtime.manager.context.EmptyContext;
 import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
 import org.kie.internal.task.api.UserGroupCallback;
 import org.kie.test.util.db.PoolingDataSourceWrapper;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE;
-import static org.kie.api.runtime.process.ProcessInstance.STATE_COMPLETED;
 
 @RunWith(Parameterized.class)
 public class TimerMigrationManagerTest extends AbstractBaseTest {
@@ -143,6 +144,7 @@ public class TimerMigrationManagerTest extends AbstractBaseTest {
             managerV2.close();
         }
         EntityManagerFactoryManager.get().clear();
+        TaskDeadlinesServiceImpl.dispose();
         pds.close();
     }
     

--- a/jbpm-runtime-manager/src/test/java/org/jbpm/test/util/AbstractBaseTest.java
+++ b/jbpm-runtime-manager/src/test/java/org/jbpm/test/util/AbstractBaseTest.java
@@ -18,6 +18,7 @@ package org.jbpm.test.util;
 
 import org.jbpm.process.instance.impl.util.LoggingPrintStream;
 import org.jbpm.runtime.manager.impl.jpa.EntityManagerFactoryManager;
+import org.jbpm.services.task.impl.TaskDeadlinesServiceImpl;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -46,6 +47,7 @@ public abstract class AbstractBaseTest {
     @After
     public void cleanup() {
     	EntityManagerFactoryManager.get().clear();
+    	TaskDeadlinesServiceImpl.dispose();
     }
     
     @BeforeClass

--- a/jbpm-services/jbpm-executor/src/test/java/org/jbpm/test/util/AbstractExecutorBaseTest.java
+++ b/jbpm-services/jbpm-executor/src/test/java/org/jbpm/test/util/AbstractExecutorBaseTest.java
@@ -18,6 +18,7 @@ package org.jbpm.test.util;
 
 import org.jbpm.process.instance.impl.util.LoggingPrintStream;
 import org.jbpm.runtime.manager.impl.jpa.EntityManagerFactoryManager;
+import org.jbpm.services.task.impl.TaskDeadlinesServiceImpl;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -28,6 +29,7 @@ public abstract class AbstractExecutorBaseTest {
     @After
     public void cleanup() {
     	EntityManagerFactoryManager.get().clear();
+    	TaskDeadlinesServiceImpl.dispose();
     }
     
     @BeforeClass

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/AbstractDeploymentService.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/AbstractDeploymentService.java
@@ -43,6 +43,7 @@ import org.jbpm.services.api.ListenerSupport;
 import org.jbpm.services.api.RuntimeDataService;
 import org.jbpm.services.api.model.DeployedUnit;
 import org.jbpm.services.api.model.DeploymentUnit;
+import org.jbpm.services.task.commands.InitDeadlinesCommand;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.manager.RuntimeEnvironment;
 import org.kie.api.runtime.manager.RuntimeManager;
@@ -50,6 +51,7 @@ import org.kie.api.runtime.manager.RuntimeManagerFactory;
 import org.kie.internal.identity.IdentityProvider;
 import org.kie.internal.runtime.conf.DeploymentDescriptor;
 import org.kie.internal.runtime.manager.InternalRuntimeManager;
+import org.kie.internal.runtime.manager.context.EmptyContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,7 +153,7 @@ public abstract class AbstractDeploymentService implements DeploymentService, Li
                 if (!deployedUnit.isActive()) {
                     ((InternalRuntimeManager)manager).deactivate();
                 }                
-                
+                manager.getRuntimeEngine(EmptyContext.get()).getTaskService().execute(new InitDeadlinesCommand(unit.getIdentifier()));
                 ((InternalRuntimeManager)manager).setKieContainer(kieContainer);
                 deployedUnit.setRuntimeManager(manager);
                 DeploymentDescriptor descriptor = ((InternalRuntimeManager)manager).getDeploymentDescriptor();

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
@@ -137,13 +137,7 @@ public class EjbSchedulerService implements GlobalSchedulerService {
 	}
 	
    private boolean isNewTimer(JobContext ctx) {
-
-        boolean isNewTimer = true;
-        if (ctx instanceof ProcessJobContext) {
-            ProcessJobContext processCtx = (ProcessJobContext) ctx;
-            isNewTimer = processCtx.isNewTimer();
-        }
-        return isNewTimer;
-    }
+       return ctx instanceof ProcessJobContext && ((ProcessJobContext) ctx).isNewTimer();
+   }
 
 }

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/ConcurrentGlobalTimerServiceTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/ConcurrentGlobalTimerServiceTest.java
@@ -16,6 +16,10 @@
 
 package org.jbpm.test.functional.timer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -38,6 +42,7 @@ import org.jbpm.process.core.timer.GlobalSchedulerService;
 import org.jbpm.process.core.timer.impl.ThreadPoolSchedulerService;
 import org.jbpm.services.task.exception.PermissionDeniedException;
 import org.jbpm.services.task.identity.JBossUserGroupCallbackImpl;
+import org.jbpm.services.task.impl.TaskDeadlinesServiceImpl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -64,10 +69,6 @@ import org.kie.internal.task.api.UserGroupCallback;
 import org.kie.internal.task.api.model.InternalOrganizationalEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 public class ConcurrentGlobalTimerServiceTest extends TimerBaseTest {
     
@@ -109,6 +110,7 @@ public class ConcurrentGlobalTimerServiceTest extends TimerBaseTest {
             manager.close();
         }
         emf.close();
+        TaskDeadlinesServiceImpl.dispose();
     }
 	
     @Test

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/GlobalTimerServiceBaseTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/GlobalTimerServiceBaseTest.java
@@ -16,6 +16,11 @@
 
 package org.jbpm.test.functional.timer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.ArrayList;
@@ -46,6 +51,7 @@ import org.jbpm.runtime.manager.impl.AbstractRuntimeManager;
 import org.jbpm.runtime.manager.impl.SimpleRuntimeEnvironment;
 import org.jbpm.runtime.manager.impl.jpa.EntityManagerFactoryManager;
 import org.jbpm.services.task.identity.JBossUserGroupCallbackImpl;
+import org.jbpm.services.task.impl.TaskDeadlinesServiceImpl;
 import org.jbpm.services.task.persistence.JPATaskPersistenceContextManager;
 import org.jbpm.test.listener.process.NodeLeftCountDownProcessEventListener;
 import org.jbpm.workflow.instance.WorkflowProcessInstance;
@@ -82,11 +88,6 @@ import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 
 public abstract class GlobalTimerServiceBaseTest extends TimerBaseTest{
     
@@ -113,6 +114,7 @@ public abstract class GlobalTimerServiceBaseTest extends TimerBaseTest{
         if (emf != null && emf.isOpen()) {
             emf.close();
         }
+        TaskDeadlinesServiceImpl.dispose();
     }
 
     @Test(timeout=20000)

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/GlobalTimerServiceVolumeTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/GlobalTimerServiceVolumeTest.java
@@ -16,6 +16,9 @@
 
 package org.jbpm.test.functional.timer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -41,6 +44,7 @@ import org.jbpm.process.core.timer.impl.GlobalTimerService;
 import org.jbpm.process.core.timer.impl.GlobalTimerService.GlobalJobHandle;
 import org.jbpm.process.core.timer.impl.QuartzSchedulerService;
 import org.jbpm.services.task.identity.JBossUserGroupCallbackImpl;
+import org.jbpm.services.task.impl.TaskDeadlinesServiceImpl;
 import org.jbpm.test.listener.process.NodeLeftCountDownProcessEventListener;
 import org.junit.After;
 import org.junit.Before;
@@ -75,9 +79,6 @@ import org.kie.internal.task.api.UserGroupCallback;
 import org.kie.internal.task.api.model.InternalOrganizationalEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 @RunWith(Parameterized.class)
 public class GlobalTimerServiceVolumeTest extends TimerBaseTest {
@@ -172,6 +173,7 @@ public class GlobalTimerServiceVolumeTest extends TimerBaseTest {
             }
             emf.close();
         }
+        TaskDeadlinesServiceImpl.dispose();
     }
 
     @Test(timeout=30000)

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/InMemoryTimerPersistenceTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/InMemoryTimerPersistenceTest.java
@@ -16,6 +16,10 @@
 
 package org.jbpm.test.functional.timer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,10 +32,6 @@ import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * See JBPM-3170/JBPM-3391
@@ -55,9 +55,10 @@ public class InMemoryTimerPersistenceTest extends JbpmTestCase {
     }
     
     @Before
-    public void setup() { 
+    public void setup() throws Exception { 
         System.clearProperty(TIMER_FIRED_PROP);
         System.clearProperty(TIMER_FIRED_TIME_PROP);
+        super.setUp();
     }
     
     @Test

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/SerializedTimerRollbackTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/SerializedTimerRollbackTest.java
@@ -16,6 +16,11 @@
 
 package org.jbpm.test.functional.timer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.sql.Blob;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -37,6 +42,7 @@ import org.drools.serialization.protobuf.ProtobufMarshaller;
 import org.jbpm.process.instance.InternalProcessRuntime;
 import org.jbpm.process.instance.timer.TimerInstance;
 import org.jbpm.process.instance.timer.TimerManager;
+import org.jbpm.services.task.impl.TaskDeadlinesServiceImpl;
 import org.jbpm.test.JbpmTestCase;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,11 +56,6 @@ import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class SerializedTimerRollbackTest extends JbpmTestCase {
 
@@ -74,6 +75,7 @@ public class SerializedTimerRollbackTest extends JbpmTestCase {
             EntityManager em = getEmf().createEntityManager();
             em.createQuery("delete from SessionInfo").executeUpdate();
             em.close();
+            TaskDeadlinesServiceImpl.dispose();
             ut.commit();
         } catch (Exception e) {
             ut.rollback();

--- a/jbpm-test/src/main/java/org/jbpm/test/JbpmJUnitBaseTestCase.java
+++ b/jbpm-test/src/main/java/org/jbpm/test/JbpmJUnitBaseTestCase.java
@@ -16,6 +16,11 @@
 
 package org.jbpm.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.ArrayList;
@@ -46,6 +51,7 @@ import org.jbpm.runtime.manager.impl.DefaultRegisterableItemsFactory;
 import org.jbpm.runtime.manager.impl.SimpleRegisterableItemsFactory;
 import org.jbpm.runtime.manager.impl.jpa.EntityManagerFactoryManager;
 import org.jbpm.services.task.identity.JBossUserGroupCallbackImpl;
+import org.jbpm.services.task.impl.TaskDeadlinesServiceImpl;
 import org.jbpm.test.persistence.processinstance.objects.TestEventEmitter;
 import org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl;
 import org.junit.After;
@@ -79,11 +85,6 @@ import org.kie.internal.runtime.manager.context.EmptyContext;
 import org.kie.test.util.db.PoolingDataSourceWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 /**
  * Base test case class that shall be used for jBPM related tests. It provides four sections:
@@ -543,6 +544,7 @@ public abstract class JbpmJUnitBaseTestCase extends AbstractBaseTest {
             manager.close();
             manager = null;
         }
+        TaskDeadlinesServiceImpl.dispose();
     }
 
     /**

--- a/jbpm-test/src/main/java/org/jbpm/test/services/AbstractCaseServicesTest.java
+++ b/jbpm-test/src/main/java/org/jbpm/test/services/AbstractCaseServicesTest.java
@@ -16,6 +16,8 @@
 
 package org.jbpm.test.services;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -52,6 +54,7 @@ import org.jbpm.services.api.model.ProcessInstanceDesc;
 import org.jbpm.services.api.model.UserTaskDefinition;
 import org.jbpm.services.api.query.QueryService;
 import org.jbpm.services.api.service.ServiceRegistry;
+import org.jbpm.services.task.impl.TaskDeadlinesServiceImpl;
 import org.junit.After;
 import org.junit.Before;
 import org.kie.api.task.model.TaskSummary;
@@ -62,8 +65,6 @@ import org.kie.internal.runtime.conf.NamedObjectModel;
 import org.kie.internal.runtime.conf.ObjectModel;
 import org.kie.internal.runtime.conf.RuntimeStrategy;
 import org.kie.internal.runtime.manager.deploy.DeploymentDescriptorImpl;
-
-import static java.util.stream.Collectors.toMap;
 
 public abstract class AbstractCaseServicesTest extends AbstractServicesTest {
 
@@ -133,6 +134,7 @@ public abstract class AbstractCaseServicesTest extends AbstractServicesTest {
     protected void close() {
         caseConfigurator.close();
         EntityManagerFactoryManager.get().clear();
+        TaskDeadlinesServiceImpl.dispose();
         closeDataSource();
     }
 

--- a/jbpm-test/src/main/java/org/jbpm/test/services/AbstractKieServicesTest.java
+++ b/jbpm-test/src/main/java/org/jbpm/test/services/AbstractKieServicesTest.java
@@ -33,6 +33,7 @@ import org.jbpm.services.api.model.DeploymentUnit;
 import org.jbpm.services.api.query.QueryService;
 import org.jbpm.services.api.service.ServiceRegistry;
 import org.jbpm.services.api.utils.KieServiceConfigurator;
+import org.jbpm.services.task.impl.TaskDeadlinesServiceImpl;
 import org.junit.After;
 import org.junit.Before;
 import org.kie.internal.runtime.conf.DeploymentDescriptor;
@@ -97,6 +98,7 @@ public abstract class AbstractKieServicesTest extends AbstractServicesTest {
             serviceConfigurator.close();
         }
         EntityManagerFactoryManager.get().clear();
+        TaskDeadlinesServiceImpl.dispose();
         closeDataSource();
     }
 


### PR DESCRIPTION
[JBPM-9920] Loading only the timers of the initialized deployment
Trying to avoid call to dispose in tests

**JIRA**:

[link](https://issues.redhat.com/browse/JBPM-9920)

