### PR TITLE
[JBPM-10065] Triggering task activated event in a different way

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/commands/AddTaskCommand.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/commands/AddTaskCommand.java
@@ -15,7 +15,6 @@
  */
 package org.jbpm.services.task.commands;
 
-import java.util.List;
 import java.util.Map;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -42,7 +41,6 @@ import org.kie.internal.task.api.model.ContentData;
 import org.kie.internal.task.api.model.InternalPeopleAssignments;
 import org.kie.internal.task.api.model.InternalTask;
 import org.kie.internal.task.api.model.InternalTaskData;
-import org.kie.internal.task.api.model.Operation;
 
 /**
  * Operation.Start : [ new OperationCommand().{ status = [ Status.Ready ],
@@ -116,13 +114,6 @@ public class AddTaskCommand extends UserGroupCallbackTaskCommand<Long> {
             
         	taskId = context.getTaskInstanceService().addTask(taskImpl, params);
         }
-
-        // if the status is different from created it means it has been activated in the middle
-        if (!Status.Created.equals(taskImpl.getTaskData().getStatus())) {
-            ((InternalTask) taskImpl).setId(taskId);
-            context.getTaskInstanceService().fireEvent(Operation.Activate, taskImpl);
-        }
-
         DeadlineSchedulerHelper.scheduleDeadlinesForTask((InternalTask) taskImpl, context, DeadlineType.values());
     	
     	return taskId;

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/task/HumanTaskTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/task/HumanTaskTest.java
@@ -16,6 +16,14 @@
 
 package org.jbpm.test.regression.task;
 
+import static java.util.Collections.emptyMap;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggered;
+import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggeredAndLeft;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +35,6 @@ import org.assertj.core.api.Assertions;
 import org.jbpm.services.task.events.DefaultTaskEventListener;
 import org.jbpm.test.JbpmTestCase;
 import org.jbpm.test.listener.TrackingProcessEventListener;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
@@ -39,12 +46,6 @@ import org.kie.api.task.model.Status;
 import org.kie.api.task.model.Task;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.task.api.EventService;
-
-import static java.util.Collections.emptyMap;
-import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggered;
-import static org.jbpm.test.tools.TrackingListenerAssert.assertTriggeredAndLeft;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class HumanTaskTest extends JbpmTestCase {
 
@@ -240,6 +241,22 @@ public class HumanTaskTest extends JbpmTestCase {
             @Override
             public void afterTaskActivatedEvent(TaskEvent event) {
                 triggered.increment();
+                assertNotEquals(Status.Created, event.getTask().getTaskData().getStatus());
+            }
+            
+            @Override
+            public void beforeTaskActivatedEvent(TaskEvent event) {
+                assertEquals(Status.Created, event.getTask().getTaskData().getStatus());
+            }
+            
+            @Override
+            public void afterTaskAddedEvent(TaskEvent event) {
+                assertEquals(Status.Created, event.getTask().getTaskData().getStatus());
+            }
+            
+            @Override
+            public void beforeTaskAddedEvent(TaskEvent event) {
+                assertNull(event.getTask().getTaskData().getStatus());
             }
 
         };


### PR DESCRIPTION
Moving the activate event triggering code inside addTask. This should generate a valid sequence. 

**JIRA**: 

[link](https://issues.redhat.com/browse/JBPM-10065)

