### PR TITLE
[7.67.x-blue][JBPM-10039] Incorrect groups are returned when "org.kie.server.bypass.auth.user" is set and JAASUserGroupCallbackImpl is used

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/identity/JAASUserGroupCallbackImpl.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/identity/JAASUserGroupCallbackImpl.java
@@ -113,7 +113,7 @@ public class JAASUserGroupCallbackImpl extends AbstractUserGroupInfo implements 
         try {
             Subject subject = getSubjectFromContainer();
     
-            if (subject != null) {
+            if (subject != null && subjectContainsUser(subject, userId)) {
                 Set<Principal> principals = subject.getPrincipals();
     
                 if (principals != null) {
@@ -156,6 +156,10 @@ public class JAASUserGroupCallbackImpl extends AbstractUserGroupInfo implements 
         }
         return roles;
 	}
+
+    private boolean subjectContainsUser(Subject subject, String userId) {
+        return subject.getPrincipals().stream().map(Principal::getName).anyMatch(userId::equals);
+    }
 
 	protected Subject getSubjectFromContainer() {
          try {


### PR DESCRIPTION
Backport of https://github.com/kiegroup/jbpm/pull/2125/commits/b675883ae8778ff23dc7c390461cc47361af6cd8