### PR TITLE
[JBPM-10144] Flush TimerMappingInfo persist operation early to avoid stale timers

### DIFF
--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/AbstractRuntimeManager.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/AbstractRuntimeManager.java
@@ -254,7 +254,8 @@ public abstract class AbstractRuntimeManager implements InternalRuntimeManager {
                         }
                     }
                     em.persist(info);
-                    logger.debug("Created Timer Mapping Info for {}", info);
+                    em.flush();
+                    logger.debug("Created Timer Mapping Info for {} and flushed to DB", info);
                 } finally {
                     em.close();
                 }


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/JBPM-10144