### PR TITLE
[KOGITO-9500] - Remove pmml dependencies from SWF

### DIFF
--- a/jbpm-flow/pom.xml
+++ b/jbpm-flow/pom.xml
@@ -107,6 +107,11 @@
       <artifactId>drools-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jpmml</groupId>
+      <artifactId>pmml-model</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-mvel</artifactId>
     </dependency>


### PR DESCRIPTION
Jira : https://issues.redhat.com/browse/KOGITO-9500

Decalred pmml-model as optional as  the below dependencies are unsupported  in SWF.

org.jpmml:pmml-model:jar:1.5.1:compile
org.jpmml:pmml-agent:jar:1.5.1:compile