### PR TITLE
[DBACLD-164346] Bump smack jar version from 3.1.0 to 4.0.2

### DIFF
--- a/jbpm-distribution/pom.xml
+++ b/jbpm-distribution/pom.xml
@@ -53,9 +53,14 @@
                   <version>${version.org.quartz-scheduler}</version>
                 </additionalDependency>
                 <additionalDependency>
-                  <groupId>jivesoftware</groupId>
-                  <artifactId>smack</artifactId>
-                  <version>${version.jivesoftware.smack}</version>
+                  <groupId>org.igniterealtime.smack</groupId>
+                  <artifactId>smack-core</artifactId>
+                  <version>${version.org.igniterealtime.smack-core}</version>
+                </additionalDependency>
+                <additionalDependency>
+                  <groupId>org.igniterealtime.smack</groupId>
+                  <artifactId>smack-tcp</artifactId>
+                  <version>${version.org.igniterealtime.smack-tcp}</version>
                 </additionalDependency>
                 <additionalDependency>
                   <groupId>rome</groupId>


### PR DESCRIPTION
**Thank you for submitting this pull request**

**referenced Pull Requests**: _(https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2542)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.
 
 