### PR TITLE
[JBPM-10176] Detect creation of timers for notifications

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/timer/TimerManager.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/timer/TimerManager.java
@@ -399,7 +399,7 @@ public class TimerManager {
         private JobHandle jobHandle;
         private Long sessionId;
         
-        private boolean newTimer;
+        private boolean isNew;
 
         public ProcessJobContext(final TimerInstance timer, final Trigger trigger, final Long processInstanceId,
                 final InternalKnowledgeRuntime kruntime) {
@@ -408,17 +408,17 @@ public class TimerManager {
             this.processInstanceId = processInstanceId;
             this.kruntime = kruntime;
             this.sessionId = timer.getSessionId();
-            this.newTimer = true;
+            this.isNew = true;
         }
         
         public ProcessJobContext(final TimerInstance timer, final Trigger trigger, final Long processInstanceId,
-                final InternalKnowledgeRuntime kruntime, boolean newTimer) {
+                final InternalKnowledgeRuntime kruntime, boolean isNew) {
             this.timer = timer;
             this.trigger = trigger;
             this.processInstanceId = processInstanceId;
             this.kruntime = kruntime;
             this.sessionId = timer.getSessionId();
-            this.newTimer = newTimer;
+            this.isNew = isNew;
         }
 
         public Long getProcessInstanceId() {
@@ -457,9 +457,10 @@ public class TimerManager {
         public InternalWorkingMemory getWorkingMemory() {
             return kruntime instanceof InternalWorkingMemory ? (InternalWorkingMemory)kruntime : null;
         }
-        
-        public boolean isNewTimer() {
-            return newTimer;
+
+        @Override
+        public boolean isNew() {
+            return isNew;
         }
     }
 
@@ -493,7 +494,7 @@ public class TimerManager {
         }
 
         @Override
-        public boolean isNewTimer() {
+        public boolean isNew() {
             return false;
         }
 

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/util/DeadlineSchedulerHelper.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/impl/util/DeadlineSchedulerHelper.java
@@ -138,7 +138,7 @@ public class DeadlineSchedulerHelper {
         for (Deadline deadline : deadlines) {
             if (Boolean.FALSE.equals(deadline.isEscalated())) {
                 Date date = deadline.getDate();
-                deadlineService.schedule(taskId, deadline.getId(), date.getTime() - now, type);
+                deadlineService.scheduleNew(taskId, deadline.getId(), date.getTime() - now, type);
             }
         }
     }

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
@@ -48,7 +48,6 @@ import org.jbpm.process.core.timer.SchedulerServiceInterceptor;
 import org.jbpm.process.core.timer.impl.DelegateSchedulerServiceInterceptor;
 import org.jbpm.process.core.timer.impl.GlobalTimerService;
 import org.jbpm.process.core.timer.impl.GlobalTimerService.GlobalJobHandle;
-import org.jbpm.process.instance.timer.TimerManager.ProcessJobContext;
 import org.jbpm.runtime.manager.impl.jpa.EntityManagerFactoryManager;
 import org.jbpm.runtime.manager.impl.jpa.TimerMappingInfo;
 import org.kie.internal.runtime.manager.InternalRuntimeManager;
@@ -77,7 +76,7 @@ public class EjbSchedulerService implements GlobalSchedulerService {
 		TimerJobInstance jobInstance = null;
 		// check if given timer job is marked as new timer meaning it was never scheduled before, 
 		// if so skip the check by timer name as it has no way to exist
-		if (!isNewTimer(ctx)) {
+		if (!ctx.isNew()) {
 		    jobInstance = getTimerJobInstance(jobName);
 		    if (jobInstance == null) {
 		        jobInstance = scheduler.getTimerByName(jobName);
@@ -265,9 +264,4 @@ public class EjbSchedulerService implements GlobalSchedulerService {
     protected String getJobName(JobContext ctx, long id) {
            return JobNameHelper.getJobName(ctx, id);
 	}
-	
-   private boolean isNewTimer(JobContext ctx) {
-       return ctx instanceof ProcessJobContext && ((ProcessJobContext) ctx).isNewTimer();
-   }
-
 }


### PR DESCRIPTION
[JBPM-10176](https://issues.redhat.com/browse/JBPM-10176)

needs:
-  https://github.com/kiegroup/droolsjbpm-knowledge/pull/641
- https://github.com/kiegroup/drools/pull/5293

Add a TimerJobContext to detect if a job is just created to not look for it in existing timers

The problem is only noticeable if you have lot of timers and creates a new notifications.

The interface allow any other job creating timers to control this behaviour.