### PR TITLE
[7.67.x-blue][kie-roadmap#52] Improve LogCleanupCommand, do not delete RequestInfo and ErrorInfo records of active process instances

### DIFF
--- a/jbpm-audit/src/main/java/org/jbpm/process/audit/query/AbstractAuditDeleteBuilderImpl.java
+++ b/jbpm-audit/src/main/java/org/jbpm/process/audit/query/AbstractAuditDeleteBuilderImpl.java
@@ -50,14 +50,20 @@ public abstract class AbstractAuditDeleteBuilderImpl<T> extends AbstractDeleteBu
         private String queryBase;
         private int queryParamId;
         private QueryWhere where;
+        private String join;
 
         private QueryAndParameterAppender queryAndParameterAppender;
 
         public Subquery(String field, String queryBase, int queryParamId) {
+            this(field, queryBase, queryParamId, "in");
+        }
+
+        public Subquery(String field, String queryBase, int queryParamId, String join) {
             this.field = field;
             this.queryBase = queryBase;
             this.queryParamId = queryParamId;
             this.where = new QueryWhere();
+            this.join = join;
         }
 
         public Subquery parameter(String listId, Object... values) {
@@ -79,7 +85,7 @@ public abstract class AbstractAuditDeleteBuilderImpl<T> extends AbstractDeleteBu
             if (queryAndParameterAppender == null) {
                 queryAndParameterAppender = QueryHelper.createQuery(queryBase, where, new HashMap<>(), queryParamId);
             }
-            return field + " in (" + queryAndParameterAppender.toSQL() + ")";
+            return field + " " + join + " (" + queryAndParameterAppender.toSQL() + ")";
         }
 
     }

--- a/jbpm-services/jbpm-executor-cdi/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-services/jbpm-executor-cdi/src/test/filtered-resources/META-INF/persistence.xml
@@ -10,6 +10,7 @@
     <mapping-file>META-INF/Executor-orm.xml</mapping-file>
     <class>org.jbpm.executor.entities.ErrorInfo</class>
     <class>org.jbpm.executor.entities.RequestInfo</class>
+    <class>org.jbpm.process.audit.ProcessInstanceLog</class>
     <class>org.jbpm.runtime.manager.impl.jpa.ExecutionErrorInfo</class>
     <exclude-unlisted-classes>true</exclude-unlisted-classes>
  

--- a/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/impl/jpa/ExecutionErrorInfoDeleteBuilderImpl.java
+++ b/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/impl/jpa/ExecutionErrorInfoDeleteBuilderImpl.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import org.jbpm.process.audit.JPAAuditLogService;
 import org.jbpm.process.audit.query.AbstractAuditDeleteBuilderImpl;
 import org.jbpm.runtime.manager.impl.jpa.ExecutionErrorInfo;
+import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.internal.runtime.manager.audit.query.ExecutionErrorInfoDeleteBuilder;
 
 import static org.kie.internal.query.QueryParameterIdentifiers.ERROR_DATE_LIST;
@@ -51,5 +52,25 @@ public class ExecutionErrorInfoDeleteBuilderImpl extends AbstractAuditDeleteBuil
         rangeEnd = ensureDateNotTimestamp(rangeEnd)[0];
         addRangeParameter(ERROR_DATE_LIST, "date range end", rangeEnd, false);
         return this;
+    }
+
+    @Override
+    protected boolean isSubquerySupported() {
+        return true;
+    }
+
+    @Override
+    protected Subquery applyParameters(Subquery subquery) {
+        return subquery;
+    }
+
+    @Override
+    protected Subquery getSubQuery() {
+        String queryBaseStr = "SELECT spl.processInstanceId FROM ProcessInstanceLog spl where spl.status in (" +
+            ProcessInstance.STATE_PENDING + "," + // 0
+            ProcessInstance.STATE_ACTIVE + "," + // 1
+            ProcessInstance.STATE_SUSPENDED + // 4
+            ")";
+        return new Subquery("l.processInstanceId", queryBaseStr, 1, "not in");
     }
 }

--- a/jbpm-services/jbpm-executor/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-services/jbpm-executor/src/test/filtered-resources/META-INF/persistence.xml
@@ -10,6 +10,7 @@
     <mapping-file>META-INF/Executor-orm.xml</mapping-file>
     <class>org.jbpm.executor.entities.ErrorInfo</class>
     <class>org.jbpm.executor.entities.RequestInfo</class>
+    <class>org.jbpm.process.audit.ProcessInstanceLog</class>
     <class>org.jbpm.runtime.manager.impl.jpa.ExecutionErrorInfo</class>
     <exclude-unlisted-classes>true</exclude-unlisted-classes>
  

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/ExecutorLogCleanTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/log/ExecutorLogCleanTest.java
@@ -112,6 +112,9 @@ public class ExecutorLogCleanTest extends JbpmAsyncJobTestCase {
         List<ErrorInfo> errorList = getExecutorService().getAllErrors(new QueryContext());
         Assertions.assertThat(errorList).hasSize(2);
 
+        // Abort running process instance
+        ksession.abortProcessInstance(pi.getId());
+
         // Delete a record
         int resultCount = auditService.errorInfoLogDeleteBuilder()
                 .date(errorList.get(0).getTime())
@@ -132,9 +135,6 @@ public class ExecutorLogCleanTest extends JbpmAsyncJobTestCase {
 
         // Assert remaining records
         Assertions.assertThat(getExecutorService().getAllErrors(new QueryContext())).hasSize(remaining);
-        
-        // Abort running process instance
-        ksession.abortProcessInstance(pi.getId());
     }
 
 }


### PR DESCRIPTION
https://github.com/IBM/kie-roadmap/issues/52

Running LogCleanupCommand with parameter OlderThanPeriod=xd removes inactive records from RequestInfo and ErrorInfo even if the related process instance is still active. These entries should not be deleted as long as the process instance is active, as this breaks the ability to reschedule a failed job. Records for active process instances might also be needed for audit purposes.

This is a copy of https://github.com/kiegroup/jbpm/pull/2282 that was raised against main branch.