### PR TITLE
Avoid error if timer is not found

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/admin/commands/ListTimersCommand.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/admin/commands/ListTimersCommand.java
@@ -120,7 +120,9 @@ public class ListTimersCommand implements ExecutableCommand<List<TimerInstance>>
                 TimerNodeInstance tni = (TimerNodeInstance) nodeInstance;
             	org.jbpm.process.instance.timer.TimerInstance timer = tm.getTimerMap().get(tni.getTimerId());
             	TimerInstanceImpl details = buildTimer(timer);
-                details.setTimerName(resolveVariable(timer.getName(), tni));
+                if (timer != null) {
+                    details.setTimerName(resolveVariable(timer.getName(), tni));
+                }
                 
                 timers.add(details);
             
@@ -132,7 +134,9 @@ public class ListTimersCommand implements ExecutableCommand<List<TimerInstance>>
                     for (Long timerId : timerList) {
                         org.jbpm.process.instance.timer.TimerInstance timer = tm.getTimerMap().get(timerId);
                         TimerInstanceImpl details = buildTimer(timer);
-                        details.setTimerName(resolveVariable(timer.getName(), sbni));
+                        if (timer != null) {
+                            details.setTimerName(resolveVariable(timer.getName(), sbni));
+                        }
                         timers.add(details);
                     }
             	}


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: https://issues.redhat.com/browse/RHPAM-4192

<details>
<summary>
Is not clear how this reproduces, but control this makes sense. Looks like a corner case
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
