### PR TITLE
[JBPM-10172] Same id used for timers when using per request

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/timer/TimerManager.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/timer/TimerManager.java
@@ -49,7 +49,6 @@ import org.jbpm.process.instance.InternalProcessRuntime;
 import org.jbpm.process.instance.ProcessInstance;
 import org.jbpm.process.instance.ProcessRuntimeImpl;
 import org.kie.api.runtime.KieSession;
-import org.kie.api.runtime.manager.RuntimeManager;
 import org.kie.api.time.SessionClock;
 import org.jbpm.workflow.instance.NodeInstanceContainer;
 import org.jbpm.workflow.instance.node.TimerNodeInstance;

--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/timer/TimerManager.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/timer/TimerManager.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.common.InternalWorkingMemory;
@@ -61,8 +62,8 @@ public class TimerManager {
     
     private static final Logger logger = LoggerFactory.getLogger(TimerManager.class);
 
-    private long timerId = 0;
-
+    private static AtomicLong timerCounter = new AtomicLong();
+  
     private InternalKnowledgeRuntime kruntime;
     private TimerService timerService;
     private Map<Long, TimerInstance> timers = new ConcurrentHashMap<Long, TimerInstance>();
@@ -78,7 +79,7 @@ public class TimerManager {
         try {
             kruntime.startOperation();
 
-            timer.setId(++timerId);
+            timer.setId(timerCounter.incrementAndGet());
             timer.setProcessInstanceId(processInstance.getId());
             timer.setSessionId(((KieSession) kruntime).getIdentifier());
             timer.setActivated(new Date());
@@ -109,7 +110,7 @@ public class TimerManager {
         try {
             kruntime.startOperation();
 
-            timer.setId(++timerId);
+            timer.setId(timerCounter.incrementAndGet());
             timer.setProcessInstanceId(-1l);
             timer.setSessionId(((StatefulKnowledgeSession) kruntime).getIdentifier());
             timer.setActivated(new Date());
@@ -211,11 +212,11 @@ public class TimerManager {
     }
 
     public long internalGetTimerId() {
-        return timerId;
+        return timerCounter.get();
     }
 
     public void internalSetTimerId(long timerId) {
-        this.timerId = timerId;
+        timerCounter.set(timerId);
     }
 
     public void setTimerService(TimerService timerService) {

--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/timer/TimerManager.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/timer/TimerManager.java
@@ -110,12 +110,12 @@ public class TimerManager {
     }
 
     private long getTimerId(ProcessInstance processInstance) {
-        RuntimeManager manager = (RuntimeManager)kruntime.getEnvironment().get("RuntimeManager");
-        if (!(processInstance instanceof NodeInstanceContainer) || manager.getClass().getSimpleName().equals("PerProcessInstanceRuntimeManager")) {
+        Object manager = kruntime.getEnvironment().get("RuntimeManager");
+        if (!(processInstance instanceof NodeInstanceContainer) || manager != null && manager.getClass().getSimpleName().equals("PerProcessInstanceRuntimeManager")) {
             return ++timerId;
         } else {
             return ((NodeInstanceContainer)processInstance).getNodeInstances(true).stream().filter(TimerNodeInstance.class::isInstance).map(TimerNodeInstance.class::cast)
-               .map(TimerNodeInstance::getTimerId).max(Comparator.comparingLong(Long::longValue)).orElse(timerId) + 1;
+               .map(TimerNodeInstance::getTimerId).max(Comparator.comparingLong(Long::longValue)).map(l -> l +1).orElseGet(()-> ++timerId);
         }
     }
 

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/TimerUpdateTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/TimerUpdateTest.java
@@ -16,12 +16,19 @@
 package org.jbpm.test.functional.timer;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
+import org.drools.core.command.SingleSessionCommandService;
+import org.drools.core.command.impl.CommandBasedStatefulKnowledgeSession;
+import org.drools.core.impl.StatefulKnowledgeSessionImpl;
+import org.jbpm.process.instance.InternalProcessRuntime;
 import org.jbpm.process.instance.command.UpdateTimerCommand;
+import org.jbpm.process.instance.timer.TimerInstance;
+import org.jbpm.process.instance.timer.TimerManager;
 import org.jbpm.test.JbpmTestCase;
 import org.jbpm.test.listener.process.DefaultCountDownProcessEventListener;
 import org.jbpm.test.listener.process.NodeLeftCountDownProcessEventListener;
@@ -168,8 +175,14 @@ public class TimerUpdateTest extends JbpmTestCase {
         long id = kieSession.startProcess(PROCESS_NAME).getId();
         long startTime = System.currentTimeMillis();
         Assertions.assertThat(list).isNotEmpty();
+        
+        //Get the timerId (there is only one)
+        Collection<TimerInstance> timers = getTimerManager(kieSession).getTimers();
+        Assertions.assertThat(timers.size()).isEqualTo(1);
+        long timerId = timers.iterator().next().getId();
+        
         //set delay to 3s
-        kieSession.execute(new UpdateTimerCommand(id, 1, 3));
+        kieSession.execute(new UpdateTimerCommand(id, timerId, 3));
 
         listener.waitTillCompleted();
         Assertions.assertThat(timerHasFired()).isTrue();
@@ -320,5 +333,14 @@ public class TimerUpdateTest extends JbpmTestCase {
         Map<String, Object> parameters = new HashMap<>();
         Assertions.assertThatThrownBy(() -> kieSession.startProcess(ISO_TIMER_NAME, parameters)).hasCauseInstanceOf(IllegalArgumentException.class);
 
+    }
+    
+    private TimerManager getTimerManager(KieSession ksession) {
+        KieSession internal = ksession;
+        if (ksession instanceof CommandBasedStatefulKnowledgeSession) {
+            internal = ((SingleSessionCommandService)((CommandBasedStatefulKnowledgeSession)ksession ).getRunner()).getKieSession();
+        }
+
+        return ((InternalProcessRuntime)((StatefulKnowledgeSessionImpl)internal).getProcessRuntime()).getTimerManager();
     }
 }

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/TimerUpdateTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/TimerUpdateTest.java
@@ -178,7 +178,7 @@ public class TimerUpdateTest extends JbpmTestCase {
         
         //Get the timerId (there is only one)
         Collection<TimerInstance> timers = getTimerManager(kieSession).getTimers();
-        Assertions.assertThat(timers.size()).isEqualTo(1);
+        Assertions.assertThat(timers).hasSize(1);
         long timerId = timers.iterator().next().getId();
         
         //set delay to 3s


### PR DESCRIPTION
This basically makes timer id to behave as if singleton strategy was used both for per request and per process instance. 
Thats clearly needed on per request. Singleton remains the same and the only concern might be that know the timer id is globally unique and before, when using per process instance, it was unique per process instance. 
But I think that a per process instance id into a globally unique one should not cause any issue (the contrary is not true)

Changed the approach to use the max process instance timer id if the runtime strategy if not per process instance

**JIRA**: 

[link](https://issues.redhat.com/browse/JBPM-10172)
