### PR TITLE
Use date format for log cleanup command

### DIFF
--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/CaseLogCleanupCommandTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/CaseLogCleanupCommandTest.java
@@ -17,6 +17,7 @@
 package org.jbpm.test.functional.jobexec;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -323,7 +324,7 @@ public class CaseLogCleanupCommandTest extends AbstractCaseServicesTest {
         commandContext.setData("EmfName", "org.jbpm.test.persistence");
         commandContext.setData("SingleRun", "true");
         commandContext.setData("DateFormat", dateFormat);
-        commandContext.setData("OlderThan", LocalDateTime.now().toString());
+        commandContext.setData("OlderThan", LocalDateTime.now().format(DateTimeFormatter.ofPattern(dateFormat)));
 
         Iterator<Map.Entry<String, Object>> iterator = parameters.entrySet().iterator();
         while (iterator.hasNext()) {


### PR DESCRIPTION
This fixes the following error in the GHA log: WARN  Error during command org.jbpm.casemgmt.impl.audit.CaseLogCleanupCommand error message Unparseable date: "2022-12-01T11:24:25"