### PR TITLE
[JBPM-10097] Improving performance of getTimerByName

### DIFF
--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/DefaultEJBTimerRetriever.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/DefaultEJBTimerRetriever.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.services.ejb.timer;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import javax.ejb.Timer;
+import javax.ejb.TimerService;
+
+class DefaultEJBTimerRetriever extends EJBTimerRetriever<Void> {
+    
+    protected DefaultEJBTimerRetriever(TimerService timerService) {
+        super(timerService);
+    }
+
+    @Override
+    public Collection<Object> getTimers(String jobName, Void accepted) {
+        return timerService.getTimers().stream().map(Timer::getInfo).collect(Collectors.toList());
+    }
+}

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EJBTimerDB.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EJBTimerDB.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.services.ejb.timer;
+
+enum EJBTimerDB {
+    ORACLE("select info from jboss_ejb_timer where utl_raw.cast_to_varchar2(utl_encode.base64_decode(utl_raw.cast_to_raw(dbms_lob.substr(info,2000,1)))) like '%?%'"),
+    POSTGRESQL("select info from jboss_ejb_timerwhere decode(info, 'base64') like '%?%'");
+    
+    private final String query;
+    
+    private EJBTimerDB (String query) {
+        this.query = query;
+    }
+    
+    public String getQuery() {
+        return query;
+    }
+}

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EJBTimerRetriever.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EJBTimerRetriever.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.services.ejb.timer;
+
+
+import java.util.Collection;
+import java.util.Optional;
+
+import javax.ejb.TimerService;
+
+import org.jbpm.process.core.timer.impl.GlobalTimerService;
+
+public abstract class EJBTimerRetriever<T>  {
+    
+     protected final TimerService timerService;
+     
+     protected EJBTimerRetriever (TimerService timerService) {
+         this.timerService = timerService;
+     }
+    
+     @SuppressWarnings("squid:S1172")
+     public Optional<T> accept (GlobalTimerService globalTimerService) {
+         return Optional.empty();
+     }
+     
+     public abstract Collection<Object> getTimers(String jobName,T accepted);
+}

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/EjbSchedulerService.java
@@ -71,7 +71,7 @@ public class EjbSchedulerService implements GlobalSchedulerService {
 		if (!ctx.isNew()) {
 		    jobInstance = getTimerJobInstance(jobName);
 		    if (jobInstance == null) {
-		        jobInstance = scheduler.getTimerByName(jobName);
+		        jobInstance = scheduler.getTimerByName(globalTimerService, jobName);
 		    }
     		if (jobInstance != null) {
     			return jobInstance.getJobHandle();

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/WildflyAcceptedInfo.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/WildflyAcceptedInfo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.services.ejb.timer;
+
+import javax.persistence.EntityManagerFactory;
+
+class WildflyAcceptedInfo {
+    private final EJBTimerDB db;
+    private final EntityManagerFactory emf;
+    
+    public WildflyAcceptedInfo(EJBTimerDB db, EntityManagerFactory emf) {
+        this.db = db;
+        this.emf = emf;
+    }
+    public EntityManagerFactory getEmf() {
+        return emf;
+    }
+
+    public EJBTimerDB getDb() {
+        return db;
+    }
+}

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/WildflyEJBTimerRetriever.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/main/java/org/jbpm/services/ejb/timer/WildflyEJBTimerRetriever.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.services.ejb.timer;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.ejb.TimerService;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import org.jbpm.process.core.timer.impl.GlobalTimerService;
+import org.jbpm.runtime.manager.impl.jpa.EntityManagerFactoryManager;
+import org.kie.internal.runtime.manager.InternalRuntimeManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class WildflyEJBTimerRetriever extends EJBTimerRetriever<WildflyAcceptedInfo> {
+
+    private static final Logger logger = LoggerFactory.getLogger(WildflyEJBTimerRetriever.class);
+    private final boolean isPersistentWildfly;
+    private Object persistence;
+    
+    
+    protected WildflyEJBTimerRetriever(TimerService timerService) {
+        super(timerService);
+        isPersistentWildfly = isPersistentWildfly();
+        if (isPersistentWildfly) {
+            logger.info ("EJBTimer is using Wildfly persistence");
+        }  
+    }
+
+    @SuppressWarnings({"squid:S1872","squid:S3011"})
+    private boolean isPersistentWildfly() {
+        Class<? extends TimerService> clazz = timerService.getClass();
+        if (clazz.getName().equals("org.jboss.as.ejb3.timerservice.TimerServiceImpl")) {
+            try {
+                Field field = clazz.getDeclaredField("persistence");
+                field.setAccessible(true);
+                persistence = field.get(timerService);
+                return persistence != null && persistence.getClass().getName().equals("org.jboss.as.ejb3.timerservice.persistence.database.DatabaseTimerPersistence");
+            } catch (ReflectiveOperationException ex) {
+                logger.trace("Exception retrieving timer service persistence field", ex);
+            }
+        }
+        return false;
+    }
+
+    
+    @Override
+    public Optional<WildflyAcceptedInfo> accept(GlobalTimerService globalTimerService) {
+        return isPersistentWildfly ? getDB(globalTimerService.getRuntimeManager()) : Optional.empty();
+    }
+
+    private Optional<WildflyAcceptedInfo> getDB(InternalRuntimeManager runtime) {
+        EntityManagerFactory emf = EntityManagerFactoryManager.get().getOrCreate(runtime.getDeploymentDescriptor().getPersistenceUnit());
+        for (Object value : emf.getProperties().values()) {
+            if (value instanceof String) {
+                String search = value.toString().toLowerCase();
+                if (search.contains("oracle")) {
+                    return Optional.of(new WildflyAcceptedInfo(EJBTimerDB.ORACLE, emf));
+                } else if (search.contains("postgresql")) {
+                    return Optional.of(new WildflyAcceptedInfo(EJBTimerDB.POSTGRESQL,emf));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+   
+    @Override
+    public Collection<Object> getTimers(String jobName, WildflyAcceptedInfo accepted) {
+        EntityManager em = accepted.getEmf().createEntityManager();
+        List<String> results = em.createNativeQuery(accepted.getDb().getQuery(), String.class).setParameter(1, jobName).getResultList();
+        return results.stream().map(this::deserialize).collect(Collectors.toList());
+    }
+    
+    private Object deserialize( String info) {
+        try {
+            Method method = persistence.getClass().getMethod("deSerialize", String.class);
+            return method.invoke(persistence, info);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Error deserializing info", e);
+        }
+    }
+
+}


### PR DESCRIPTION
**JIRA**:

[link](https://issues.redhat.com/browse/JBPM-10197)

A huge hack, because it made certain assumptions that should not be made if TimerService API was functional for the usage we are giving it (which is even a huger hack in my opinion ;)), but maybe worthy  for users having performance issues with` getTimerByName()`. 

If Timer implementation is wildfly and it is using DB as persistence mechanism and if DB is oracle or postgresql, we can actually try to reduce the number of timers to be checked in getTimerByName using a bit of reflection and a couple of native queries. The hacky part is isolated into a single class. 

The Wildfly hacky assumptions are:

1.  TimerService implementation wildffy class name
2.  The field containing the persistence instance is called `persistence`
3.  The class name  of the instance assigned to field persistence
4.  The method used to deserialize info column is called deSerialize
5.  That there is a table called ejb_timer with a string column called info. 

If assumptions 1), 2) and 3) are changed by a future wildfly release, linear search will be done (so we are covered on that regard). 4) and 5) are trickier, since the exception will get propagated. 

**DISCLAIMER**
I did not want to do this, but I consider this approach better than potentially creating duplicates (see closed PRs over the same JIRA) or performing a linear search over  thousands of timers once we know how Wildfly is working.  If Application Server is not widlfly, or the persistence is not on DB or widfly change the class name, we will revert to linear search, so it is just a hack that boost performance of a certain wildfly setup and a couple of DBs, it does not imply losing any existing functionality if the setup is not matched . 

**PS**
If we are ok with the possibility of assuming Wildfly, my idea, before moving into "ready for review" and once this has been tested with an existing problematic setup, is to switch to ServiceLoader mechanism and try to add as much DBs as possible, so the classes related with Wildfly are not in the EJB timer module, but in a separate one that might be added only for wildfly setup (this will allow including the Wildfly dependencues, the usage of instanceof and even calling the deSerialize method through direct call). Before that I want to verify that this approach really boost performance. 


