### PR TITLE
JBPM-10112: Expand class name of fundamental java classes if not defi…

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/ObjectDataType.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/ObjectDataType.java
@@ -107,20 +107,19 @@ public class ObjectDataType implements DataType {
     }
 
     private boolean isValidDate(Object value) {
-        String dateString = (String)value;
         boolean parseable = false;
         try{
-            parseable = LocalDate.parse(dateString)!=null;
+            parseable = LocalDate.parse((String)value)!=null;
         } catch(Exception e) {
             // ignore parse exception
         }
         try{
-            parseable = LocalDateTime.parse(dateString)!=null;
+            parseable = LocalDateTime.parse((String)value)!=null;
         } catch(Exception e) {
             // ignore parse exception
         }
         try{
-            parseable = ZonedDateTime.parse(dateString)!=null;
+            parseable = ZonedDateTime.parse((String)value)!=null;
         } catch(Exception e) {
             // ignore parse exception
         }

--- a/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/ObjectDataType.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/ObjectDataType.java
@@ -19,6 +19,10 @@ package org.jbpm.process.core.datatype.impl.type;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.Map;
 
 import com.thoughtworks.xstream.XStream;
@@ -81,7 +85,7 @@ public class ObjectDataType implements DataType {
         }
         try {
             Class<?> clazz = Class.forName(className, true, value.getClass().getClassLoader());
-            if (clazz.isInstance(value)) {
+            if (clazz.isInstance(value) || isValidDate(value)) {
                 return true;
             }
         } catch (ClassNotFoundException e) {
@@ -100,6 +104,27 @@ public class ObjectDataType implements DataType {
             }
         }
         return false;
+    }
+
+    private boolean isValidDate(Object value) {
+        String dateString = (String)value;
+        boolean parseable = false;
+        try{
+            parseable = LocalDate.parse(dateString)!=null;
+        } catch(Exception e) {
+            // ignore parse exception
+        }
+        try{
+            parseable = LocalDateTime.parse(dateString)!=null;
+        } catch(Exception e) {
+            // ignore parse exception
+        }
+        try{
+            parseable = ZonedDateTime.parse(dateString)!=null;
+        } catch(Exception e) {
+            // ignore parse exception
+        }
+        return parseable;
     }
 
     public Object readValue(String value) {

--- a/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/ObjectDataType.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/ObjectDataType.java
@@ -85,7 +85,19 @@ public class ObjectDataType implements DataType {
                 return true;
             }
         } catch (ClassNotFoundException e) {
-            return false;
+            // check class again
+        }
+        // try to expand fundamental classes if it's not a FQCN
+        if(!className.contains(".")) {
+            try {
+                className = "java.lang."+className;
+                Class<?> clazz = Class.forName(className, true, value.getClass().getClassLoader());
+                if (clazz.isInstance(value)) {
+                    return true;
+                }
+            } catch (ClassNotFoundException e) {
+                return false;
+            }
         }
         return false;
     }

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/ProcessServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/ProcessServiceImplTest.java
@@ -87,6 +87,7 @@ public class ProcessServiceImplTest extends AbstractKieServicesBaseTest {
         processes.add("repo/processes/parentProcess/parentWithNotIndepententSubProcess.bpmn");
         processes.add("repo/processes/parentProcess/subprocess.bpmn");
         processes.add("repo/processes/general/SynchronousProcess.bpmn");
+        processes.add("repo/processes/general/MIProcess.bpmn");
 
         InternalKieModule kJar1 = createKieJar(ks, releaseId, processes);
         File pom = new File("target/kmodule", "pom.xml");
@@ -148,6 +149,23 @@ public class ProcessServiceImplTest extends AbstractKieServicesBaseTest {
 
     	ProcessInstance pi = processService.getProcessInstance(processInstanceId);
     	assertNull(pi);
+    }
+
+    @Test
+    public void testStartMIProcessWithObjectVariable() {
+        assertNotNull(deploymentService);
+
+        KModuleDeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
+
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+        assertNotNull(processService);
+
+        long processInstanceId = processService.startProcess(deploymentUnit.getIdentifier(), "MIProcess");
+        assertNotNull(processInstanceId);
+
+        ProcessInstance pi = processService.getProcessInstance(processInstanceId);
+        assertNull(pi);
     }
 
     @Test

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/ProcessServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/ProcessServiceImplTest.java
@@ -88,6 +88,7 @@ public class ProcessServiceImplTest extends AbstractKieServicesBaseTest {
         processes.add("repo/processes/parentProcess/subprocess.bpmn");
         processes.add("repo/processes/general/SynchronousProcess.bpmn");
         processes.add("repo/processes/general/MIProcess.bpmn");
+        processes.add("repo/processes/general/DateVariableTestProcess.bpmn");
 
         InternalKieModule kJar1 = createKieJar(ks, releaseId, processes);
         File pom = new File("target/kmodule", "pom.xml");
@@ -162,6 +163,28 @@ public class ProcessServiceImplTest extends AbstractKieServicesBaseTest {
         assertNotNull(processService);
 
         long processInstanceId = processService.startProcess(deploymentUnit.getIdentifier(), "MIProcess");
+        assertNotNull(processInstanceId);
+
+        ProcessInstance pi = processService.getProcessInstance(processInstanceId);
+        assertNull(pi);
+    }
+
+    @Test
+    public void testStartProcessInstanceWithDateVariable() {
+        assertNotNull(deploymentService);
+
+        KModuleDeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
+
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+        assertNotNull(processService);
+
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("timerIn", "6000000");
+        params.put("DateIn", "2002-07-08T23:17:00.000Z");
+
+
+        long processInstanceId = processService.startProcess(deploymentUnit.getIdentifier(), "DateVariableTestProcess", params);
         assertNotNull(processInstanceId);
 
         ProcessInstance pi = processService.getProcessInstance(processInstanceId);

--- a/jbpm-services/jbpm-kie-services/src/test/resources/repo/processes/general/DateVariableTestProcess.bpmn
+++ b/jbpm-services/jbpm-kie-services/src/test/resources/repo/processes/general/DateVariableTestProcess.bpmn
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns:xsi="xsi" id="_WYEpYPsVEDqMLbgzTznQgw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_integerInItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_booleanInItem" structureRef="Boolean"/>
+  <bpmn2:itemDefinition id="_stringInItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_timerInItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_DateInItem" structureRef="java.util.Date"/>
+  <bpmn2:collaboration id="_DEF1A7E1-4CC2-4924-8B1F-CDD4EF43F1E9" name="Default Collaboration">
+    <bpmn2:participant id="_B2A78040-3312-40DA-8A0E-515D7A8106EC" name="Pool Participant" processRef="DateVariableTestProcess"/>
+  </bpmn2:collaboration>
+  <bpmn2:process id="DateVariableTestProcess" drools:packageName="org.jbpm" drools:version="1.0" drools:adHoc="false" name="DateVariableTestProcess" isExecutable="true" processType="Public">
+    <bpmn2:property id="integerIn" itemSubjectRef="_integerInItem" name="integerIn"/>
+    <bpmn2:property id="booleanIn" itemSubjectRef="_booleanInItem" name="booleanIn"/>
+    <bpmn2:property id="stringIn" itemSubjectRef="_stringInItem" name="stringIn"/>
+    <bpmn2:property id="timerIn" itemSubjectRef="_timerInItem" name="timerIn"/>
+    <bpmn2:property id="DateIn" itemSubjectRef="_DateInItem" name="DateIn"/>
+    <bpmn2:sequenceFlow id="_7D18BF09-4F26-40EA-861C-7ACAB1513C54" sourceRef="processStartEvent" targetRef="_22D8FB9E-239E-4D9C-853C-1347E9C12CE7"/>
+    <bpmn2:sequenceFlow id="_0758DEB3-CEC9-4949-A667-5D5E00175FB1" sourceRef="_22D8FB9E-239E-4D9C-853C-1347E9C12CE7" targetRef="_83540C34-97AC-4A4D-82EC-9C281E956A71"/>
+    <bpmn2:startEvent id="processStartEvent" name="Attendre un Timer">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Attendre un Timer]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_7D18BF09-4F26-40EA-861C-7ACAB1513C54</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:scriptTask id="_22D8FB9E-239E-4D9C-853C-1347E9C12CE7" name="Script Node 1" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Script Node 1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_7D18BF09-4F26-40EA-861C-7ACAB1513C54</bpmn2:incoming>
+      <bpmn2:outgoing>_0758DEB3-CEC9-4949-A667-5D5E00175FB1</bpmn2:outgoing>
+      <bpmn2:script>System.out.println("Timer Process Phase 1 " + timerIn);</bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:endEvent id="_83540C34-97AC-4A4D-82EC-9C281E956A71" name="Timer Terminé">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Timer Terminé]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_0758DEB3-CEC9-4949-A667-5D5E00175FB1</bpmn2:incoming>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="DateVariableTestProcess">
+      <bpmndi:BPMNShape id="shape__83540C34-97AC-4A4D-82EC-9C281E956A71" bpmnElement="_83540C34-97AC-4A4D-82EC-9C281E956A71">
+        <dc:Bounds height="56" width="56" x="500" y="165"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__22D8FB9E-239E-4D9C-853C-1347E9C12CE7" bpmnElement="_22D8FB9E-239E-4D9C-853C-1347E9C12CE7">
+        <dc:Bounds height="79" width="99" x="272.5" y="154"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape_processStartEvent" bpmnElement="processStartEvent">
+        <dc:Bounds height="56" width="56" x="120" y="165"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__22D8FB9E-239E-4D9C-853C-1347E9C12CE7_to_shape__83540C34-97AC-4A4D-82EC-9C281E956A71" bpmnElement="_0758DEB3-CEC9-4949-A667-5D5E00175FB1">
+        <di:waypoint x="322" y="193.5"/>
+        <di:waypoint x="514" y="179"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape_processStartEvent_to_shape__22D8FB9E-239E-4D9C-853C-1347E9C12CE7" bpmnElement="_7D18BF09-4F26-40EA-861C-7ACAB1513C54">
+        <di:waypoint x="135" y="180"/>
+        <di:waypoint x="272.5" y="193.5"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_22D8FB9E-239E-4D9C-853C-1347E9C12CE7">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="processStartEvent">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:UniformDistribution max="10" min="5"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_WYEpYPsVEDqMLbgzTznQgw</bpmn2:source>
+    <bpmn2:target>_WYEpYPsVEDqMLbgzTznQgw</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-services/jbpm-kie-services/src/test/resources/repo/processes/general/MIProcess.bpmn
+++ b/jbpm-services/jbpm-kie-services/src/test/resources/repo/processes/general/MIProcess.bpmn
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_vBs4UBcmEe2bpNurlT5VKw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_mi_listItem" structureRef="java.util.List"/>
+  <bpmn2:itemDefinition id="_CCC9BEA0-99B9-4246-A579-72FD06BAD168_multiInstanceItemType_mi_current_var" structureRef="Object"/>
+  <bpmn2:process id="MIProcess" drools:packageName="org.jbpm" drools:version="1.0" drools:adHoc="false" name="case03281958" isExecutable="true" processType="Public">
+    <bpmn2:property id="mi_list" itemSubjectRef="_mi_listItem" name="mi_list"/>
+    <bpmn2:sequenceFlow id="_886C9D7E-26C4-440A-A08A-3DD7DAA62EB3" sourceRef="_6E098911-A004-4295-959A-502B8AEF3902" targetRef="_CCC9BEA0-99B9-4246-A579-72FD06BAD168">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_64A22910-5378-4F6E-968A-DE4C03058283" sourceRef="_CCC9BEA0-99B9-4246-A579-72FD06BAD168" targetRef="_47CDD733-964E-4C51-85AA-F7EB68739FE4">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_EE283882-AA20-4AA0-9AC7-CD792EB25A70" sourceRef="_F033EE15-B0A2-4794-8E80-F87752268F17" targetRef="_6E098911-A004-4295-959A-502B8AEF3902">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:scriptTask id="_6E098911-A004-4295-959A-502B8AEF3902" name="Task" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_EE283882-AA20-4AA0-9AC7-CD792EB25A70</bpmn2:incoming>
+      <bpmn2:outgoing>_886C9D7E-26C4-440A-A08A-3DD7DAA62EB3</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[java.util.ArrayList temp_list= new java.util.ArrayList<java.lang.String>();
+temp_list.add("val1");
+temp_list.add("val2");
+
+kcontext.setVariable("mi_list",temp_list);]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:endEvent id="_47CDD733-964E-4C51-85AA-F7EB68739FE4">
+      <bpmn2:incoming>_64A22910-5378-4F6E-968A-DE4C03058283</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:startEvent id="_F033EE15-B0A2-4794-8E80-F87752268F17">
+      <bpmn2:outgoing>_EE283882-AA20-4AA0-9AC7-CD792EB25A70</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:subProcess id="_CCC9BEA0-99B9-4246-A579-72FD06BAD168" name="Sub-process">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Sub-process]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_886C9D7E-26C4-440A-A08A-3DD7DAA62EB3</bpmn2:incoming>
+      <bpmn2:outgoing>_64A22910-5378-4F6E-968A-DE4C03058283</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_vBtfYBcmEe2bpNurlT5VKw">
+        <bpmn2:dataInput id="_CCC9BEA0-99B9-4246-A579-72FD06BAD168_IN_COLLECTIONInputX" itemSubjectRef="_mi_listItem" name="IN_COLLECTION"/>
+        <bpmn2:dataInput id="_CCC9BEA0-99B9-4246-A579-72FD06BAD168_mi_current_varInputX" itemSubjectRef="_CCC9BEA0-99B9-4246-A579-72FD06BAD168_multiInstanceItemType_mi_current_var" name="mi_current_var"/>
+        <bpmn2:inputSet id="_vBtfYRcmEe2bpNurlT5VKw">
+          <bpmn2:dataInputRefs>_CCC9BEA0-99B9-4246-A579-72FD06BAD168_IN_COLLECTIONInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_CCC9BEA0-99B9-4246-A579-72FD06BAD168_mi_current_varInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_vBtfYhcmEe2bpNurlT5VKw"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_vBtfYxcmEe2bpNurlT5VKw">
+        <bpmn2:sourceRef>mi_list</bpmn2:sourceRef>
+        <bpmn2:targetRef>_CCC9BEA0-99B9-4246-A579-72FD06BAD168_IN_COLLECTIONInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:multiInstanceLoopCharacteristics id="_vBtfZBcmEe2bpNurlT5VKw">
+        <bpmn2:loopDataInputRef>_CCC9BEA0-99B9-4246-A579-72FD06BAD168_IN_COLLECTIONInputX</bpmn2:loopDataInputRef>
+        <bpmn2:inputDataItem xsi:type="bpmn2:tDataInput" id="mi_current_var" itemSubjectRef="_CCC9BEA0-99B9-4246-A579-72FD06BAD168_multiInstanceItemType_mi_current_var" name="mi_current_var"/>
+      </bpmn2:multiInstanceLoopCharacteristics>
+      <bpmn2:sequenceFlow id="_9AC86D68-87A7-461C-BB38-A5066B2A869A" sourceRef="_C516F3A8-5EE5-49F7-A296-9AC631970106" targetRef="_B5F95E2C-11A1-4A8F-82D4-1A97C2FADB4E">
+        <bpmn2:extensionElements>
+          <drools:metaData name="isAutoConnection.target">
+            <drools:metaValue><![CDATA[true]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+      </bpmn2:sequenceFlow>
+      <bpmn2:sequenceFlow id="_5022B4F5-383A-44BB-9F07-6D450B47DC19" sourceRef="_106675F1-D1AF-41EC-A0D4-BE094640CB79" targetRef="_C516F3A8-5EE5-49F7-A296-9AC631970106">
+        <bpmn2:extensionElements>
+          <drools:metaData name="isAutoConnection.source">
+            <drools:metaValue><![CDATA[true]]></drools:metaValue>
+          </drools:metaData>
+          <drools:metaData name="isAutoConnection.target">
+            <drools:metaValue><![CDATA[true]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+      </bpmn2:sequenceFlow>
+      <bpmn2:endEvent id="_B5F95E2C-11A1-4A8F-82D4-1A97C2FADB4E">
+        <bpmn2:incoming>_9AC86D68-87A7-461C-BB38-A5066B2A869A</bpmn2:incoming>
+      </bpmn2:endEvent>
+      <bpmn2:scriptTask id="_C516F3A8-5EE5-49F7-A296-9AC631970106" name="Task" scriptFormat="http://www.java.com/java">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[Task]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:incoming>_5022B4F5-383A-44BB-9F07-6D450B47DC19</bpmn2:incoming>
+        <bpmn2:outgoing>_9AC86D68-87A7-461C-BB38-A5066B2A869A</bpmn2:outgoing>
+        <bpmn2:script><![CDATA[System.out.println("MI sub-process executed for variable " + mi_current_var);]]></bpmn2:script>
+      </bpmn2:scriptTask>
+      <bpmn2:startEvent id="_106675F1-D1AF-41EC-A0D4-BE094640CB79">
+        <bpmn2:outgoing>_5022B4F5-383A-44BB-9F07-6D450B47DC19</bpmn2:outgoing>
+      </bpmn2:startEvent>
+    </bpmn2:subProcess>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_vBtfZRcmEe2bpNurlT5VKw">
+    <bpmndi:BPMNPlane id="_vBtfZhcmEe2bpNurlT5VKw" bpmnElement="SignalIssueProject.case03281958">
+      <bpmndi:BPMNShape id="shape__CCC9BEA0-99B9-4246-A579-72FD06BAD168" bpmnElement="_CCC9BEA0-99B9-4246-A579-72FD06BAD168">
+        <dc:Bounds height="249.0" width="559.0" x="473.0" y="123.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__106675F1-D1AF-41EC-A0D4-BE094640CB79" bpmnElement="_106675F1-D1AF-41EC-A0D4-BE094640CB79">
+        <dc:Bounds height="56.0" width="56.0" x="542.0" y="216.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__C516F3A8-5EE5-49F7-A296-9AC631970106_to_shape__B5F95E2C-11A1-4A8F-82D4-1A97C2FADB4E" bpmnElement="_9AC86D68-87A7-461C-BB38-A5066B2A869A">
+        <di:waypoint xsi:type="dc:Point" x="755.0" y="244.0"/>
+        <di:waypoint xsi:type="dc:Point" x="919.0" y="241.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__106675F1-D1AF-41EC-A0D4-BE094640CB79_to_shape__C516F3A8-5EE5-49F7-A296-9AC631970106" bpmnElement="_5022B4F5-383A-44BB-9F07-6D450B47DC19">
+        <di:waypoint xsi:type="dc:Point" x="598.0" y="244.0"/>
+        <di:waypoint xsi:type="dc:Point" x="678.0" y="244.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="shape__C516F3A8-5EE5-49F7-A296-9AC631970106" bpmnElement="_C516F3A8-5EE5-49F7-A296-9AC631970106">
+        <dc:Bounds height="102.0" width="154.0" x="678.0" y="193.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__B5F95E2C-11A1-4A8F-82D4-1A97C2FADB4E" bpmnElement="_B5F95E2C-11A1-4A8F-82D4-1A97C2FADB4E">
+        <dc:Bounds height="56.0" width="56.0" x="919.0" y="213.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__F033EE15-B0A2-4794-8E80-F87752268F17" bpmnElement="_F033EE15-B0A2-4794-8E80-F87752268F17">
+        <dc:Bounds height="56.0" width="56.0" x="96.0" y="213.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__47CDD733-964E-4C51-85AA-F7EB68739FE4" bpmnElement="_47CDD733-964E-4C51-85AA-F7EB68739FE4">
+        <dc:Bounds height="56.0" width="56.0" x="1115.0" y="219.5"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__6E098911-A004-4295-959A-502B8AEF3902" bpmnElement="_6E098911-A004-4295-959A-502B8AEF3902">
+        <dc:Bounds height="102.0" width="154.0" x="231.0" y="190.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__F033EE15-B0A2-4794-8E80-F87752268F17_to_shape__6E098911-A004-4295-959A-502B8AEF3902" bpmnElement="_EE283882-AA20-4AA0-9AC7-CD792EB25A70">
+        <di:waypoint xsi:type="dc:Point" x="152.0" y="241.0"/>
+        <di:waypoint xsi:type="dc:Point" x="231.0" y="241.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__CCC9BEA0-99B9-4246-A579-72FD06BAD168_to_shape__47CDD733-964E-4C51-85AA-F7EB68739FE4" bpmnElement="_64A22910-5378-4F6E-968A-DE4C03058283">
+        <di:waypoint xsi:type="dc:Point" x="1032.0" y="247.5"/>
+        <di:waypoint xsi:type="dc:Point" x="1115.0" y="247.5"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__6E098911-A004-4295-959A-502B8AEF3902_to_shape__CCC9BEA0-99B9-4246-A579-72FD06BAD168" bpmnElement="_886C9D7E-26C4-440A-A08A-3DD7DAA62EB3">
+        <di:waypoint xsi:type="dc:Point" x="308.0" y="241.0"/>
+        <di:waypoint xsi:type="dc:Point" x="473.0" y="247.5"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_vBtfZxcmEe2bpNurlT5VKw" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_F033EE15-B0A2-4794-8E80-F87752268F17" id="_vBtfaBcmEe2bpNurlT5VKw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_6E098911-A004-4295-959A-502B8AEF3902" id="_vBtfaRcmEe2bpNurlT5VKw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_vBs4UBcmEe2bpNurlT5VKw</bpmn2:source>
+    <bpmn2:target>_vBs4UBcmEe2bpNurlT5VKw</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION
…ned as FQCN to address org.xmlpull.v1.XmlPullParserException in VariableScope.validateVariable

**Thank you for submitting this pull request**

**JIRA**: [JBPM-10112](https://issues.redhat.com/browse/JBPM-10112)

Due to the changes from JBPM-9924, a variable defined as "Object" (without package name), holding a String value fails to be validated. The proposed fix improves the class resolution in ObjectDataType.verifyDataType by adding the 'java.lang.' package to the className in an additional check.