### PR TITLE
[CVE] CVE-2021-20250

### DIFF
--- a/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-in-container-test/jbpm-container-test-suite/pom.xml
@@ -254,18 +254,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss</groupId>
-      <artifactId>jboss-remote-naming</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.xnio</groupId>
-          <artifactId>xnio-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jboss.remoting</groupId>
-          <artifactId>jboss-remoting</artifactId>
-        </exclusion>
-      </exclusions>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-remoting</artifactId>
+        <version>${version.org.wildfly.core}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.jms</groupId>

--- a/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
@@ -226,10 +226,9 @@
       <artifactId>jbpm-bpmn2</artifactId>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
-      <groupId>org.jboss</groupId>
-      <artifactId>jboss-remote-naming</artifactId>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-remoting</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.xnio</groupId>

--- a/jbpm-container-test/jbpm-remote-ejb-test/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/pom.xml
@@ -31,9 +31,9 @@
       <!-- Override necessary to be compatible with jboss-remote-naming
            Must put this here so it only overrides version in EJB tests -->
       <dependency>
-        <groupId>org.jboss.remoting</groupId>
-        <artifactId>jboss-remoting</artifactId>
-        <version>${version.org.jboss.remoting.naming}</version>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-remoting</artifactId>
+        <version>${version.org.wildfly.core}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jbpm-container-test/pom.xml
+++ b/jbpm-container-test/pom.xml
@@ -44,9 +44,6 @@
      here or via system property when running the build (don't forget to use the `file://` prefix when
      referencing the zip from local filesystem). -->
     <eap7.download.url>file:///valid-url-for-eap-7-needs-to-be-specified-here-or-via-cmd-line</eap7.download.url>
-
-    <!-- jboss-remoting version compatible with jboss-remote-naming -->
-    <version.org.jboss.remoting.naming>4.0.18.Final</version.org.jboss.remoting.naming>
   </properties>
 
   <build>


### PR DESCRIPTION
Issue in the remoting code that we're putting in from JBoss. EAP 7.4.20 is using wildfly, so aligning with that version.

See https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2555