### PR TITLE
JBPM-10197 Parameter org.jbpm.ejb.timer.lookup to disable search for timers

### DIFF
--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
@@ -59,6 +59,7 @@ public class EjbSchedulerService implements GlobalSchedulerService {
     private static final Logger logger = LoggerFactory.getLogger(EjbSchedulerService.class);
 
     private static final Boolean TRANSACTIONAL = Boolean.parseBoolean(System.getProperty("org.jbpm.ejb.timer.tx", "true"));
+    private static final Boolean lookupTimers = Boolean.parseBoolean(System.getProperty("org.jbpm.ejb.timer.lookup", "true"));
 
 	private AtomicLong idCounter = new AtomicLong();
 	private TimerService globalTimerService;
@@ -78,7 +79,7 @@ public class EjbSchedulerService implements GlobalSchedulerService {
 		// if so skip the check by timer name as it has no way to exist
 		if (!ctx.isNew()) {
 		    jobInstance = getTimerJobInstance(jobName);
-		    if (jobInstance == null) {
+		    if (lookupTimers && jobInstance == null) {
 		        jobInstance = scheduler.getTimerByName(jobName);
 		    }
     		if (jobInstance != null) {


### PR DESCRIPTION
In databases with lot of timers, search for timer is a bottleneck. Is better to have a failed timer executed than search for it

Alternative to https://github.com/kiegroup/jbpm/pull/2335

This should be resolved with a feature for timers: externalId: https://issues.redhat.com/browse/EAPSUP-1336

ping @martinweiler @fjtirado 