### PR TITLE
[JBPM-10094]- Current index settings might cause DeadLocks in SQL Server

### DIFF
--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/db2/db2-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/db2/db2-jbpm-schema.sql
@@ -773,7 +773,7 @@
     create index IDX_Task_archived on Task(archived);
     create index IDX_Task_workItemId on Task(workItemId);
     
-    create index IDX_EventTypes_element ON EventTypes(element);
+    create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
     create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/derby/derby-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/derby/derby-jbpm-schema.sql
@@ -778,7 +778,7 @@
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
     create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
-    create index IDX_EventTypes_element ON EventTypes(element);
+    create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 
     create index IDX_CMI_Context ON ContextMappingInfo(CONTEXT_ID);    
     create index IDX_CMI_KSession ON ContextMappingInfo(KSESSION_ID);    

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/h2/h2-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/h2/h2-jbpm-schema.sql
@@ -779,7 +779,7 @@
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
     create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
-    create index IDX_EventTypes_element ON EventTypes(element);
+    create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 
     create index IDX_CMI_Context ON ContextMappingInfo(CONTEXT_ID);    
     create index IDX_CMI_KSession ON ContextMappingInfo(KSESSION_ID);    

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/hsqldb/hsqldb-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/hsqldb/hsqldb-jbpm-schema.sql
@@ -780,7 +780,7 @@
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
     create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
-    create index IDX_EventTypes_element ON EventTypes(element);
+    create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 
     create index IDX_CMI_Context ON ContextMappingInfo(CONTEXT_ID);    
     create index IDX_CMI_KSession ON ContextMappingInfo(KSESSION_ID);    

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/oracle/oracle-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/oracle/oracle-jbpm-schema.sql
@@ -847,7 +847,7 @@
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
     create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
-    create index IDX_EventTypes_element ON EventTypes(element);
+    create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 
     create index IDX_CMI_Context ON ContextMappingInfo(CONTEXT_ID);    
     create index IDX_CMI_KSession ON ContextMappingInfo(KSESSION_ID);    

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/oracle/oracle-springboot-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/oracle/oracle-springboot-jbpm-schema.sql
@@ -114,7 +114,7 @@ alter table DeploymentStore add constraint UK85rgskt09thd8mkkfl3tb0y81 unique (D
 create index IDX_ErrorInfo_Id on ErrorInfo (REQUEST_ID);
 create index IDX_Escalation_Id on Escalation (Deadline_Escalation_Id);
 create index IDX_EventTypes_Id on EventTypes (InstanceId);
-create index IDX_EventTypes_element on EventTypes (element);
+create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 create index IDX_ErrorInfo_pInstId on ExecutionErrorInfo (PROCESS_INST_ID);
 create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo (ERROR_ACK);
 create index IDX_I18NText_SubjId on I18NText (Task_Subjects_Id);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-bytea-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-bytea-jbpm-schema.sql
@@ -114,7 +114,7 @@ alter table DeploymentStore add constraint UK85rgskt09thd8mkkfl3tb0y81 unique (D
 create index IDX_ErrorInfo_Id on ErrorInfo (REQUEST_ID);
 create index IDX_Escalation_Id on Escalation (Deadline_Escalation_Id);
 create index IDX_EventTypes_Id on EventTypes (InstanceId);
-create index IDX_EventTypes_element on EventTypes (element);
+create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 create index IDX_ErrorInfo_pInstId on ExecutionErrorInfo (PROCESS_INST_ID);
 create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo (ERROR_ACK);
 create index IDX_I18NText_SubjId on I18NText (Task_Subjects_Id);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-jbpm-schema.sql
@@ -848,7 +848,7 @@
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
     create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
-    create index IDX_EventTypes_element ON EventTypes(element);
+    create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 
     create index IDX_CMI_Context ON ContextMappingInfo(CONTEXT_ID);    
     create index IDX_CMI_KSession ON ContextMappingInfo(KSESSION_ID);    

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-springboot-bytea-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-springboot-bytea-jbpm-schema.sql
@@ -114,7 +114,7 @@ alter table DeploymentStore add constraint UK85rgskt09thd8mkkfl3tb0y81 unique (D
 create index IDX_ErrorInfo_Id on ErrorInfo (REQUEST_ID);
 create index IDX_Escalation_Id on Escalation (Deadline_Escalation_Id);
 create index IDX_EventTypes_Id on EventTypes (InstanceId);
-create index IDX_EventTypes_element on EventTypes (element);
+create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 create index IDX_ErrorInfo_pInstId on ExecutionErrorInfo (PROCESS_INST_ID);
 create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo (ERROR_ACK);
 create index IDX_I18NText_SubjId on I18NText (Task_Subjects_Id);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-springboot-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-springboot-jbpm-schema.sql
@@ -114,7 +114,7 @@ alter table DeploymentStore add constraint UK85rgskt09thd8mkkfl3tb0y81 unique (D
 create index IDX_ErrorInfo_Id on ErrorInfo (REQUEST_ID);
 create index IDX_Escalation_Id on Escalation (Deadline_Escalation_Id);
 create index IDX_EventTypes_Id on EventTypes (InstanceId);
-create index IDX_EventTypes_element on EventTypes (element);
+create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 create index IDX_ErrorInfo_pInstId on ExecutionErrorInfo (PROCESS_INST_ID);
 create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo (ERROR_ACK);
 create index IDX_I18NText_SubjId on I18NText (Task_Subjects_Id);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver/sqlserver-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver/sqlserver-jbpm-schema.sql
@@ -780,7 +780,7 @@
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
     create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
-    create index IDX_EventTypes_element ON EventTypes(element);
+    create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 
     create index IDX_CMI_Context ON ContextMappingInfo(CONTEXT_ID);    
     create index IDX_CMI_KSession ON ContextMappingInfo(KSESSION_ID);    

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver/sqlserver-springboot-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver/sqlserver-springboot-jbpm-schema.sql
@@ -114,7 +114,7 @@ alter table DeploymentStore add constraint UK85rgskt09thd8mkkfl3tb0y81 unique (D
 create index IDX_ErrorInfo_Id on ErrorInfo (REQUEST_ID);
 create index IDX_Escalation_Id on Escalation (Deadline_Escalation_Id);
 create index IDX_EventTypes_Id on EventTypes (InstanceId);
-create index IDX_EventTypes_element on EventTypes (element);
+create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 create index IDX_ErrorInfo_pInstId on ExecutionErrorInfo (PROCESS_INST_ID);
 create index IDX_ErrorInfo_errorAck on ExecutionErrorInfo (ERROR_ACK);
 create index IDX_I18NText_SubjId on I18NText (Task_Subjects_Id);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver2008/sqlserver2008-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver2008/sqlserver2008-jbpm-schema.sql
@@ -780,7 +780,7 @@
     create index IDX_TaskEvent_taskId on TaskEvent (taskId);
     create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId);
 
-    create index IDX_EventTypes_element ON EventTypes(element);
+    create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
 
     create index IDX_CMI_Context ON ContextMappingInfo(CONTEXT_ID);    
     create index IDX_CMI_KSession ON ContextMappingInfo(KSESSION_ID);    

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sybase/sybase-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sybase/sybase-jbpm-schema.sql
@@ -926,7 +926,7 @@
     create index IDX_TaskEvent_processInstanceId on TaskEvent (processInstanceId)
     go
 
-    create index IDX_EventTypes_element ON EventTypes(element)
+    create index IDX_EventTypes_IdElement ON EventTypes(InstanceId,element)
     go
 
     create index IDX_CMI_Context ON ContextMappingInfo(CONTEXT_ID)

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/db2/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/db2/jbpm-7.72-to-7.73.sql
@@ -1,0 +1,2 @@
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/jbpm-7.72-to-7.73.sql
@@ -1,0 +1,2 @@
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/rhpam-7.13-to-7.13.1.sql
@@ -1,2 +1,4 @@
 ALTER TABLE TimerMappingInfo ADD COLUMN processInstanceId bigint;
 ALTER TABLE TimerMappingInfo ALTER COLUMN timerId bigint;
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/jbpm-7.72-to-7.73.sql
@@ -1,0 +1,2 @@
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/jbpm-7.72-to-7.73.sql
@@ -1,2 +1,2 @@
-DROP INDEX EventTypes.IDX_EventTypes_element;
+DROP INDEX IDX_EventTypes_element;
 CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/rhpam-7.13-to-7.13.1.sql
@@ -1,4 +1,4 @@
 ALTER TABLE TimerMappingInfo ADD COLUMN processInstanceId bigint;
 ALTER TABLE TimerMappingInfo ALTER COLUMN timerId bigint;
-DROP INDEX EventTypes.IDX_EventTypes_element;
+DROP INDEX IDX_EventTypes_element;
 CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/h2/rhpam-7.13-to-7.13.1.sql
@@ -1,2 +1,4 @@
 ALTER TABLE TimerMappingInfo ADD COLUMN processInstanceId bigint;
 ALTER TABLE TimerMappingInfo ALTER COLUMN timerId bigint;
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/jbpm-7.72-to-7.73.sql
@@ -1,0 +1,2 @@
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/rhpam-7.13-to-7.13.1.sql
@@ -1,2 +1,4 @@
 ALTER TABLE TimerMappingInfo ADD COLUMN processInstanceId bigint;
 ALTER TABLE TimerMappingInfo ALTER COLUMN timerId bigint;
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/jbpm-7.72-to-7.73.sql
@@ -1,0 +1,2 @@
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/jbpm-7.72-to-7.73.sql
@@ -1,2 +1,2 @@
-DROP INDEX EventTypes.IDX_EventTypes_element;
+DROP INDEX IDX_EventTypes_element;
 CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/rhpam-7.13-to-7.13.1.sql
@@ -1,2 +1,4 @@
 ALTER TABLE TimerMappingInfo ADD processInstanceId number(19,0);
 ALTER TABLE TimerMappingInfo ALTER COLUMN timerId number(19,0);
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/oracle/rhpam-7.13-to-7.13.1.sql
@@ -1,4 +1,4 @@
 ALTER TABLE TimerMappingInfo ADD processInstanceId number(19,0);
 ALTER TABLE TimerMappingInfo ALTER COLUMN timerId number(19,0);
-DROP INDEX EventTypes.IDX_EventTypes_element;
+DROP INDEX IDX_EventTypes_element;
 CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/jbpm-7.72-to-7.73.sql
@@ -1,0 +1,2 @@
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/jbpm-7.72-to-7.73.sql
@@ -1,2 +1,2 @@
-DROP INDEX EventTypes.IDX_EventTypes_element;
+DROP INDEX IDX_EventTypes_element;
 CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/rhpam-7.13-to-7.13.1.sql
@@ -1,4 +1,4 @@
 ALTER TABLE TimerMappingInfo ADD COLUMN processInstanceId int8;
 ALTER TABLE TimerMappingInfo ALTER COLUMN timerId int8;
-DROP INDEX EventTypes.IDX_EventTypes_element;
+DROP INDEX IDX_EventTypes_element;
 CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/rhpam-7.13-to-7.13.1.sql
@@ -1,2 +1,4 @@
 ALTER TABLE TimerMappingInfo ADD COLUMN processInstanceId int8;
 ALTER TABLE TimerMappingInfo ALTER COLUMN timerId int8;
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/jbpm-7.72-to-7.73.sql
@@ -1,0 +1,2 @@
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/rhpam-7.13-to-7.13.1.sql
@@ -1,2 +1,4 @@
 ALTER TABLE TimerMappingInfo ADD processInstanceId numeric(19,0);
 ALTER TABLE TimerMappingInfo ALTER timerId numeric(19,0);
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/jbpm-7.72-to-7.73.sql
@@ -1,0 +1,2 @@
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/rhpam-7.13-to-7.13.1.sql
@@ -1,2 +1,4 @@
 ALTER TABLE TimerMappingInfo ADD processInstanceId bigint;
 ALTER TABLE TimerMappingInfo ALTER timerId bigint;
+DROP INDEX EventTypes.IDX_EventTypes_element;
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/jbpm-7.72-to-7.73.sql
@@ -1,3 +1,4 @@
-ALTER TABLE TimerMappingInfo ADD COLUMN info blob(2147483647);
 DROP INDEX EventTypes.IDX_EventTypes_element;
+go
 CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
+go

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/rhpam-7.13-to-7.13.1.sql
@@ -2,3 +2,7 @@ ALTER TABLE TimerMappingInfo ADD COLUMN processInstanceId numeric(19,0);
 go
 ALTER TABLE TimerMappingInfo ALTER COLUMN timerId numeric(19,0);
 go
+DROP INDEX EventTypes.IDX_EventTypes_element;
+go
+CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);
+go

--- a/jbpm-db-scripts/src/test/resources/ddl60/db2/db2-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/test/resources/ddl60/db2/db2-jbpm-schema.sql
@@ -577,3 +577,5 @@
         add constraint FK61F475A5F510CB46 
         foreign key (TaskData_Comments_Id) 
         references Task;
+
+    create index IDX_EventTypes_element ON EventTypes(element);

--- a/jbpm-db-scripts/src/test/resources/ddl60/derby/derby-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/test/resources/ddl60/derby/derby-jbpm-schema.sql
@@ -577,3 +577,5 @@
         add constraint FK61F475A5F510CB46 
         foreign key (TaskData_Comments_Id) 
         references Task;
+
+    create index IDX_EventTypes_element ON EventTypes(element);

--- a/jbpm-db-scripts/src/test/resources/ddl60/h2/h2-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/test/resources/ddl60/h2/h2-jbpm-schema.sql
@@ -577,3 +577,5 @@ alter table task_comment
     add constraint FK61F475A5F510CB46
     foreign key (TaskData_Comments_Id)
     references Task;
+
+create index IDX_EventTypes_element ON EventTypes(element);

--- a/jbpm-db-scripts/src/test/resources/ddl60/hsqldb/hsqldb-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/test/resources/ddl60/hsqldb/hsqldb-jbpm-schema.sql
@@ -577,3 +577,5 @@
         add constraint FK61F475A5F510CB46 
         foreign key (TaskData_Comments_Id) 
         references Task;
+
+    create index IDX_EventTypes_element ON EventTypes(element);

--- a/jbpm-db-scripts/src/test/resources/ddl60/mysql5/mysql5-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/test/resources/ddl60/mysql5/mysql5-jbpm-schema.sql
@@ -622,3 +622,5 @@
         add constraint FK61F475A5F510CB46 
         foreign key (TaskData_Comments_Id) 
         references Task (id);
+
+    create index IDX_EventTypes_element ON EventTypes(element);

--- a/jbpm-db-scripts/src/test/resources/ddl60/mysqlinnodb/mysql-innodb-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/test/resources/ddl60/mysqlinnodb/mysql-innodb-jbpm-schema.sql
@@ -622,3 +622,5 @@
         add constraint FK61F475A5F510CB46 
         foreign key (TaskData_Comments_Id) 
         references Task (id);
+
+    create index IDX_EventTypes_element ON EventTypes(element);

--- a/jbpm-db-scripts/src/test/resources/ddl60/oracle/oracle-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/test/resources/ddl60/oracle/oracle-jbpm-schema.sql
@@ -627,3 +627,5 @@
     create sequence VAR_INST_LOG_ID_SEQ;
 
     create sequence WORKITEMINFO_ID_SEQ;
+
+    create index IDX_EventTypes_element ON EventTypes(element);

--- a/jbpm-db-scripts/src/test/resources/ddl60/postgresql/postgresql-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/test/resources/ddl60/postgresql/postgresql-jbpm-schema.sql
@@ -627,3 +627,5 @@
     create sequence VAR_INST_LOG_ID_SEQ;
 
     create sequence WORKITEMINFO_ID_SEQ;
+
+    create index IDX_EventTypes_element ON EventTypes(element);

--- a/jbpm-db-scripts/src/test/resources/ddl60/sqlserver/sqlserver-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/test/resources/ddl60/sqlserver/sqlserver-jbpm-schema.sql
@@ -577,3 +577,5 @@
         add constraint FK61F475A5F510CB46 
         foreign key (TaskData_Comments_Id) 
         references Task;
+
+    create index IDX_EventTypes_element ON EventTypes(element);

--- a/jbpm-db-scripts/src/test/resources/ddl60/sqlserver2008/sqlserver2008-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/test/resources/ddl60/sqlserver2008/sqlserver2008-jbpm-schema.sql
@@ -577,3 +577,5 @@
         add constraint FK61F475A5F510CB46 
         foreign key (TaskData_Comments_Id) 
         references Task;
+
+    create index IDX_EventTypes_element ON EventTypes(element);


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/JBPM-10094

Updated the index settings in SQL Server DDL Script-sqlserver-jbpm-schema.sql to resolve the DeadLocks in SQL Server under stress tests.