### PR TITLE
RHPAM-4442: before and after TaskAssignmentsAddedEvent show same user…

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/events/TaskEventSupport.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/events/TaskEventSupport.java
@@ -161,19 +161,18 @@ public class TaskEventSupport extends AbstractEventSupport<TaskLifeCycleEventLis
             notifyAllListeners( event, ( l, e ) -> l.beforeTaskInputVariableChangedEvent( e, variables ) );
         }
     }
-    
-    
+
     public void fireBeforeTaskOutputVariablesChanged(final Task task, TaskContext context, Map<String, Object> variables) {
         if ( hasListeners() ) {
             final TaskEventImpl event = new TaskEventImpl(task, context);
             notifyAllListeners( event, ( l, e ) -> l.beforeTaskOutputVariableChangedEvent( e, variables ) );
         }
     }
-    
-    public void fireBeforeTaskAssignmentsAddedEvent(final Task task, TaskContext context, AssignmentType type, List<OrganizationalEntity> entities) {
+
+    public void fireBeforeTaskAssignmentsAddedEvent(final Task task, TaskContext context, AssignmentType type, List<OrganizationalEntity> entities, List<OrganizationalEntity> beforeChangeEntities) {
         if ( hasListeners() ) {
             final TaskEventImpl event = new TaskEventImpl(task, context);
-            notifyAllListeners( event, ( l, e ) -> l.beforeTaskAssignmentsAddedEvent(e, type, entities) );
+            notifyAllListeners( event, ( l, e ) -> l.beforeTaskAssignmentsAddedEvent(e, type, entities, beforeChangeEntities) );
         }
     }
     
@@ -329,10 +328,10 @@ public class TaskEventSupport extends AbstractEventSupport<TaskLifeCycleEventLis
         }
     }
     
-    public void fireAfterTaskAssignmentsAddedEvent(final Task task, TaskContext context, AssignmentType type, List<OrganizationalEntity> entities) {
+    public void fireAfterTaskAssignmentsAddedEvent(final Task task, TaskContext context, AssignmentType type, List<OrganizationalEntity> entities,  List<OrganizationalEntity> afterChangeEntities) {
         if ( hasListeners() ) {
             final TaskEventImpl event = new TaskEventImpl(task, context);
-            notifyAllListeners( event, ( l, e ) -> l.afterTaskAssignmentsAddedEvent(e, type, entities) );
+            notifyAllListeners( event, ( l, e ) -> l.afterTaskAssignmentsAddedEvent(e, type, entities, afterChangeEntities) );
         }
     }
     

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/TaskAssignmentAddedListenersTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/TaskAssignmentAddedListenersTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.test.functional.task;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.jbpm.kie.services.impl.admin.commands.AddPeopleAssignmentsCommand;
+import org.jbpm.services.task.events.DefaultTaskEventListener;
+import org.jbpm.services.task.impl.model.UserImpl;
+import org.jbpm.test.JbpmTestCase;
+import org.junit.After;
+import org.junit.Test;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.manager.RuntimeEngine;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.api.task.TaskEvent;
+import org.kie.api.task.TaskLifeCycleEventListener;
+import org.kie.api.task.TaskService;
+import org.kie.api.task.model.OrganizationalEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test listeners tied to adding assignments - RHPAM-4442
+ */
+public class TaskAssignmentAddedListenersTest extends JbpmTestCase {
+
+    private KieSession ksession;
+    private TaskService ts;
+
+
+    List<OrganizationalEntity> beforePotentialOwners;
+    List<OrganizationalEntity> beforeEntitiesToSet;
+    List<OrganizationalEntity> afterPotentialOwners;
+    List<OrganizationalEntity> afterEntitiesToSet;
+
+
+    MutableInt triggeredBeforeListenerCounter;
+    MutableInt triggeredAfterListenerCounter;
+
+
+
+
+    private static final String PROCESS = "org/jbpm/test/functional/task/HumanTask-simple.bpmn2";
+    private static final String PROCESS_ID = "org.jbpm.test.functional.task.HumanTask-simple";
+
+
+    private void init() {
+        createRuntimeManager(PROCESS);
+        RuntimeEngine runtimeEngine = getRuntimeEngine();
+        ksession = runtimeEngine.getKieSession();
+        ts = runtimeEngine.getTaskService();
+    }
+
+    @After
+    public void clenaup() {
+        if (ksession != null) {
+            ksession.dispose();
+        }
+        disposeRuntimeManager();
+    }
+
+    @Test
+    public void testAddedAssignmentListenersThreeParamApiRegression() {
+        DefaultTaskEventListener listener = new DefaultTaskEventListener() {
+            @Override
+            public void beforeTaskAssignmentsAddedEvent(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities) {
+                triggeredBeforeListenerCounter.increment();
+                beforePotentialOwners.addAll(event.getTask().getPeopleAssignments().getPotentialOwners());
+                beforeEntitiesToSet.addAll(entities);
+                logger.debug("before potentialOwners: " + beforePotentialOwners);
+                logger.debug("before entities: " + beforeEntitiesToSet);
+            }
+
+            @Override
+            public void afterTaskAssignmentsAddedEvent(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities) {
+                triggeredAfterListenerCounter.increment();
+                afterPotentialOwners.addAll(event.getTask().getPeopleAssignments().getPotentialOwners());
+                afterEntitiesToSet.addAll(entities);
+
+                logger.debug("after potentialOwners: " + afterPotentialOwners);
+                logger.debug("after entities: " + afterEntitiesToSet);
+            }
+
+        };
+        testRegression(listener);
+    }
+
+    @Test
+    public void testAddedAssignmentListenersFourParamApiRegression() {
+
+        TaskLifeCycleEventListener listener = new DefaultTaskEventListener() {
+            @Override
+            public void beforeTaskAssignmentsAddedEvent(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities, List<OrganizationalEntity> beforeChangeEntities) {
+                triggeredBeforeListenerCounter.increment();
+                beforePotentialOwners.addAll(event.getTask().getPeopleAssignments().getPotentialOwners());
+                beforeEntitiesToSet.addAll(entities);
+                logger.debug("before potentialOwners: " + beforePotentialOwners);
+                logger.debug("before entities: " + beforeEntitiesToSet);
+            }
+
+            @Override
+            public void afterTaskAssignmentsAddedEvent(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities, List<OrganizationalEntity> afterChangeEntities) {
+                triggeredAfterListenerCounter.increment();
+                afterPotentialOwners.addAll(event.getTask().getPeopleAssignments().getPotentialOwners());
+                afterEntitiesToSet.addAll(entities);
+
+                logger.debug("after potentialOwners: " + afterPotentialOwners);
+                logger.debug("after entities: " + afterEntitiesToSet);
+            }
+        };
+
+        testRegression(listener);
+    }
+
+    @Test
+    public void testAddedAssignmentListenersFourParamApi() {
+        triggeredBeforeListenerCounter = new MutableInt(0);
+        triggeredAfterListenerCounter = new MutableInt(0);
+
+        List<OrganizationalEntity> beforeChangeEntitiesResult = new ArrayList<>();
+        List<OrganizationalEntity> afterChangeEntitiesResult = new ArrayList<>();
+
+        TaskLifeCycleEventListener listener = new DefaultTaskEventListener() {
+            @Override
+            public void beforeTaskAssignmentsAddedEvent(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities, List<OrganizationalEntity> beforeChangeEntities) {
+                triggeredBeforeListenerCounter.increment();
+                beforeChangeEntitiesResult.addAll(beforeChangeEntities);
+                logger.debug("beforeChangeEntities: " + beforeChangeEntities);
+            }
+
+            @Override
+            public void afterTaskAssignmentsAddedEvent(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities, List<OrganizationalEntity> afterChangeEntities) {
+                triggeredAfterListenerCounter.increment();
+                afterChangeEntitiesResult.addAll(afterChangeEntities);
+                logger.debug("afterChangeEntities: " + afterChangeEntities);
+
+            }
+        };
+
+        addTaskEventListener(listener);
+
+        init();
+
+        ProcessInstance pi = ksession.startProcess(PROCESS_ID);
+
+        long pid = pi.getId();
+
+        assertProcessInstanceActive(pi.getId(), ksession);
+        assertNodeTriggered(pi.getId(),  "Start", "Task");
+
+        long taskId = ts.getTasksByProcessInstanceId(pid).get(0);
+
+        UserImpl john = new UserImpl("john");
+        UserImpl mary = new UserImpl("mary");
+        UserImpl jim = new UserImpl("jim");
+
+        //add assignment
+        ts.execute(new AddPeopleAssignmentsCommand("Administrator", taskId, 0, new UserImpl[]{john}, false));
+        assertThat(beforeChangeEntitiesResult).isEmpty();
+
+        assertThat(afterChangeEntitiesResult).hasSize(1);
+        assertThat(afterChangeEntitiesResult).contains(john);
+
+        clearLists(beforeChangeEntitiesResult, afterChangeEntitiesResult);
+
+        // Add one more without removing existing
+        ts.execute(new AddPeopleAssignmentsCommand("Administrator", taskId, 0, new UserImpl[]{mary}, false));
+        assertThat(beforeChangeEntitiesResult).hasSize(1);
+        assertThat(beforeChangeEntitiesResult).contains(john).doesNotContain(mary);
+
+        assertThat(afterChangeEntitiesResult).hasSize(2);
+        assertThat(afterChangeEntitiesResult).contains(john, mary);
+
+        clearLists(beforeChangeEntitiesResult, afterChangeEntitiesResult);
+
+        // Add one more but with removing existing ones
+        ts.execute(new AddPeopleAssignmentsCommand("Administrator", taskId, 0, new UserImpl[]{jim}, true));
+        assertThat(beforeChangeEntitiesResult).hasSize(2);
+        assertThat(beforeChangeEntitiesResult).contains(john, mary).doesNotContain(jim);
+
+        assertThat(afterChangeEntitiesResult).hasSize(1);
+        assertThat(afterChangeEntitiesResult).contains(jim).doesNotContain(john, mary);
+
+        clearLists(beforeChangeEntitiesResult, afterChangeEntitiesResult);
+
+        assertThat(triggeredBeforeListenerCounter.getValue()).isEqualTo(3);
+        assertThat(triggeredAfterListenerCounter.getValue()).isEqualTo(3);
+    }
+
+    private void testRegression(TaskLifeCycleEventListener listener) {
+        triggeredBeforeListenerCounter = new MutableInt(0);
+        triggeredAfterListenerCounter = new MutableInt(0);
+
+        beforePotentialOwners = new ArrayList<>();
+        beforeEntitiesToSet = new ArrayList<>();
+        afterPotentialOwners = new ArrayList<>();
+        afterEntitiesToSet = new ArrayList<>();
+
+        addTaskEventListener(listener);
+
+        init();
+
+        ProcessInstance pi = ksession.startProcess(PROCESS_ID);
+        long pid = pi.getId();
+
+        assertProcessInstanceActive(pi.getId(), ksession);
+        assertNodeTriggered(pi.getId(),  "Start", "Task");
+
+        long taskId = ts.getTasksByProcessInstanceId(pid).get(0);
+
+        UserImpl john = new UserImpl("john");
+        UserImpl mary = new UserImpl("mary");
+        UserImpl jim = new UserImpl("jim");
+
+        //add assignment
+        ts.execute(new AddPeopleAssignmentsCommand("Administrator", taskId, 0, new UserImpl[]{john}, false));
+        assertThat(beforePotentialOwners).hasSize(1);
+        assertThat(beforePotentialOwners).contains(john);
+
+        assertThat(beforeEntitiesToSet).hasSize(1);
+        assertThat(beforeEntitiesToSet).contains(john);
+
+        assertThat(afterPotentialOwners).hasSize(1);
+        assertThat(afterPotentialOwners).contains(john);
+
+        assertThat(afterEntitiesToSet).hasSize(1);
+        assertThat(afterEntitiesToSet).contains(john);
+
+        clearLists(beforePotentialOwners, beforeEntitiesToSet, afterPotentialOwners, afterEntitiesToSet);
+
+        // Add one more without removing existing
+        ts.execute(new AddPeopleAssignmentsCommand("Administrator", taskId, 0, new UserImpl[]{mary}, false));
+        assertThat(beforePotentialOwners).hasSize(2);
+        assertThat(beforePotentialOwners).contains(john, mary);
+
+        assertThat(beforeEntitiesToSet).hasSize(1);
+        assertThat(beforeEntitiesToSet).contains(mary);
+
+        assertThat(afterPotentialOwners).hasSize(2);
+        assertThat(afterPotentialOwners).contains(john, mary);
+
+        assertThat(afterEntitiesToSet).hasSize(1);
+        assertThat(afterEntitiesToSet).contains(mary);
+
+        clearLists(beforePotentialOwners, beforeEntitiesToSet, afterPotentialOwners, afterEntitiesToSet);
+
+        // Add one more but with removing existing ones
+        ts.execute(new AddPeopleAssignmentsCommand("Administrator", taskId, 0, new UserImpl[]{jim}, true));
+        assertThat(beforePotentialOwners).hasSize(1);
+        assertThat(beforePotentialOwners).contains(jim).doesNotContain(john, mary);
+
+        assertThat(beforeEntitiesToSet).hasSize(1);
+        assertThat(beforeEntitiesToSet).contains(jim).doesNotContain(john, mary);
+
+        assertThat(afterPotentialOwners).isEmpty();
+
+        assertThat(afterEntitiesToSet).hasSize(1);
+        assertThat(afterEntitiesToSet).contains(jim).doesNotContain(john, mary);
+
+        clearLists(beforePotentialOwners, beforeEntitiesToSet, afterPotentialOwners, afterEntitiesToSet);
+
+        assertThat(triggeredBeforeListenerCounter.getValue()).isEqualTo(3);
+        assertThat(triggeredAfterListenerCounter.getValue()).isEqualTo(3);
+    }
+
+    @SafeVarargs
+    private final void clearLists(List<OrganizationalEntity>... listsToClear) {
+        for (List<OrganizationalEntity> l : listsToClear) {
+            l.clear();
+            assertThat(l).isEmpty();
+        }
+    }
+}

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/task/HumanTask-simple.bpmn2
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/task/HumanTask-simple.bpmn2
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_qawoYLrzEDuh_a8vC56DnQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_PriorityInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_CommentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_DescriptionInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_CreatedByInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_TaskNameInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_GroupIdInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_ContentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_NotStartedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_NotCompletedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_NotStartedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_NotCompletedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:collaboration id="_AFA78AF7-C4F6-43DB-8A15-2D56E9A55E66" name="Default Collaboration">
+    <bpmn2:participant id="_0C0AB161-DD89-4C8A-9654-E7780157D897" name="Pool Participant" processRef="org.jbpm.test.functional.task.HumanTask-simple"/>
+  </bpmn2:collaboration>
+  <bpmn2:process id="org.jbpm.test.functional.task.HumanTask-simple" drools:packageName="org.jbpm.test.functional.task" drools:version="1.0" drools:adHoc="false" name="TestProcess" isExecutable="true" processType="Public">
+    <bpmn2:sequenceFlow id="_99027D7C-CB12-4BD7-AB46-E0BD6651AC33" sourceRef="_782F2FFB-4A45-4957-BA1F-C1920469443D" targetRef="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_99C505A7-2B8C-4A30-A845-A87BC62986B6" sourceRef="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA" targetRef="_E158C414-E636-4D22-A59E-35694EC0CEB7">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:startEvent id="_782F2FFB-4A45-4957-BA1F-C1920469443D" name="Start">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Start]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_99027D7C-CB12-4BD7-AB46-E0BD6651AC33</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:userTask id="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA" name="Task">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_99027D7C-CB12-4BD7-AB46-E0BD6651AC33</bpmn2:incoming>
+      <bpmn2:outgoing>_99C505A7-2B8C-4A30-A845-A87BC62986B6</bpmn2:outgoing>
+      <bpmn2:ioSpecification>
+        <bpmn2:dataInput id="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA_TaskNameInputX" drools:dtype="String" itemSubjectRef="__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA_GroupIdInputX" name="GroupId"/>
+        <bpmn2:dataInput id="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA_SkippableInputX" name="Skippable"/>
+        <bpmn2:inputSet id="_LSLjcg9oEe22-rjOji_nsQ">
+          <bpmn2:dataInputRefs>_9E72D077-F2EE-4F00-A987-6A88DD09F5EA_TaskNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_9E72D077-F2EE-4F00-A987-6A88DD09F5EA_GroupIdInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_9E72D077-F2EE-4F00-A987-6A88DD09F5EA_SkippableInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet />
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_9E72D077-F2EE-4F00-A987-6A88DD09F5EA_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[Task]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9E72D077-F2EE-4F00-A987-6A88DD09F5EA_TaskNameInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_9E72D077-F2EE-4F00-A987-6A88DD09F5EA_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[false]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9E72D077-F2EE-4F00-A987-6A88DD09F5EA_SkippableInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:endEvent id="_E158C414-E636-4D22-A59E-35694EC0CEB7" name="End">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[End]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_99C505A7-2B8C-4A30-A845-A87BC62986B6</bpmn2:incoming>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="org.jbpm.test.functional.task.HumanTask-simple">
+      <bpmndi:BPMNShape id="shape__E158C414-E636-4D22-A59E-35694EC0CEB7" bpmnElement="_E158C414-E636-4D22-A59E-35694EC0CEB7">
+        <dc:Bounds height="56" width="56" x="696" y="546"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__9E72D077-F2EE-4F00-A987-6A88DD09F5EA" bpmnElement="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA">
+        <dc:Bounds height="102" width="154" x="391" y="529"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__782F2FFB-4A45-4957-BA1F-C1920469443D" bpmnElement="_782F2FFB-4A45-4957-BA1F-C1920469443D">
+        <dc:Bounds height="56" width="56" x="258" y="552"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__9E72D077-F2EE-4F00-A987-6A88DD09F5EA_to_shape__E158C414-E636-4D22-A59E-35694EC0CEB7" bpmnElement="_99C505A7-2B8C-4A30-A845-A87BC62986B6">
+        <di:waypoint x="545" y="580"/>
+        <di:waypoint x="696" y="574"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__782F2FFB-4A45-4957-BA1F-C1920469443D_to_shape__9E72D077-F2EE-4F00-A987-6A88DD09F5EA" bpmnElement="_99027D7C-CB12-4BD7-AB46-E0BD6651AC33">
+        <di:waypoint x="314" y="580"/>
+        <di:waypoint x="391" y="580"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_9E72D077-F2EE-4F00-A987-6A88DD09F5EA">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_782F2FFB-4A45-4957-BA1F-C1920469443D">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_qawoYLrzEDuh_a8vC56DnQ</bpmn2:source>
+    <bpmn2:target>_qawoYLrzEDuh_a8vC56DnQ</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION
add workaround that offers data expected in before and afterTaskAssignementAddedEvent with some tests

https://github.com/kiegroup/droolsjbpm-knowledge/pull/647 needs to be merged first

cherrypicked from 035e8ab31fd0562a99f51cc0280d7e8b3a020415