### PR TITLE
(GSS) [7.59.x] [JBPM-9915] EJBTimerScheduler.localCache contains entries from already fired timers

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/core/timer/GlobalSchedulerService.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/timer/GlobalSchedulerService.java
@@ -74,4 +74,12 @@ public interface GlobalSchedulerService extends SchedulerService, InternalSchedu
      * @return
      */
     boolean isValid(GlobalJobHandle jobHandle);
+
+    /** 
+     * Operations to be performed before the job is removed
+     * @param jobHandle job handle being invalidated
+     */
+    default void invalidate(JobHandle jobHandle) {
+        
+    }
 }

--- a/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/GlobalTimerService.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/GlobalTimerService.java
@@ -127,6 +127,7 @@ public class GlobalTimerService implements TimerService, InternalSchedulerServic
         if (jobHandle == null) {
             return false;
         }
+        this.schedulerService.invalidate(jobHandle);
 
         if (startTimerJobs.contains(jobHandle)) {
             logger.debug("Start Job timer handle found {} removed", jobHandle.getId());

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
@@ -76,13 +76,15 @@ public class EjbSchedulerService implements GlobalSchedulerService {
 		return jobHandle;
 	}
 
-	@Override
-	public boolean removeJob(JobHandle jobHandle) {
-		
-		boolean result = scheduler.removeJob(jobHandle);
-	
-		return result;
-	}
+    @Override
+    public boolean removeJob(JobHandle jobHandle) {
+        return scheduler.removeJob(jobHandle);
+    }
+
+    @Override
+    public void invalidate(JobHandle jobHandle) {
+        scheduler.evictCache(jobHandle);
+    }
 
 	@Override
 	public void internalSchedule(TimerJobInstance timerJobInstance) {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/JBPM-9915

cherry-pick: https://github.com/kiegroup/jbpm/commit/0f229c0097ba4c06cfc7b0667fefa48593b011c9