### PR TITLE
test: make org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testGetNodes deterministic

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/admin/ProcessInstanceAdminServiceImplTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/admin/ProcessInstanceAdminServiceImplTest.java
@@ -21,6 +21,7 @@ import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -46,6 +47,7 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.query.QueryContext;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.query.QueryFilter;
+import org.kie.internal.runtime.conf.DeploymentDescriptor;
 import org.kie.internal.runtime.conf.ObjectModel;
 import org.kie.internal.runtime.error.ExecutionError;
 import org.kie.scanner.KieMavenRepository;
@@ -90,7 +92,9 @@ public class ProcessInstanceAdminServiceImplTest extends AbstractKieServicesBase
         processes.add("repo/processes/general/BPMN2-ProcessSLA.bpmn2");
         processes.add("repo/processes/general/BPMN2-SuspendUntil.bpmn2");
 
-        InternalKieModule kJar1 = createKieJar(ks, releaseId, processes);
+        Map<String, String> extraResources = new LinkedHashMap<>();
+        extraResources.put("src/main/resources/" + DeploymentDescriptor.META_INF_LOCATION, StableDescriptorXml.descriptorXml());
+        InternalKieModule kJar1 = createKieJar(ks, releaseId, processes, extraResources);
         File pom = new File("target/admin", "pom.xml");
         pom.getParentFile().mkdir();
         try {
@@ -584,7 +588,4 @@ public class ProcessInstanceAdminServiceImplTest extends AbstractKieServicesBase
         return listeners;
     }
     
-    protected boolean createDescriptor() {
-        return true;
-    }
 }

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/admin/StableDescriptorXml.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/admin/StableDescriptorXml.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.kie.services.impl.admin;
+
+/*
+ * Provides a pre-rendered kie-deployment-descriptor.xml so the test does not depend on JAXB iteration order.
+ * Mirrors the descriptor produced by AbstractKieServicesTest#createDeploymentDescriptor() for this fixture,
+ * ensuring the deployment remains stable across runs.
+ */
+final class StableDescriptorXml {
+
+    private static final String XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+            + "<deployment-descriptor xsi:schemaLocation=\"http://www.jboss.org/jbpm deployment-descriptor.xsd\" "
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n"
+            + "    <persistence-unit>org.jbpm.domain</persistence-unit>\n"
+            + "    <audit-persistence-unit>org.jbpm.domain</audit-persistence-unit>\n"
+            + "    <audit-mode>JPA</audit-mode>\n"
+            + "    <persistence-mode>JPA</persistence-mode>\n"
+            + "    <runtime-strategy>SINGLETON</runtime-strategy>\n"
+            + "    <marshalling-strategies/>\n"
+            + "    <event-listeners>\n"
+            + "        <event-listener>\n"
+            + "            <resolver>mvel</resolver>\n"
+            + "            <identifier>org.jbpm.kie.test.util.CountDownListenerFactory.get(&quot;processAdminService&quot;, &quot;timer&quot;, 1)</identifier>\n"
+            + "            <parameters/>\n"
+            + "        </event-listener>\n"
+            + "    </event-listeners>\n"
+            + "    <task-event-listeners/>\n"
+            + "    <globals/>\n"
+            + "    <work-item-handlers/>\n"
+            + "    <environment-entries/>\n"
+            + "    <configurations/>\n"
+            + "    <required-roles/>\n"
+            + "    <remoteable-classes/>\n"
+            + "    <limit-serialization-classes>true</limit-serialization-classes>\n"
+            + "</deployment-descriptor>\n";
+
+    private StableDescriptorXml() {
+    }
+
+    static String descriptorXml() {
+        return XML;
+    }
+}


### PR DESCRIPTION
**Summary**
- Type: deterministic comparison (schema/iteration-order)
- Scope: test-only; no production changes
- Module: `jbpm-services/jbpm-kie-services`
- Test: `org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest#testGetNodes`

**Root Cause**
JAXB serialization of the deployment descriptor is order-sensitive with respect to the schema. When collection iteration order varies, the marshaller can emit elements (e.g., `audit-persistence-unit`) before expected groups, leading to schema validation errors during descriptor generation. This manifests as intermittent test failures when the iteration order differs across runs.

**Fix**
Provide a pre-rendered `kie-deployment-descriptor.xml` in the test fixture (`StableDescriptorXml`) and add it via `extraResources` when building the test KJAR. The XML mirrors the descriptor produced by `AbstractKieServicesTest#createDeploymentDescriptor()` for this test (including the event listener), ensuring stable, schema-compliant element order without changing any runtime behavior or assertions.

**Validation**
- Local: `mvn -pl jbpm-services/jbpm-kie-services -Dtest=org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest#testGetNodes test` passes consistently
- Assertions unchanged: still validates node count (8) and name→type map

**Risk**
Low. Test-only resource injection; no production classes modified. The descriptor content is equivalent, just rendered with a stable element order.

