### PR TITLE
[JBPM-10037] LogCleanupCommnand and records per transation

### DIFF
--- a/jbpm-audit/src/main/java/org/jbpm/process/audit/JPAAuditLogService.java
+++ b/jbpm-audit/src/main/java/org/jbpm/process/audit/JPAAuditLogService.java
@@ -16,40 +16,6 @@
 
 package org.jbpm.process.audit;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.TreeMap;
-import java.util.function.Consumer;
-
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.FlushModeType;
-import javax.persistence.NoResultException;
-import javax.persistence.Query;
-
-import org.jbpm.process.audit.query.NodeInstLogQueryBuilderImpl;
-import org.jbpm.process.audit.query.NodeInstanceLogDeleteBuilderImpl;
-import org.jbpm.process.audit.query.ProcInstLogQueryBuilderImpl;
-import org.jbpm.process.audit.query.ProcessInstanceLogDeleteBuilderImpl;
-import org.jbpm.process.audit.query.VarInstLogQueryBuilderImpl;
-import org.jbpm.process.audit.query.VarInstanceLogDeleteBuilderImpl;
-import org.jbpm.process.audit.strategy.PersistenceStrategyType;
-import org.jbpm.query.jpa.data.QueryWhere;
-import org.jbpm.query.jpa.impl.QueryCriteriaUtil;
-import org.kie.api.runtime.Environment;
-import org.kie.internal.runtime.manager.audit.query.NodeInstanceLogDeleteBuilder;
-import org.kie.internal.runtime.manager.audit.query.NodeInstanceLogQueryBuilder;
-import org.kie.internal.runtime.manager.audit.query.ProcessInstanceLogDeleteBuilder;
-import org.kie.internal.runtime.manager.audit.query.ProcessInstanceLogQueryBuilder;
-import org.kie.internal.runtime.manager.audit.query.VariableInstanceLogDeleteBuilder;
-import org.kie.internal.runtime.manager.audit.query.VariableInstanceLogQueryBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import static org.jbpm.query.jpa.impl.QueryCriteriaUtil.convertListToInterfaceList;
 import static org.kie.internal.query.QueryParameterIdentifiers.CASE_FILE_DATA_LOG_LASTMODIFIED;
 import static org.kie.internal.query.QueryParameterIdentifiers.CORRELATION_KEY_LIST;
@@ -84,6 +50,38 @@ import static org.kie.internal.query.QueryParameterIdentifiers.VALUE_LIST;
 import static org.kie.internal.query.QueryParameterIdentifiers.VARIABLE_ID_LIST;
 import static org.kie.internal.query.QueryParameterIdentifiers.VARIABLE_INSTANCE_ID_LIST;
 import static org.kie.internal.query.QueryParameterIdentifiers.WORK_ITEM_ID_LIST;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.FlushModeType;
+import javax.persistence.NoResultException;
+import javax.persistence.Query;
+
+import org.jbpm.process.audit.query.NodeInstLogQueryBuilderImpl;
+import org.jbpm.process.audit.query.NodeInstanceLogDeleteBuilderImpl;
+import org.jbpm.process.audit.query.ProcInstLogQueryBuilderImpl;
+import org.jbpm.process.audit.query.ProcessInstanceLogDeleteBuilderImpl;
+import org.jbpm.process.audit.query.VarInstLogQueryBuilderImpl;
+import org.jbpm.process.audit.query.VarInstanceLogDeleteBuilderImpl;
+import org.jbpm.process.audit.strategy.PersistenceStrategyType;
+import org.jbpm.query.jpa.data.QueryWhere;
+import org.jbpm.query.jpa.impl.QueryCriteriaUtil;
+import org.kie.api.runtime.Environment;
+import org.kie.internal.runtime.manager.audit.query.NodeInstanceLogDeleteBuilder;
+import org.kie.internal.runtime.manager.audit.query.NodeInstanceLogQueryBuilder;
+import org.kie.internal.runtime.manager.audit.query.ProcessInstanceLogDeleteBuilder;
+import org.kie.internal.runtime.manager.audit.query.ProcessInstanceLogQueryBuilder;
+import org.kie.internal.runtime.manager.audit.query.VariableInstanceLogDeleteBuilder;
+import org.kie.internal.runtime.manager.audit.query.VariableInstanceLogQueryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JPAAuditLogService extends JPAService implements AuditLogService {
 
@@ -412,7 +410,6 @@ public class JPAAuditLogService extends JPAService implements AuditLogService {
                 queryData, queryParams, subQuery).toSQL(), queryParams);
     }
 
-    @SuppressWarnings("unchecked")
     public int doPartialDelete(String queryTable,
                                QueryWhere queryData,
                                String subQuery,
@@ -421,12 +418,10 @@ public class JPAAuditLogService extends JPAService implements AuditLogService {
         EntityManager em = getEntityManager();
         Object newTx = joinTransaction(em);
         try {
-            Query query = em.createQuery(QueryHelper.createQueryWithSubQuery(
-                    String.format("SELECT l.id FROM %s l", queryTable), queryData, queryParams, subQuery).toSQL());
+            Query query = em.createQuery(QueryHelper.createQueryWithSubQuery(String.format("SELECT l.id FROM %s l", queryTable), queryData, queryParams, subQuery).toSQL()).setMaxResults(chunkSize);
             applyMetaQueryParameters(queryParams, query);
-            IdConsumer consumer = new IdConsumer(queryTable, chunkSize);
-            query.getResultStream().forEach(consumer);
-            return consumer.getResult();
+            List<?> ids = query.getResultList();
+            return ids.isEmpty() ? 0 : executeQuery(String.format("DELETE FROM %s p WHERE p.id IN (:ids)", queryTable), Collections.singletonMap("ids", ids));
         } finally {
             closeEntityManager(em, newTx);
         }
@@ -489,34 +484,5 @@ public class JPAAuditLogService extends JPAService implements AuditLogService {
     private int executeWithParameters(Map<String, Object> params, Query query) {
         applyMetaQueryParameters(params, query);
         return query.executeUpdate();
-    }
-
-    private class IdConsumer implements Consumer<Object> {
-
-        private List<Object> ids = new ArrayList<>();
-        private String query;
-        private int chunkSize;
-        private int result;
-
-        public IdConsumer(String queryTable, int chunkSize) {
-            this.query = String.format("DELETE FROM %s p WHERE p.id IN (:ids)", queryTable);
-            this.chunkSize = chunkSize;
-        }
-
-        @Override
-        public void accept(Object id) {
-            ids.add(id);
-            if (ids.size() >= chunkSize) {
-                result += executeQuery(query, Collections.singletonMap("ids", ids));
-                ids.clear();
-            }
-        }
-
-        public int getResult() {
-            if (!ids.isEmpty()) {
-                result += executeQuery(query, Collections.singletonMap("ids", ids));
-            }
-            return result;
-        }
     }
 }


### PR DESCRIPTION
Rescheduling command automatically if suspecting there might be more
records to delete when records per transaction is set
ProcessInstanceLog deletion are saved for the latests transaction, since the subqueries depends on them

**JIRA**:

[link](https://issues.redhat.com/browse/JBPM-10037)

**referenced Pull Requests**: 

