### PR TITLE
[DBACLD-162578] LogCleanupCommand rescheduling with FIXED delay not working as expected

### DIFF
--- a/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/impl/AbstractAvailableJobsExecutor.java
+++ b/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/impl/AbstractAvailableJobsExecutor.java
@@ -132,9 +132,8 @@ public abstract class AbstractAvailableJobsExecutor {
                         ctx.setData("ClassLoader", cl);
 
                         // add scheduled execution time
-                        if(ctx.getData("scheduledExecutionTime") == null) {
-                            ctx.setData("scheduledExecutionTime", request.getTime());
-                        }
+                        ctx.setData("scheduledExecutionTime", request.getTime());
+                        
 
                         cmd = classCacheManager.findCommand(request.getCommandName(), cl);
                         // increment execution counter directly to cover both success and failure paths


### PR DESCRIPTION
**JIRA**: _(DBACLD-162578)_ 

This PR will  fix the rescheduling in both scenarios:

    Long running LogCleanupCommand
    Multiple LogCleanupCommand runs due to RecordsPerTransaction setting


  
