### PR TITLE
[7.67.x-blue] [incubator-kie-issues#1049] Add index to ProcessInstanceLog table to improve LogCleanupCommand performance

### DIFF
--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/db2/db2-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/db2/db2-jbpm-schema.sql
@@ -875,7 +875,6 @@
     create index IDX_PInstLog_pId on ProcessInstanceLog(processId);
     create index IDX_PInstLog_pInsteDescr on ProcessInstanceLog(processInstanceDescription);
     create index IDX_PInstLog_pInstId on ProcessInstanceLog(processInstanceId);
-    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
     create index IDX_PInstLog_pName on ProcessInstanceLog(processName);
     create index IDX_PInstLog_pVersion on ProcessInstanceLog(processVersion);
     create index IDX_PInstLog_start_date on ProcessInstanceLog(start_date);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/derby/derby-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/derby/derby-jbpm-schema.sql
@@ -809,7 +809,7 @@
     create index IDX_PInstLog_pId on ProcessInstanceLog(processId);
     create index IDX_PInstLog_pInsteDescr on ProcessInstanceLog(processInstanceDescription);
     create index IDX_PInstLog_pInstId on ProcessInstanceLog(processInstanceId);
-    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
+    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog(processInstanceId, status) WHERE status IN (0,1,4);
     create index IDX_PInstLog_pName on ProcessInstanceLog(processName);
     create index IDX_PInstLog_pVersion on ProcessInstanceLog(processVersion);
     create index IDX_PInstLog_start_date on ProcessInstanceLog(start_date);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/hsqldb/hsqldb-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/hsqldb/hsqldb-jbpm-schema.sql
@@ -811,7 +811,7 @@
     create index IDX_PInstLog_pId on ProcessInstanceLog(processId);
     create index IDX_PInstLog_pInsteDescr on ProcessInstanceLog(processInstanceDescription);
     create index IDX_PInstLog_pInstId on ProcessInstanceLog(processInstanceId);
-    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
+    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog(processInstanceId, status) WHERE status IN (0,1,4);
     create index IDX_PInstLog_pName on ProcessInstanceLog(processName);
     create index IDX_PInstLog_pVersion on ProcessInstanceLog(processVersion);
     create index IDX_PInstLog_start_date on ProcessInstanceLog(start_date);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
@@ -800,7 +800,6 @@
     create index IDX_PInstLog_pId on ProcessInstanceLog(processId);
     create index IDX_PInstLog_pInsteDescr on ProcessInstanceLog(processInstanceDescription);
     create index IDX_PInstLog_pInstId on ProcessInstanceLog(processInstanceId);
-    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
     create index IDX_PInstLog_pName on ProcessInstanceLog(processName);
     create index IDX_PInstLog_pVersion on ProcessInstanceLog(processVersion);
     create index IDX_PInstLog_start_date on ProcessInstanceLog(start_date);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysqlinnodb/mysql-innodb-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysqlinnodb/mysql-innodb-jbpm-schema.sql
@@ -799,7 +799,6 @@
     create index IDX_PInstLog_pId on ProcessInstanceLog(processId);
     create index IDX_PInstLog_pInsteDescr on ProcessInstanceLog(processInstanceDescription);
     create index IDX_PInstLog_pInstId on ProcessInstanceLog(processInstanceId);
-    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
     create index IDX_PInstLog_pName on ProcessInstanceLog(processName);
     create index IDX_PInstLog_pVersion on ProcessInstanceLog(processVersion);
     create index IDX_PInstLog_start_date on ProcessInstanceLog(start_date);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/oracle/oracle-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/oracle/oracle-jbpm-schema.sql
@@ -878,7 +878,6 @@
     create index IDX_PInstLog_pId on ProcessInstanceLog(processId);
     create index IDX_PInstLog_pInsteDescr on ProcessInstanceLog(processInstanceDescription);
     create index IDX_PInstLog_pInstId on ProcessInstanceLog(processInstanceId);
-    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
     create index IDX_PInstLog_pName on ProcessInstanceLog(processName);
     create index IDX_PInstLog_pVersion on ProcessInstanceLog(processVersion);
     create index IDX_PInstLog_start_date on ProcessInstanceLog(start_date);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-bytea-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-bytea-jbpm-schema.sql
@@ -154,7 +154,7 @@ create index IDX_PInstLog_parentPInstId on ProcessInstanceLog (parentProcessInst
 create index IDX_PInstLog_pId on ProcessInstanceLog (processId);
 create index IDX_PInstLog_pInsteDescr on ProcessInstanceLog (processInstanceDescription);
 create index IDX_PInstLog_pInstId on ProcessInstanceLog (processInstanceId);
-create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
+create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog(processInstanceId, status) WHERE status IN (0,1,4);
 create index IDX_PInstLog_pName on ProcessInstanceLog (processName);
 create index IDX_PInstLog_pVersion on ProcessInstanceLog (processVersion);
 create index IDX_PInstLog_start_date on ProcessInstanceLog (start_date);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/postgresql/postgresql-jbpm-schema.sql
@@ -879,7 +879,7 @@
     create index IDX_PInstLog_pId on ProcessInstanceLog(processId);
     create index IDX_PInstLog_pInsteDescr on ProcessInstanceLog(processInstanceDescription);
     create index IDX_PInstLog_pInstId on ProcessInstanceLog(processInstanceId);
-    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
+    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog(processInstanceId, status) WHERE status IN (0,1,4);
     create index IDX_PInstLog_pName on ProcessInstanceLog(processName);
     create index IDX_PInstLog_pVersion on ProcessInstanceLog(processVersion);
     create index IDX_PInstLog_start_date on ProcessInstanceLog(start_date);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver/sqlserver-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver/sqlserver-jbpm-schema.sql
@@ -811,7 +811,7 @@
     create index IDX_PInstLog_pId on ProcessInstanceLog(processId);
     create index IDX_PInstLog_pInsteDescr on ProcessInstanceLog(processInstanceDescription);
     create index IDX_PInstLog_pInstId on ProcessInstanceLog(processInstanceId);
-    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
+    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog(processInstanceId, status) WHERE status IN (0,1,4);
     create index IDX_PInstLog_pName on ProcessInstanceLog(processName);
     create index IDX_PInstLog_pVersion on ProcessInstanceLog(processVersion);
     create index IDX_PInstLog_start_date on ProcessInstanceLog(start_date);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver2008/sqlserver2008-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sqlserver2008/sqlserver2008-jbpm-schema.sql
@@ -811,7 +811,7 @@
     create index IDX_PInstLog_pId on ProcessInstanceLog(processId);
     create index IDX_PInstLog_pInsteDescr on ProcessInstanceLog(processInstanceDescription);
     create index IDX_PInstLog_pInstId on ProcessInstanceLog(processInstanceId);
-    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
+    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog(processInstanceId, status) WHERE status IN (0,1,4);
     create index IDX_PInstLog_pName on ProcessInstanceLog(processName);
     create index IDX_PInstLog_pVersion on ProcessInstanceLog(processVersion);
     create index IDX_PInstLog_start_date on ProcessInstanceLog(start_date);

--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sybase/sybase-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/sybase/sybase-jbpm-schema.sql
@@ -983,8 +983,6 @@
     go
     create index IDX_PInstLog_pInstId on ProcessInstanceLog(processInstanceId)
     go
-    create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4)
-    go
     create index IDX_PInstLog_pName on ProcessInstanceLog(processName)
     go
     create index IDX_PInstLog_pVersion on ProcessInstanceLog(processVersion)

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/db2/rhpam-7.13.1-to-7.13.5.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/db2/rhpam-7.13.1-to-7.13.5.sql
@@ -1,1 +1,0 @@
-create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/rhpam-7.13.1-to-7.13.5.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/derby/rhpam-7.13.1-to-7.13.5.sql
@@ -1,1 +1,1 @@
-create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
+create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog(processInstanceId, status) WHERE status IN (0,1,4);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/rhpam-7.13.1-to-7.13.5.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/hsqldb/rhpam-7.13.1-to-7.13.5.sql
@@ -1,1 +1,1 @@
-create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
+create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog(processInstanceId, status) WHERE status IN (0,1,4);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/rhpam-7.13.1-to-7.13.5.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/rhpam-7.13.1-to-7.13.5.sql
@@ -1,1 +1,0 @@
-create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/rhpam-7.13.1-to-7.13.5.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/rhpam-7.13.1-to-7.13.5.sql
@@ -1,1 +1,0 @@
-create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/rhpam-7.13.1-to-7.13.5.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/postgresql/rhpam-7.13.1-to-7.13.5.sql
@@ -1,1 +1,1 @@
-create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
+create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog(processInstanceId, status) WHERE status IN (0,1,4);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/rhpam-7.13.1-to-7.13.5.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver/rhpam-7.13.1-to-7.13.5.sql
@@ -1,1 +1,1 @@
-create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
+create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog(processInstanceId, status) WHERE status IN (0,1,4);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/rhpam-7.13.1-to-7.13.5.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sqlserver2008/rhpam-7.13.1-to-7.13.5.sql
@@ -1,1 +1,1 @@
-create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4);
+create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog(processInstanceId, status) WHERE status IN (0,1,4);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/rhpam-7.13.1-to-7.13.5.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/sybase/rhpam-7.13.1-to-7.13.5.sql
@@ -1,2 +1,0 @@
-create index IDX_PInstLog_pInstId_status ON ProcessInstanceLog (processInstanceId, status)  WHERE status IN (0,1,4)
-go


### PR DESCRIPTION
Removes the index from the scripts for database systems that don't support defining indexes with "where" clause. It is only supported in SQLServer and PostgreSQL. 