### PR TITLE
Fix SQL scripts for MySQL.

### DIFF
--- a/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
+++ b/jbpm-db-scripts/src/main/resources/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
@@ -102,7 +102,7 @@
     );
 
     create table TimerMappingInfo (
-    	id bigint generated not null auto_increment, 
+    	id bigint not null auto_increment,
     	externalTimerId varchar(255), 
     	kieSessionId bigint not null, 
     	processInstanceId bigint, 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/jbpm-7.61-to-7.62-TimerMappingInfo.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/jbpm-7.61-to-7.62-TimerMappingInfo.sql
@@ -1,6 +1,6 @@
 
 create table TimerMappingInfo (
-	id bigint generated not null auto_increment, 
+	id bigint not null auto_increment,
 	externalTimerId varchar(255), 
 	kieSessionId bigint not null, 
 	timerId bigint not null, 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/jbpm-7.72-to-7.73.sql
@@ -1,3 +1,3 @@
-DROP INDEX IDX_EventTypes_element;
-DROP INDEX IDX_EventTypes_compound;
+DROP INDEX IDX_EventTypes_element on EventTypes;
+DROP INDEX IDX_EventTypes_compound on EventTypes;
 CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/rhpam-7.12-to-7.13.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/rhpam-7.12-to-7.13.sql
@@ -2,7 +2,7 @@ ALTER TABLE TaskEvent ADD COLUMN currentOwner varchar(255);
 alter table NodeInstanceLog add column observation varchar(255);
 
 create table TimerMappingInfo (
-	id bigint generated not null auto_increment, 
+	id bigint not null auto_increment,
 	externalTimerId varchar(255), 
 	kieSessionId bigint not null, 
 	timerId bigint not null, 

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysql5/rhpam-7.13-to-7.13.1.sql
@@ -1,5 +1,5 @@
 ALTER TABLE TimerMappingInfo ADD COLUMN processInstanceId bigint;
 ALTER TABLE TimerMappingInfo MODIFY timerId bigint NULL;
-DROP INDEX IDX_EventTypes_element;
-DROP INDEX IDX_EventTypes_compound;
+DROP INDEX IDX_EventTypes_element on EventTypes;
+DROP INDEX IDX_EventTypes_compound on EventTypes ;
 CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/jbpm-7.72-to-7.73.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/jbpm-7.72-to-7.73.sql
@@ -1,3 +1,3 @@
-DROP INDEX IDX_EventTypes_element;
-DROP INDEX IDX_EventTypes_compound;
+DROP INDEX IDX_EventTypes_element on EventTypes;
+DROP INDEX IDX_EventTypes_compound on EventTypes;
 CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);

--- a/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/rhpam-7.13-to-7.13.1.sql
+++ b/jbpm-db-scripts/src/main/resources/db/upgrade-scripts/mysqlinnodb/rhpam-7.13-to-7.13.1.sql
@@ -1,5 +1,5 @@
 ALTER TABLE TimerMappingInfo ADD COLUMN processInstanceId bigint;
 ALTER TABLE TimerMappingInfo MODIFY timerId bigint NULL;
-DROP INDEX IDX_EventTypes_element;
-DROP INDEX IDX_EventTypes_compound;
+DROP INDEX IDX_EventTypes_element on EventTypes;
+DROP INDEX IDX_EventTypes_compound on EventTypes;
 CREATE INDEX IDX_EventTypes_IdElement ON EventTypes(InstanceId,element);


### PR DESCRIPTION
- Fixes drop indexes, it needs table specification on MySQL, otherwise it fails. 
- Fixes TimerMappingInfo creation on MySQL, the generated keyword doesn't work on MySQL. 