### PR TITLE
[7.67.x-blue] RHPAM-4446: beforeTaskCompletedEvent shows updated value of process vars

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/commands/CompleteTaskCommand.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/commands/CompleteTaskCommand.java
@@ -44,6 +44,8 @@ import java.util.Map;
 public class CompleteTaskCommand extends UserGroupCallbackTaskCommand<Void> {
 
 	private static final long serialVersionUID = 412409697422083299L;
+
+    public static final String TASK_OUT_VARS_CONTEXT_KEY = "beforeTaskExecutedOutputVariables";
 	
 	@XmlJavaTypeAdapter(JaxbMapAdapter.class)
     @XmlElement
@@ -75,6 +77,12 @@ public class CompleteTaskCommand extends UserGroupCallbackTaskCommand<Void> {
         Task task = context.getTaskQueryService().getTaskInstanceById(taskId);
         if (task == null) {            
             throw new PermissionDeniedException("Task '" + taskId + "' not found");
+        }
+
+        if (task.getTaskData().getTaskOutputVariables() != null ) {
+            Map<String, Object> taskOutputVariablesContext= new HashMap<>();
+            taskOutputVariablesContext.putAll(task.getTaskData().getTaskOutputVariables());
+            context.getContextData().put(TASK_OUT_VARS_CONTEXT_KEY, taskOutputVariablesContext);
         }
         
         context.loadTaskVariables(task);

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/commands/TaskContext.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/commands/TaskContext.java
@@ -15,6 +15,7 @@
  */
 package org.jbpm.services.task.commands;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.jbpm.services.task.events.TaskEventSupport;
@@ -64,6 +65,8 @@ public class TaskContext implements org.kie.internal.task.api.TaskContext, Reque
     private org.kie.internal.task.api.TaskContext delegate;
     
     private String userId;
+
+    private Map<String, Object> contextData;
     
     public TaskContext() {
     }   
@@ -238,5 +241,12 @@ public class TaskContext implements org.kie.internal.task.api.TaskContext, Reque
     
     public void setUserId(String userId) {
         this.userId = userId;
+    }
+
+    public Map<String, Object> getContextData() {
+        if (contextData == null) {
+            contextData = new HashMap<>();
+        }
+        return contextData;
     }
 }

--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/persistence/TaskTransactionInterceptor.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/persistence/TaskTransactionInterceptor.java
@@ -246,6 +246,11 @@ public class TaskTransactionInterceptor extends AbstractInterceptor {
 	    public void setUserId(String userId) {
 	        this.userId = userId;
 	    }
+
+		@Override
+		public Map<String, Object> getContextData() {
+			throw new UnsupportedOperationException( "org.jbpm.services.task.persistence.TaskTransactionInterceptor.TransactionContext.getApplicationContext -> TODO" );
+		}
 	}
 	
 	public void initTransactionManager(Environment env) {

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/TaskCompletedListenersTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/TaskCompletedListenersTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.test.functional.task;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.jbpm.services.task.commands.CompleteTaskCommand;
+import org.jbpm.services.task.events.DefaultTaskEventListener;
+import org.jbpm.test.JbpmTestCase;
+import org.junit.Test;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.manager.RuntimeEngine;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.api.task.TaskEvent;
+import org.kie.api.task.TaskService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test listeners tied to adding assignments - RHPAM-4442
+ */
+public class TaskCompletedListenersTest extends JbpmTestCase {
+
+    private KieSession ksession;
+    private TaskService ts;
+
+
+    Map<String, Object> formerVars;
+    Map<String, Object> actualVars;
+
+
+    MutableInt triggeredBeforeTaskCompletedListenerCounter;
+
+
+    private static final String PROCESS = "org/jbpm/test/functional/task/HumanTask-simple-with-outputvars.bpmn2";
+    private static final String PROCESS_ID = "org.jbpm.test.functional.task.HumanTask_simple_with_outputvars";
+
+
+    private void init() {
+        createRuntimeManager(PROCESS);
+        RuntimeEngine runtimeEngine = getRuntimeEngine();
+        ksession = runtimeEngine.getKieSession();
+        ts = runtimeEngine.getTaskService();
+    }
+//
+//    @After
+//    public void clenaup() {
+//        if (ksession != null) {
+//            ksession.dispose();
+//        }
+//        disposeRuntimeManager();
+//    }
+
+    @Test
+    public void testBeforeCompletedListenersRegression() {
+        DefaultTaskEventListener listener = new DefaultTaskEventListener() {
+            @Override
+            public void beforeTaskCompletedEvent(TaskEvent event) {
+
+                putAllNullSafe(actualVars, event.getTask().getTaskData().getTaskOutputVariables());
+                triggeredBeforeTaskCompletedListenerCounter.increment();
+
+                logger.debug("taskOutputVariables: " + event.getTask().getTaskData().getTaskOutputVariables());
+            }
+        };
+
+        triggeredBeforeTaskCompletedListenerCounter = new MutableInt(0);
+
+        actualVars = new HashMap<>();
+
+        addTaskEventListener(listener);
+
+        init();
+
+        ProcessInstance pi = ksession.startProcess(PROCESS_ID);
+        long pid = pi.getId();
+
+        assertProcessInstanceActive(pi.getId(), ksession);
+        assertNodeTriggered(pi.getId(), "Start", "Task");
+
+        Map<String, Object> outputParams = new HashMap<>();
+        outputParams.put("Output", "RHPAM-4446");
+        for (long taskId : ts.getTasksByProcessInstanceId(pid)) {
+            ts.start(taskId, "john");
+            ts.complete(taskId, "john", outputParams);
+        }
+
+        assertThat(triggeredBeforeTaskCompletedListenerCounter.getValue()).isEqualTo(1);
+        assertThat(actualVars).hasSize(1);
+        assertThat(actualVars).containsKey("Output");
+    }
+
+    @Test
+    public void testBeforeCompletedListener() {
+        triggeredBeforeTaskCompletedListenerCounter = new MutableInt(0);
+
+        formerVars = new HashMap<>();
+        actualVars = new HashMap<>();
+
+        DefaultTaskEventListener listener = new DefaultTaskEventListener() {
+            @Override
+            public void beforeTaskCompletedEvent(TaskEvent event) {
+
+                putAllNullSafe(actualVars, event.getTask().getTaskData().getTaskOutputVariables());
+                Map<String, Object> contextData = event.getTaskContext().getContextData();
+                Map<String, Object> taskOutputVarsCtx = (Map<String,Object>) contextData.get(CompleteTaskCommand.TASK_OUT_VARS_CONTEXT_KEY);
+                putAllNullSafe(formerVars, taskOutputVarsCtx);
+
+                triggeredBeforeTaskCompletedListenerCounter.increment();
+
+                logger.debug("taskOutputVariables: " + event.getTask().getTaskData().getTaskOutputVariables());
+                logger.debug("before completed TaskOutputVariables: " + taskOutputVarsCtx);
+            }
+        };
+
+        addTaskEventListener(listener);
+
+        init();
+
+        ProcessInstance pi = ksession.startProcess(PROCESS_ID);
+        long pid = pi.getId();
+
+        assertProcessInstanceActive(pi.getId(), ksession);
+        assertNodeTriggered(pi.getId(), "Start", "Task");
+
+        Map<String, Object> outputParams = new HashMap<>();
+        outputParams.put("Output", "RHPAM-4446");
+        for (long taskId : ts.getTasksByProcessInstanceId(pid)) {
+            ts.start(taskId, "john");
+            ts.complete(taskId, "john", outputParams);
+        }
+
+        assertThat(triggeredBeforeTaskCompletedListenerCounter.getValue()).isEqualTo(1);
+        assertThat(formerVars).hasSize(0);
+        assertThat(formerVars).doesNotContainKey("Output");
+
+        assertThat(actualVars).hasSize(1);
+        assertThat(actualVars).containsKey("Output");
+
+    }
+
+    private <K, V> void putAllNullSafe(Map<K, V> target, Map<K, V> source) {
+        if ((source == null || target == null)) {
+            return;
+        }
+        target.putAll(source);
+    }
+}

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/task/HumanTask-simple-with-outputvars.bpmn2
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/task/HumanTask-simple-with-outputvars.bpmn2
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_rV5_YNiqEDuJ-N6lPK_Veg" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_originalOutputItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_PriorityInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_CommentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_DescriptionInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_CreatedByInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_TaskNameInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_GroupIdInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_ContentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_NotStartedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_NotCompletedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_NotStartedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_NotCompletedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_origOutputNameInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_originalOutputNameOutputXItem" structureRef="Object"/>
+  <bpmn2:collaboration id="_B0C02FF4-D754-4F8F-8143-121BC5FDD282" name="Default Collaboration">
+    <bpmn2:participant id="_63649A65-DFE4-4485-AB8C-BEC52F882AD4" name="Pool Participant" processRef="org.jbpm.test.functional.task.HumanTask_simple_with_outputvars"/>
+  </bpmn2:collaboration>
+  <bpmn2:process id="org.jbpm.test.functional.task.HumanTask_simple_with_outputvars" drools:packageName="org.jbpm.test.functional.task" drools:version="1.0" drools:adHoc="false" name="HumanTask_simple_with_outputvars" isExecutable="true" processType="Public">
+    <bpmn2:property id="originalOutput" itemSubjectRef="_originalOutputItem" name="originalOutput"/>
+    <bpmn2:sequenceFlow id="_CD6217FC-9A99-41DD-BB7C-3E7D686C94BB" sourceRef="_93BBB96D-DD25-40BC-8A7A-16B1548A0402" targetRef="_638AD949-1E1A-46E0-BA91-4724F2C6BAAD"/>
+    <bpmn2:sequenceFlow id="_0AC41881-638D-4232-A208-1365BFEC14E9" sourceRef="_FB3D668D-B2A9-4891-9254-58AD0729B797" targetRef="_93BBB96D-DD25-40BC-8A7A-16B1548A0402"/>
+    <bpmn2:endEvent id="_638AD949-1E1A-46E0-BA91-4724F2C6BAAD">
+      <bpmn2:incoming>_CD6217FC-9A99-41DD-BB7C-3E7D686C94BB</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:userTask id="_93BBB96D-DD25-40BC-8A7A-16B1548A0402" name="Task">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_0AC41881-638D-4232-A208-1365BFEC14E9</bpmn2:incoming>
+      <bpmn2:outgoing>_CD6217FC-9A99-41DD-BB7C-3E7D686C94BB</bpmn2:outgoing>
+      <bpmn2:ioSpecification>
+        <bpmn2:dataInput id="_93BBB96D-DD25-40BC-8A7A-16B1548A0402_TaskNameInputX" drools:dtype="Object" itemSubjectRef="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_93BBB96D-DD25-40BC-8A7A-16B1548A0402_origOutputNameInputX" drools:dtype="Object" itemSubjectRef="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_origOutputNameInputXItem" name="origOutputName"/>
+        <bpmn2:dataInput id="_93BBB96D-DD25-40BC-8A7A-16B1548A0402_SkippableInputX" drools:dtype="Object" itemSubjectRef="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_SkippableInputXItem" name="Skippable"/>
+        <bpmn2:dataOutput id="_93BBB96D-DD25-40BC-8A7A-16B1548A0402_originalOutputNameOutputX" drools:dtype="Object" itemSubjectRef="__93BBB96D-DD25-40BC-8A7A-16B1548A0402_originalOutputNameOutputXItem" name="originalOutputName"/>
+        <bpmn2:inputSet>
+          <bpmn2:dataInputRefs>_93BBB96D-DD25-40BC-8A7A-16B1548A0402_TaskNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_93BBB96D-DD25-40BC-8A7A-16B1548A0402_origOutputNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_93BBB96D-DD25-40BC-8A7A-16B1548A0402_SkippableInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet>
+          <bpmn2:dataOutputRefs>_93BBB96D-DD25-40BC-8A7A-16B1548A0402_originalOutputNameOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_93BBB96D-DD25-40BC-8A7A-16B1548A0402_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[Task]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_93BBB96D-DD25-40BC-8A7A-16B1548A0402_TaskNameInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:sourceRef>originalOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>_93BBB96D-DD25-40BC-8A7A-16B1548A0402_origOutputNameInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_93BBB96D-DD25-40BC-8A7A-16B1548A0402_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[false]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_93BBB96D-DD25-40BC-8A7A-16B1548A0402_SkippableInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation>
+        <bpmn2:sourceRef>_93BBB96D-DD25-40BC-8A7A-16B1548A0402_originalOutputNameOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>originalOutput</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:potentialOwner id="_rV8boNiqEDuJ-N6lPK_Veg">
+        <bpmn2:resourceAssignmentExpression id="_rV8bodiqEDuJ-N6lPK_Veg">
+          <bpmn2:formalExpression>john</bpmn2:formalExpression>
+        </bpmn2:resourceAssignmentExpression>
+      </bpmn2:potentialOwner>
+    </bpmn2:userTask>
+    <bpmn2:startEvent id="_FB3D668D-B2A9-4891-9254-58AD0729B797" name="Start">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Start]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_0AC41881-638D-4232-A208-1365BFEC14E9</bpmn2:outgoing>
+    </bpmn2:startEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="org.jbpm.test.functional.task.HumanTask_simple_with_outputvars">
+      <bpmndi:BPMNShape id="shape__FB3D668D-B2A9-4891-9254-58AD0729B797" bpmnElement="_FB3D668D-B2A9-4891-9254-58AD0729B797">
+        <dc:Bounds height="56" width="56" x="292" y="478"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__93BBB96D-DD25-40BC-8A7A-16B1548A0402" bpmnElement="_93BBB96D-DD25-40BC-8A7A-16B1548A0402">
+        <dc:Bounds height="102" width="154" x="428" y="455"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__638AD949-1E1A-46E0-BA91-4724F2C6BAAD" bpmnElement="_638AD949-1E1A-46E0-BA91-4724F2C6BAAD">
+        <dc:Bounds height="56" width="56" x="662" y="478"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__FB3D668D-B2A9-4891-9254-58AD0729B797_to_shape__93BBB96D-DD25-40BC-8A7A-16B1548A0402" bpmnElement="_0AC41881-638D-4232-A208-1365BFEC14E9">
+        <di:waypoint x="320" y="506"/>
+        <di:waypoint x="505" y="506"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__93BBB96D-DD25-40BC-8A7A-16B1548A0402_to_shape__638AD949-1E1A-46E0-BA91-4724F2C6BAAD" bpmnElement="_CD6217FC-9A99-41DD-BB7C-3E7D686C94BB">
+        <di:waypoint x="505" y="506"/>
+        <di:waypoint x="690" y="506"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_FB3D668D-B2A9-4891-9254-58AD0729B797">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_93BBB96D-DD25-40BC-8A7A-16B1548A0402">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_rV5_YNiqEDuJ-N6lPK_Veg</bpmn2:source>
+    <bpmn2:target>_rV5_YNiqEDuJ-N6lPK_Veg</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION
Provide a workaround to get variables values in beforeTaskCompleted listener before they are updated during completing task 

**JIRA**:

[link](https://issues.redhat.com/browse/RHPAM-4446)

**referenced Pull Requests**: 
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/639

