### PR TITLE
Fix CommentNotificationEventListenerTest caused by Iteration Order No…

### DIFF
--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/event/CommentNotificationEventListenerTest.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/event/CommentNotificationEventListenerTest.java
@@ -176,12 +176,12 @@ public class CommentNotificationEventListenerTest {
         listener.addPublisher(publisher);
         
         listener.afterCaseCommentAdded(event);
-        
-        String expectedNotification = "Publishing notification from cases@jbpm.org, with subject You have been mentioned in case (CASE-00001) comment to [[UserImpl:'mary'], [UserImpl:'john']] with body simple comment for john and mary";
-        
+
+        String expectedNotification = "Publishing notification from cases@jbpm\\.org, with subject You have been mentioned in case \\(CASE-00001\\) comment to \\[\\[UserImpl:'(mary|john)'], \\[UserImpl:'(john|mary)']] with body simple comment for john and mary";
+
         List<String> published = publisher.get();
         assertThat(published).hasSize(1);
-        assertThat(published.get(0)).isEqualTo(expectedNotification);
+        assertThat(published.get(0)).matches(expectedNotification);
     }
     
     protected CaseFileInstance buildCaseFile(List<String> mentionedRoles) {


### PR DESCRIPTION
# Fix Flakiness of CommentNotificationEventListenerTest caused by Iteration Order Nondeterminism


## Context
This test was failing nondeterministically due to **iteration order differences** in user lists.  
It passed in some runs but failed in others, depending on whether "john" or "mary" appeared first.
Error Message:
```
[ERROR] Failures: 
[ERROR]   CommentNotificationEventListenerTest.testNotificationOnCommentAddedWithRawBody:184 expected:<...ment to [[UserImpl:'[mary'], [UserImpl:'john]']] with body simple...> but was:<...ment to [[UserImpl:'[john'], [UserImpl:'mary]']] with body simple...>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
``` 
## Fix
Replaced strict equality (isEqualTo) with a regex match (matches), allowing the order of "john" and "mary" to vary.
```java
[UserImpl:'(mary|john)'], \\[UserImpl:'(john|mary)']]
``` 
This change makes the test verify the correctness of the notification content with nondeterministic ordering.


## Verification
- Re-ran the suite multiple times with randomized test order → **0 failures observed**.  
- Confirmed both possible user orderings are accepted by the regex.  

## Checklist
- [x] Root cause explained in PR  
- [x] Fix applied deterministically  
- [x] Random-order reruns are green 