### PR TITLE
fix: make deployment descriptor xml deterministic

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorIO.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorIO.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.internal.runtime.manager.deploy;
+
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.kie.internal.runtime.conf.DeploymentDescriptor;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * XML based deployment descriptor IO manager to read and write descriptors.
+ * Underlying uses <code>XStream</code> for serialization with special class
+ * and field mapping for more readability of the produced XML output.
+ *
+ */
+public class DeploymentDescriptorIO {
+
+    private static final List<String> TOP_LEVEL_ELEMENT_ORDER = Arrays.asList(
+            "persistence-unit",
+            "audit-persistence-unit",
+            "audit-mode",
+            "persistence-mode",
+            "runtime-strategy",
+            "marshalling-strategies",
+            "event-listeners",
+            "task-event-listeners",
+            "globals",
+            "work-item-handlers",
+            "environment-entries",
+            "configurations",
+            "required-roles",
+            "remoteable-classes",
+            "limit-serialization-classes"
+    );
+
+    private static final List<String> OBJECT_MODEL_CHILD_ORDER = Arrays.asList(
+            "resolver",
+            "identifier",
+            "parameters"
+    );
+
+    private static final List<String> NAMED_OBJECT_MODEL_CHILD_ORDER = Arrays.asList(
+            "resolver",
+            "identifier",
+            "parameters",
+            "name"
+    );
+
+    private static final List<String> OBJECT_MODEL_ELEMENT_NAMES = Arrays.asList(
+            "marshalling-strategy",
+            "event-listener",
+            "task-event-listener",
+            "objectModel"
+    );
+
+    private static final List<String> NAMED_OBJECT_MODEL_ELEMENT_NAMES = Arrays.asList(
+            "work-item-handler",
+            "global",
+            "environment-entry",
+            "configuration",
+            "namedObjectModel"
+    );
+
+    private static JAXBContext context = null;
+    private static Schema schema = null;
+
+    /**
+     * Reads XML data from given input stream and produces valid instance of
+     * <code>DeploymentDescriptor</code>
+     * @param inputStream input stream that comes with xml data of the descriptor
+     * @return instance of the descriptor after deserialization
+     */
+    public static DeploymentDescriptor fromXml(InputStream inputStream) {
+        try {
+            Unmarshaller unmarshaller = getContext().createUnmarshaller();
+            unmarshaller.setSchema(schema);
+            DeploymentDescriptor descriptor = (DeploymentDescriptor) unmarshaller.unmarshal(inputStream);
+
+            return descriptor;
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to read deployment descriptor from xml", e);
+        }
+    }
+
+    /**
+     * Serializes descriptor instance to XML
+     * @param descriptor descriptor to be serialized
+     * @return xml representation of descriptor as string
+     */
+    public static String toXml(DeploymentDescriptor descriptor) {
+        try {
+
+            Marshaller marshaller = getContext().createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+            marshaller.setProperty(Marshaller.JAXB_SCHEMA_LOCATION, "http://www.jboss.org/jbpm deployment-descriptor.xsd");
+
+            // clone the object and cleanup transients
+            DeploymentDescriptor clone = ((DeploymentDescriptorImpl) descriptor).clearClone();
+
+            Document document = newDocument();
+            marshaller.marshal(clone, document);
+
+            // Normalize element order to keep the XML schema-compliant regardless of iteration order
+            canonicalizeElementOrder(document.getDocumentElement());
+            schema.newValidator().validate(new DOMSource(document));
+
+            return toString(document);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to generate xml from deployment descriptor", e);
+        }
+    }
+
+    public static JAXBContext getContext() throws JAXBException, SAXException {
+        if (context == null) {
+            Class<?>[] jaxbClasses = {DeploymentDescriptorImpl.class};
+            context = JAXBContext.newInstance(jaxbClasses);
+            // load schema for validation
+            URL schemaLocation = DeploymentDescriptorIO.class.getResource("/deployment-descriptor.xsd");
+            schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema(schemaLocation);
+        }
+
+        return context;
+    }
+
+    private static Document newDocument() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        return factory.newDocumentBuilder().newDocument();
+    }
+
+    private static void canonicalizeElementOrder(Element element) {
+        List<String> expectedOrder = expectedChildOrderFor(element);
+        if (expectedOrder != null) {
+            reorderChildren(element, expectedOrder);
+        }
+
+        for (Element child : directChildElements(element)) {
+            canonicalizeElementOrder(child);
+        }
+    }
+
+    private static List<String> expectedChildOrderFor(Element element) {
+        String name = elementLocalName(element);
+        if ("deployment-descriptor".equals(name)) {
+            return TOP_LEVEL_ELEMENT_ORDER;
+        }
+        if (OBJECT_MODEL_ELEMENT_NAMES.contains(name)) {
+            return OBJECT_MODEL_CHILD_ORDER;
+        }
+        if (NAMED_OBJECT_MODEL_ELEMENT_NAMES.contains(name)) {
+            return NAMED_OBJECT_MODEL_CHILD_ORDER;
+        }
+        return null;
+    }
+
+    private static void reorderChildren(Element root, List<String> expectedOrder) {
+        List<Element> children = directChildElements(root);
+        if (children.isEmpty()) {
+            return;
+        }
+
+        // Split children into expected buckets and a tail list preserving original order
+        Set<String> expectedNames = new HashSet<>(expectedOrder);
+        Map<String, List<Element>> expectedBuckets = new HashMap<>();
+        List<Element> tail = new ArrayList<>();
+        for (Element child : children) {
+            String name = elementLocalName(child);
+            if (expectedNames.contains(name)) {
+                expectedBuckets.computeIfAbsent(name, k -> new ArrayList<>()).add(child);
+            } else {
+                tail.add(child);
+            }
+        }
+
+        removeAllChildren(root);
+
+        for (String name : expectedOrder) {
+            List<Element> bucket = expectedBuckets.get(name);
+            if (bucket != null) {
+                for (Element el : bucket) {
+                    root.appendChild(el);
+                }
+            }
+        }
+        // Append nodes not listed in expectedOrder, preserving their original order
+        for (Element el : tail) {
+            root.appendChild(el);
+        }
+    }
+
+    private static List<Element> directChildElements(Element root) {
+        List<Element> elements = new ArrayList<>();
+        NodeList children = root.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node node = children.item(i);
+            if (node.getNodeType() == Node.ELEMENT_NODE) {
+                elements.add((Element) node);
+            }
+        }
+        return elements;
+    }
+
+    private static void removeAllChildren(Element root) {
+        Node node = root.getFirstChild();
+        while (node != null) {
+            Node next = node.getNextSibling();
+            root.removeChild(node);
+            node = next;
+        }
+    }
+
+    private static String elementLocalName(Element element) {
+        String localName = element.getLocalName();
+        return localName != null ? localName : element.getNodeName();
+    }
+
+    private static String toString(Document document) throws Exception {
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+
+        StringWriter stringWriter = new StringWriter();
+        transformer.transform(new DOMSource(document), new StreamResult(stringWriter));
+        return stringWriter.toString();
+    }
+}


### PR DESCRIPTION
**Summary**
- Type: deterministic serialization (iteration-order)
- Scope: centralized fix in `DeploymentDescriptorIO#toXml`
- Affected tests: 115 flaky tests across `ProcessInstanceAdminServiceImplTest`, `KModuleDeploymentServiceTest`,
  `ProcessServiceImplWithoutAuditTest`, `ProcessServiceWithEntitiesTest`, `ProcessServiceWithVariableTagsTest`,
  `QueryServiceImplTest`, `RuntimeDataServiceImplSecurityTest`, `UserTaskInstanceWithPotOwnerTest`,
  `UserTaskServiceImplAuditNoneTest`, and `UserTaskWithSecurityTest`

<details>
<summary>
Flaky tests
</summary>
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testCancelAndTrigger
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testCancelAndTriggerAnotherNode
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testErrorByDeploymentId
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testErrorHandlingOnScriptTask
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testGetNodes
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testListSLATimer
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testListSuspendUntilTimer
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testQuerySlaProcess
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testReTriggerNodeInstance
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testTimerName
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testTriggerLastActionNode
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testTriggerSubProcessNodeInstance
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testUpdateTimer
org.jbpm.kie.services.impl.admin.ProcessInstanceAdminServiceImplTest.testUpdateTimerRelative
org.jbpm.kie.services.test.KModuleDeploymentServiceTest.testDeploymentAvoidEmptyDescriptorOverride
org.jbpm.kie.services.test.KModuleDeploymentServiceTest.testDeploymentOfProcessWithDescriptor
org.jbpm.kie.services.test.KModuleDeploymentServiceTest.testDeploymentOfProcessWithDescriptorKieConteinerInjection
org.jbpm.kie.services.test.KModuleDeploymentServiceTest.testDeploymentOfProcessWithDescriptorWitSecurityManager
org.jbpm.kie.services.test.ProcessServiceImplWithoutAuditTest.testStartAndAbortProcess
org.jbpm.kie.services.test.ProcessServiceImplWithoutAuditTest.testStartAndSignalProcess
org.jbpm.kie.services.test.ProcessServiceImplWithoutAuditTest.testStartAndSignalProcesses
org.jbpm.kie.services.test.ProcessServiceImplWithoutAuditTest.testStartProcess
org.jbpm.kie.services.test.ProcessServiceImplWithoutAuditTest.testStartProcessAndAbortAlreadyAborted
org.jbpm.kie.services.test.ProcessServiceImplWithoutAuditTest.testStartProcessAndAbortThenChangeVariables
org.jbpm.kie.services.test.ProcessServiceImplWithoutAuditTest.testStartProcessAndChangeVariables
org.jbpm.kie.services.test.ProcessServiceImplWithoutAuditTest.testStartProcessWithCorrelationKey
org.jbpm.kie.services.test.ProcessServiceWithEntitiesTest.testStartProcessAndGetVariables
org.jbpm.kie.services.test.ProcessServiceWithVariableTagsTest.testStartProcessWithRestrictedVariable
org.jbpm.kie.services.test.ProcessServiceWithVariableTagsTest.testStartProcessWithViolatedRestrictedVariable
org.jbpm.kie.services.test.QueryServiceImplTest.testGetFilteredProcessInstances
org.jbpm.kie.services.test.QueryServiceImplTest.testGetFilteredTaskInstancesAsBA
org.jbpm.kie.services.test.QueryServiceImplTest.testGetFilteredTaskInstancesAsPotOwners
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstances
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesByProcessId
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesByState
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesCount
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesCountAndGroup
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesCustomWithoutVars
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesCustomWithVars
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesGroupWithInterval
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesGroupWithoutInterval
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesWithCustomVariables
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesWithOrderByClause
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesWithQueryParamBuilder
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesWithRawMapper
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesWithRawMapperMultipleRows
org.jbpm.kie.services.test.QueryServiceImplTest.testGetProcessInstancesWithVariables
org.jbpm.kie.services.test.QueryServiceImplTest.testGetTaskInstances
org.jbpm.kie.services.test.QueryServiceImplTest.testGetTaskInstancesAsBA
org.jbpm.kie.services.test.QueryServiceImplTest.testGetTaskInstancesAsExcludedOwner
org.jbpm.kie.services.test.QueryServiceImplTest.testGetTaskInstancesAsPotOwners
org.jbpm.kie.services.test.QueryServiceImplTest.testGetTaskInstancesWithCustomVariables
org.jbpm.kie.services.test.QueryServiceImplTest.testGetTaskInstancesWithVariables
org.jbpm.kie.services.test.QueryServiceImplTest.testRegisterInvalidQuery
org.jbpm.kie.services.test.QueryServiceImplTest.testRegisterQueryWithCustomDataSourceResolver
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstanceById
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstanceByIdNoAccess
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstances
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByDeploymentIdAndState
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByDeploymentIdAndStateNoAccess
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByPartialProcessIdAndState
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByPartialProcessIdAndStateNoAccess
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByProcessId
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByProcessIdAndState
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByProcessIdAndStateAndInitiator
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByProcessIdAndStateAndInitiatorNoAccess
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByProcessIdAndStateNoAccess
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByProcessIdNoAccess
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByState
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByStateAndInitiator
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByStateAndInitiatorNoAccess
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesByStateNoAccess
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesNoAccess
org.jbpm.kie.services.test.RuntimeDataServiceImplSecurityTest.testGetProcessInstancesWithTimer
org.jbpm.kie.services.test.UserTaskInstanceWithPotOwnerTest.testSearchTaskByPotOwnerMapper
org.jbpm.kie.services.test.UserTaskInstanceWithPotOwnerTest.testSearchTaskByPotOwnerQueryParamBuilder
org.jbpm.kie.services.test.UserTaskInstanceWithPotOwnerTest.testSearchTaskWithModifVarsMapper
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testActivate
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testAttachmentOperations
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testCommentOperations
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testCompleteAutoProgress
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testCompleteAutoProgressWrongDeploymentId
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testContentRelatedOperations
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testDelegate
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testExecute
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testExit
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testGetTask
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testGetTaskOfAbortedProcess
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testNominate
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testProcessWithLazyLoadedVariable
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testReleaseAndBulkClaim
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testReleaseAndClaim
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testSetDescription
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testSetExpirationDate
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testSetName
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testSetPriority
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testSetSkippable
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testSkip
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testStartAndComplete
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testStartAndFail
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testStartAndForward
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testStartAndStop
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testSuspendAndResume
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testTaskOperationWithUserOrWithIdentityProvider
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testUpdateTask
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testUpdateTaskPermissionDenied
org.jbpm.kie.services.test.UserTaskServiceImplAuditNoneTest.testUpdateTaskWithData
org.jbpm.kie.services.test.UserTaskWithSecurityTest.testGetAndWorkOnUserTasks[PER_CASE]
org.jbpm.kie.services.test.UserTaskWithSecurityTest.testGetAndWorkOnUserTasks[PER_PROCESS_INSTANCE]
org.jbpm.kie.services.test.UserTaskWithSecurityTest.testGetAndWorkOnUserTasks[PER_REQUEST]
org.jbpm.kie.services.test.UserTaskWithSecurityTest.testGetAndWorkOnUserTasks[SINGLETON]
org.jbpm.kie.services.test.UserTaskWithSecurityTest.testProcessDoesNotStartForRolesNotAllowed[PER_CASE]
org.jbpm.kie.services.test.UserTaskWithSecurityTest.testProcessDoesNotStartForRolesNotAllowed[PER_PROCESS_INSTANCE]
org.jbpm.kie.services.test.UserTaskWithSecurityTest.testProcessDoesNotStartForRolesNotAllowed[PER_REQUEST]
org.jbpm.kie.services.test.UserTaskWithSecurityTest.testProcessDoesNotStartForRolesNotAllowed[SINGLETON]
</details>

**Reproduction**
Representative failures captured with `NonDex` (`-DnondexRuns=3` per test), examples:
- `ProcessInstanceAdminServiceImplTest`
  - `cvc-complex-type.2.4.a: invalid content starting with element 'persistence-mode' ... expected {...}`
- `ProcessServiceWithVariableTagsTest`
  - `cvc-complex-type.2.4.a: invalid content starting with element 'runtime-strategy' ... expected {...}`
- `QueryServiceImplTest`
  - `cvc-complex-type.2.4.a: invalid content starting with element 'runtime-strategy' ... expected {...}`
- `RuntimeDataServiceImplSecurityTest`
  - `cvc-complex-type.2.4.d: invalid content starting with element 'environment-entries' ...`
- `UserTaskWithSecurityTest`
  - `cvc-complex-type.2.4.d: invalid content starting with element 'globals' ...`
- `UserTaskInstanceWithPotOwnerTest`
  - `cvc-complex-type.2.4.a: invalid content starting with element 'persistence-mode' ... expected {...}`

**Root Cause**
`DeploymentDescriptorIO#toXml()` marshals `DeploymentDescriptorImpl` with JAXB. The descriptor contains unordered
collections; when iteration order changes, JAXB can emit elements in a sequence that violates the XSD `<sequence>`,
causing schema validation errors during marshalling.

**Fix**
- Marshal into a DOM `Document`, normalize element order to the XSD-required sequence, validate against the schema,
  then output the normalized XML.
- Validation remains strict; only ordering is normalized.
- The upstream implementation lives in `org.kie:kie-internal` (external dependency), so it cannot be modified
  directly in this repo. This fix applies a local override under `jbpm-kie-services` so the module uses the corrected
  implementation without editing upstream sources.

**Validation**
- All related unit tests pass consistently after the fix.
- Each of the 115 tests listed above was executed with `NonDex` 100 runs and remained stable after the fix.
- No assertions or test standards were relaxed.

**Impact / Scope**
- Affects only deployment descriptor XML serialization order.
- Preserves schema validation and content; missing/extra nodes still fail.
- No production behavior change beyond deterministic ordering.