### PR TITLE
[RHPAM-4872] Fix RepeatMode=FIXED when deleted records > RecordsPerTransaction

### DIFF
--- a/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/impl/AbstractAvailableJobsExecutor.java
+++ b/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/impl/AbstractAvailableJobsExecutor.java
@@ -132,7 +132,9 @@ public abstract class AbstractAvailableJobsExecutor {
                         ctx.setData("ClassLoader", cl);
 
                         // add scheduled execution time
-                        ctx.setData("scheduledExecutionTime", request.getTime());
+                        if(ctx.getData("scheduledExecutionTime") == null) {
+                            ctx.setData("scheduledExecutionTime", request.getTime());
+                        }
 
                         cmd = classCacheManager.findCommand(request.getCommandName(), cl);
                         // increment execution counter directly to cover both success and failure paths

--- a/jbpm-services/jbpm-executor/src/test/resources/byteman-scripts/simulateSlowLogCleanupCommand.btm
+++ b/jbpm-services/jbpm-executor/src/test/resources/byteman-scripts/simulateSlowLogCleanupCommand.btm
@@ -10,6 +10,20 @@ AT ENTRY
 IF TRUE
 DO debug("Pausing JPAAuditLogService.doDelete for " + Integer.getInteger("byteman.jpaaudit.sleep", 500) + "ms");
 Thread.sleep(Integer.getInteger("byteman.jpaaudit.sleep", 500));
-return 1
+return Integer.getInteger("byteman.jpaaudit.delete", 1)
 ENDRULE
 
+########################################################################
+#
+# Rule to slow down the execution of JPAAuditLogService.doPartialDelete
+#
+
+RULE JPAAuditLogService.doPartialDelete sleep
+CLASS org.jbpm.process.audit.JPAAuditLogService
+METHOD doPartialDelete
+AT ENTRY
+IF TRUE
+DO debug("Pausing JPAAuditLogService.doPartialDelete for " + Integer.getInteger("byteman.jpaaudit.sleep", 500) + "ms");
+Thread.sleep(Integer.getInteger("byteman.jpaaudit.sleep", 500));
+return Integer.getInteger("byteman.jpaaudit.delete", 1)
+ENDRULE


### PR DESCRIPTION
This is following up on the work from #2292 

The problem with job rescheduling still occurs when 'pagination' exists (There are more records to delete than the 'recordsPerTransaction' parameter). When this happens, in each page it ends up moving the date and time of next execution by not taking into account the date of the first page of the current cycle but using the current one.

This PR addresses the issue by storing the execution time of the original LogCleanupCommand.