### PR TITLE
[JBPM-10209] Switching to CMT

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/core/DisposableRuntimeEngine.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/DisposableRuntimeEngine.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.process.core;
+
+import org.kie.internal.runtime.manager.Disposable;
+import org.kie.internal.runtime.manager.InternalRuntimeEngine;
+
+public interface DisposableRuntimeEngine extends InternalRuntimeEngine, Disposable {
+    boolean isDisposed();
+}

--- a/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/GlobalTimerService.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/GlobalTimerService.java
@@ -37,6 +37,7 @@ import org.drools.core.time.impl.CommandServiceTimerJobFactoryManager;
 import org.drools.core.time.impl.DefaultJobHandle;
 import org.drools.core.time.impl.TimerJobFactoryManager;
 import org.drools.core.time.impl.TimerJobInstance;
+import org.jbpm.process.core.DisposableRuntimeEngine;
 import org.jbpm.process.core.timer.GlobalSchedulerService;
 import org.jbpm.process.core.timer.NamedJobContext;
 import org.jbpm.process.instance.timer.TimerManager.ProcessJobContext;
@@ -420,7 +421,10 @@ public class GlobalTimerService implements TimerService, InternalSchedulerServic
         	
         	return runtime.getKieSession().getEnvironment();
         }
-        
+
+        public boolean isDisposed() {
+            return runtime instanceof DisposableRuntimeEngine  && ((DisposableRuntimeEngine)runtime).isDisposed();
+        }
     }
 
     public List<TimerServiceListener> getListeners() {

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/RuntimeEngineImpl.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/RuntimeEngineImpl.java
@@ -19,14 +19,13 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.jbpm.process.audit.JPAAuditLogService;
+import org.jbpm.process.core.DisposableRuntimeEngine;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.Context;
 import org.kie.api.runtime.manager.RuntimeManager;
 import org.kie.api.runtime.manager.audit.AuditService;
 import org.kie.api.task.TaskService;
-import org.kie.internal.runtime.manager.Disposable;
 import org.kie.internal.runtime.manager.DisposeListener;
-import org.kie.internal.runtime.manager.InternalRuntimeEngine;
 import org.kie.internal.runtime.manager.InternalRuntimeManager;
 import org.kie.internal.runtime.manager.SessionNotFoundException;
 
@@ -36,7 +35,7 @@ import org.kie.internal.runtime.manager.SessionNotFoundException;
  * and work item handlers might be interested in receiving notification when the runtime engine is disposed of,
  * in order deactivate themselves too and not receive any other events.
  */
-public class RuntimeEngineImpl implements InternalRuntimeEngine, Disposable {
+public class RuntimeEngineImpl implements DisposableRuntimeEngine {
 
 	private RuntimeEngineInitlializer initializer;
 	private Context<?> context;
@@ -143,6 +142,7 @@ public class RuntimeEngineImpl implements InternalRuntimeEngine, Disposable {
         this.manager = manager;
     }
 
+    @Override
     public boolean isDisposed() {
         return disposed;
     }

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
@@ -39,7 +39,6 @@ import org.drools.core.time.Trigger;
 import org.drools.core.time.impl.TimerJobInstance;
 import org.drools.persistence.api.TransactionManager;
 import org.drools.persistence.api.TransactionManagerFactory;
-import org.drools.persistence.api.TransactionSynchronization;
 import org.drools.persistence.jta.JtaTransactionManager;
 import org.jbpm.process.core.timer.GlobalSchedulerService;
 import org.jbpm.process.core.timer.JobNameHelper;

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
@@ -98,12 +98,15 @@ public class EjbSchedulerService implements GlobalSchedulerService {
 
     @Override
     public boolean removeJob(JobHandle jobHandle) {
-        final Timer ejbTimer = getEjbTimer(getTimerMappinInfo(((EjbGlobalJobHandle) jobHandle).getUuid()));
+        String uuid = ((EjbGlobalJobHandle) jobHandle).getUuid();
+        final Timer ejbTimer = getEjbTimer(getTimerMappinInfo(uuid));
         if (TRANSACTIONAL && ejbTimer == null) {
-            // this situation needs to be avoided as it should not happen
+            logger.warn("EJB timer is null for uuid {} and transactional flag is enabled", uuid);
             return false;
         }
-        return scheduler.removeJob(jobHandle, ejbTimer);
+        boolean result = scheduler.removeJob(jobHandle, ejbTimer);
+        logger.debug("Remove job returned {}", result);
+        return result;
     }
 
     private TimerJobInstance getTimerJobInstance (String uuid) {


### PR DESCRIPTION
EJBTimerScheduler bean was using BMT. 
A BTM bean will always suspend the incoming transaction, therefore any operation within the bean, for example, scheduling a timer, will be performed in a different transaction. 
This PR switch back to CMT, removing the risk of a short delay timer colliding with the parent transaction. 
Since CMT was changed to BMT to be able to control delays and recovery when the timer is executed, as an alternative, we use CMT with requires_new to force a new transaction (achieving the same result than by handling UserTransaction). Also, the recoverTimerJobInstance was refactor a bit to make it clear that essentially, whatever the scenario (sessionNotFound, intervalTrigger or failed times) the recovery is executed within another transaction (as the regular call) 