### PR TITLE
[JBPM-10118] Wrap into CDATA to avoid escape chars in SOAP headers

### DIFF
--- a/jbpm-workitems/jbpm-workitems-webservice/src/main/java/org/jbpm/process/workitem/webservice/CDataWriterInterceptor.java
+++ b/jbpm-workitems/jbpm-workitems-webservice/src/main/java/org/jbpm/process/workitem/webservice/CDataWriterInterceptor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.process.workitem.webservice;
+
+import java.io.OutputStream;
+import javax.xml.stream.XMLStreamWriter;
+import org.apache.cxf.interceptor.AttachmentOutInterceptor;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.apache.cxf.staxutils.StaxUtils;
+
+public class CDataWriterInterceptor extends AbstractPhaseInterceptor<Message>{
+
+    private final String cdataElement;
+
+    public CDataWriterInterceptor(String cdataElement) {
+        super(Phase.PRE_STREAM);
+        addAfter(AttachmentOutInterceptor.class.getName());
+        this.cdataElement = cdataElement;
+    }
+
+    @Override
+    public void handleMessage(Message message) {
+        OutputStream msg = message.getContent(OutputStream.class);
+        if (msg == null) {
+            return;
+        }
+        
+        message.put("disable.outputstream.optimization", Boolean.TRUE);
+        message.setContent(XMLStreamWriter.class, new CDataXMLStreamWriter(StaxUtils.createXMLStreamWriter(msg), cdataElement));
+    }
+}

--- a/jbpm-workitems/jbpm-workitems-webservice/src/main/java/org/jbpm/process/workitem/webservice/CDataXMLStreamWriter.java
+++ b/jbpm-workitems/jbpm-workitems-webservice/src/main/java/org/jbpm/process/workitem/webservice/CDataXMLStreamWriter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.process.workitem.webservice;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import org.apache.cxf.staxutils.DelegatingXMLStreamWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CDataXMLStreamWriter extends DelegatingXMLStreamWriter {
+
+    private static Logger logger = LoggerFactory.getLogger(CDataXMLStreamWriter.class);
+    private final List<String> cdataElements;
+    private String currentElementName;
+
+    public CDataXMLStreamWriter(XMLStreamWriter del, String cdataElementStr) {
+        super(del);
+        this.cdataElements = Arrays.asList(cdataElementStr.split(","));
+    }
+
+    @Override
+    public void writeStartElement(String prefix, String local, String uri) throws XMLStreamException {
+        currentElementName = local; 
+        super.writeStartElement(prefix, local, uri); 
+    } 
+
+    @Override
+    public void writeCharacters(char[] text, int start, int len) throws XMLStreamException {
+        if (cdataElements.contains(currentElementName)) { 
+          logger.debug("Writing CDATA for element {}", currentElementName);
+          super.writeCData(new String(text));
+        } else {
+            logger.debug("No CDATA replacement for element {}", currentElementName);
+            super.writeCharacters(text, start, len);
+        }
+    }
+}

--- a/jbpm-workitems/jbpm-workitems-webservice/src/main/java/org/jbpm/process/workitem/webservice/WebServiceWorkItemHandler.java
+++ b/jbpm-workitems/jbpm-workitems-webservice/src/main/java/org/jbpm/process/workitem/webservice/WebServiceWorkItemHandler.java
@@ -528,6 +528,7 @@ public class WebServiceWorkItemHandler extends AbstractLogOrThrowWorkItemHandler
         setClientTimeout(workItem, client);
         setEscapeHandler(workItem, client);
         addHeaders(workItem, client);
+        addCDataWriterInterceptor(workItem, client);
         return client;
     }
 
@@ -596,6 +597,14 @@ public class WebServiceWorkItemHandler extends AbstractLogOrThrowWorkItemHandler
             logger.warn("Error instantiating escape handler, characters will be escaped", e);
         }
         return null;
+    }
+    
+    private void addCDataWriterInterceptor(WorkItem workItem, Client client) {
+        String cdataElements = (String) workItem.getParameter("CDataElements");
+        if (cdataElements != null) {
+            logger.debug("Adding CData Interceptor for elements {}", cdataElements);
+            client.getOutInterceptors().add(new CDataWriterInterceptor(cdataElements));
+        }
     }
 
     private static final class LoggingEscapeHandlerInvocationHandler implements InvocationHandler {


### PR DESCRIPTION
**JIRA**: [JBPM-10118](https://issues.redhat.com/browse/JBPM-10118)

Related test:  
* https://github.com/kiegroup/droolsjbpm-integration/pull/2858

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
