### PR TITLE
JBPM-10235 : Removed debug log statement exposing password

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/utils/LdapSearcher.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/utils/LdapSearcher.java
@@ -111,7 +111,6 @@ public class LdapSearcher {
             log.debug("Protocol: {}", config.getProperty(Context.SECURITY_PROTOCOL));
             log.debug("Provider URL: {}", config.getProperty(Context.PROVIDER_URL));
             log.debug("User DN: {}", config.getProperty(Context.SECURITY_PRINCIPAL));
-            log.debug("Password: {}", config.getProperty(Context.SECURITY_CREDENTIALS));
         }
 
         return new InitialLdapContext(config, null);


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JBPM-10235**: _(please edit the JIRA link if it exists)_ 

[link](https://issues.redhat.com/browse/JBPM-10235)

Removing the debug log statement exposing LDAP password, as raises security concerns

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.



* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>



