### PR TITLE
[7.67.x-blue] RHPAM-3709: upgrade maven dependencies to address CVE-2021-26291

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
@@ -35,7 +35,9 @@
     <container.log.file>${container.profile.dir}/profile-log.txt</container.log.file>
 
     <!-- Overridden until jboss-integration-platform-parent is upgraded -->
-    <version.org.jboss.shrinkwrap.resolver>3.1.0</version.org.jboss.shrinkwrap.resolver>
+    <version.org.jboss.shrinkwrap.resolver>3.3.0</version.org.jboss.shrinkwrap.resolver>
+    <version.org.apache.maven>3.9.3</version.org.apache.maven>
+    <version.org.apache.maven.resolver>1.9.13</version.org.apache.maven.resolver>
   </properties>
 
   <dependencyManagement>

--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
@@ -38,7 +38,7 @@
     <version.org.jboss.shrinkwrap.resolver>3.3.0</version.org.jboss.shrinkwrap.resolver>
     <version.org.apache.maven>3.9.3</version.org.apache.maven>
     <version.org.apache.maven.resolver>1.9.13</version.org.apache.maven.resolver>
-    <version.com.google.guava>20.0</version.com.google.guava>
+    <version.com.google.guava>33.1.0-jre</version.com.google.guava>
   </properties>
 
   <dependencyManagement>

--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
@@ -38,6 +38,7 @@
     <version.org.jboss.shrinkwrap.resolver>3.3.0</version.org.jboss.shrinkwrap.resolver>
     <version.org.apache.maven>3.9.3</version.org.apache.maven>
     <version.org.apache.maven.resolver>1.9.13</version.org.apache.maven.resolver>
+    <version.com.google.guava>20.0</version.com.google.guava>
   </properties>
 
   <dependencyManagement>

--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
@@ -39,6 +39,10 @@
     <version.org.apache.maven>3.9.3</version.org.apache.maven>
     <version.org.apache.maven.resolver>1.9.13</version.org.apache.maven.resolver>
     <version.com.google.guava>33.1.0-jre</version.com.google.guava>
+
+    <reuseForks>false</reuseForks>
+    <forkCount>1</forkCount>
+    <useSystemClassLoader>false</useSystemClassLoader>
   </properties>
 
   <dependencyManagement>

--- a/jbpm-runtime-manager/pom.xml
+++ b/jbpm-runtime-manager/pom.xml
@@ -18,8 +18,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.soup</groupId>

--- a/jbpm-services/jbpm-kie-services/pom.xml
+++ b/jbpm-services/jbpm-kie-services/pom.xml
@@ -160,8 +160,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.freemarker</groupId>


### PR DESCRIPTION
Replaces https://github.com/kiegroup/jbpm/pull/2398