### PR TITLE
Add GitHub Actions workflow to verify flaky testVerify flaky test

### DIFF
--- a/.github/workflows/verify-flaky-test.yml
+++ b/.github/workflows/verify-flaky-test.yml
@@ -1,0 +1,60 @@
+name: Verify Flaky Test
+
+on:
+  push:
+    branches: [ verify-flaky-test ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          
+      - name: Build with Maven (Skip Tests)
+        run: mvn clean install -DskipTests
+        
+      - name: Run Test Normally (Expected to Pass)
+        run: |
+          echo "Running test without NonDex - should PASS"
+          mvn test -pl jbpm-case-mgmt/jbpm-case-mgmt-impl -Dtest=org.jbpm.casemgmt.impl.CaseServiceImplTest#testStartExpressionCaseWithCaseFile
+          echo "Test passed without NonDex as expected"
+          
+      - name: Run Test with NonDex (Expected to Fail)
+        continue-on-error: true
+        id: nondex-run
+        run: |
+          echo "Running test with NonDex - should FAIL"
+          mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl jbpm-case-mgmt/jbpm-case-mgmt-impl -Dtest=org.jbpm.casemgmt.impl.CaseServiceImplTest#testStartExpressionCaseWithCaseFile
+          # Store the exit code
+          echo "nondex_exit_code=$?" >> $GITHUB_OUTPUT
+          
+      - name: Display NonDex Results
+        run: |
+          echo "Checking NonDex results"
+          ls -la jbpm-case-mgmt/jbpm-case-mgmt-impl/.nondex/ || echo "No .nondex directory found"
+          for dir in jbpm-case-mgmt/jbpm-case-mgmt-impl/.nondex/*/; do
+            if [ -d "$dir" ]; then
+              echo "Contents of $dir:"
+              ls -la "$dir"
+              if [ -f "$dir/failure" ]; then
+                echo "Found failure file in $dir:"
+                cat "$dir/failure"
+              fi
+            fi
+          done
+          
+      - name: Verify Test Flakiness
+        run: |
+          if [ "${{ steps.nondex-run.outputs.nondex_exit_code }}" != "0" ]; then
+            echo " Test is flaky: Passes without NonDex but fails with NonDex"
+          else
+            echo " Test is not flaky: Passes both with and without NonDex"
+            exit 1
+          fi

--- a/.github/workflows/verify-flaky-test.yml
+++ b/.github/workflows/verify-flaky-test.yml
@@ -10,31 +10,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
-          
-      - name: Build with Maven (Skip Tests)
-        run: mvn clean install -DskipTests
-        
+
+      - name: Build with Maven (Skip Tests and Skip Enforcer)
+        run: mvn clean install -DskipTests -Denforcer.skip=true
+
       - name: Run Test Normally (Expected to Pass)
         run: |
           echo "Running test without NonDex - should PASS"
           mvn test -pl jbpm-case-mgmt/jbpm-case-mgmt-impl -Dtest=org.jbpm.casemgmt.impl.CaseServiceImplTest#testStartExpressionCaseWithCaseFile
           echo "Test passed without NonDex as expected"
-          
+
       - name: Run Test with NonDex (Expected to Fail)
         continue-on-error: true
         id: nondex-run
         run: |
           echo "Running test with NonDex - should FAIL"
           mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl jbpm-case-mgmt/jbpm-case-mgmt-impl -Dtest=org.jbpm.casemgmt.impl.CaseServiceImplTest#testStartExpressionCaseWithCaseFile
-          # Store the exit code
           echo "nondex_exit_code=$?" >> $GITHUB_OUTPUT
-          
+
       - name: Display NonDex Results
         run: |
           echo "Checking NonDex results"
@@ -49,7 +48,7 @@ jobs:
               fi
             fi
           done
-          
+
       - name: Verify Test Flakiness
         run: |
           if [ "${{ steps.nondex-run.outputs.nondex_exit_code }}" != "0" ]; then


### PR DESCRIPTION
Add GitHub Actions workflow to verify flaky test

Purpose:
This PR adds a custom GitHub Actions workflow named verify-flaky-test.yml to confirm that the test org.jbpm.casemgmt.impl.CaseServiceImplTest#testStartExpressionCaseWithCaseFile is flaky.
The test passes under normal execution but fails when executed with NonDex, confirming the presence of non-deterministic behavior.

Summary of Changes:
- Added a new workflow: .github/workflows/verify-flaky-test.yml
- The workflow:
  - Sets up JDK 11 using actions/setup-java
  - Builds the project using Maven with tests skipped
  - Runs the test normally (expected to pass)
  - Runs the test again using NonDex (expected to fail)
  - Verifies flakiness by comparing exit codes and logs

Output:
The GitHub Actions build shows:
- Normal test run passes
- NonDex test run fails
- Final verification logs include:
  Test is flaky: Passes without NonDex but fails with NonDex

Logs and Output:
You can find the logs and output in the attached build artifacts, or view the successful build at:
(REPLACE WITH YOUR ACTIONS RUN LINK)

Attachments:
- CI Build Log ([ci-build.log or zip](https://drive.google.com/file/d/1GDbD5Oy5IYgUGe5Tvnyz1efLuAPND_Da/view?usp=sharing))
- [Workflow YAML](https://github.com/Md-Arif-Hasan/jbpm/blob/verify-flaky-test/.github/workflows/verify-flaky-test.yml)
- Git diff of the new workflow file

Notes:
This workflow automates the process of documenting the flakiness of CaseServiceImplTest.testStartExpressionCaseWithCaseFile using GitHub Actions. The CI logs confirm the test's behavior, showing that it passes under normal conditions but fails when executed with NonDex, which confirms the test is flaky due to non-deterministic behavior in certain environments.
Using this workflow, flaky tests can be detected and verified in a controlled, automated manner, which helps maintain the stability of the project's test suite.