### PR TITLE
[private-bamoe-issues#1326] Avoid duplicate timer execution with long running timers and async nodes

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/GlobalTimerService.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/GlobalTimerService.java
@@ -372,6 +372,25 @@ public class GlobalTimerService implements TimerService, InternalSchedulerServic
             return null;
         }
 
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + (int) (this.getId() ^ (this.getId() >>> 32));
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if ( this == obj ) return true;
+            if ( obj == null ) return false;
+            if ( getClass() != obj.getClass() ) return false;
+            final DefaultJobHandle other = (DefaultJobHandle) obj;
+            if (this.getId() != other.getId())
+                return false;
+            return true;
+        }
+
     }
     
     public static class DisposableCommandService implements InternalLocalRunner {

--- a/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/GlobalTimerService.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/core/timer/impl/GlobalTimerService.java
@@ -374,21 +374,16 @@ public class GlobalTimerService implements TimerService, InternalSchedulerServic
 
         @Override
         public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + (int) (this.getId() ^ (this.getId() >>> 32));
-            return result;
+            return (int)getId();
         }
 
         @Override
         public boolean equals(Object obj) {
             if ( this == obj ) return true;
-            if ( obj == null ) return false;
-            if ( getClass() != obj.getClass() ) return false;
-            final DefaultJobHandle other = (DefaultJobHandle) obj;
-            if (this.getId() != other.getId())
-                return false;
-            return true;
+            if (obj == null || !obj.getClass().equals(getClass())) {
+                 return false;
+            }
+            return getId() == ((DefaultJobHandle)obj).getId();
         }
 
     }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHPAM-4864

Add equals/hashCode methods in order to ensure List.contains works properly.