### PR TITLE
DBACLD-189743: [CVE][Medium] bootstrap-3.3.7.min.js

### DIFF
--- a/jbpm-workitems/jbpm-workitems-template-resources/src/main/resources/indextemplate.st
+++ b/jbpm-workitems/jbpm-workitems-template-resources/src/main/resources/indextemplate.st
@@ -3,10 +3,10 @@
     <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css" integrity="sha384-9gVQ4dYFwwWSjIDZnLEWnxCjeSWFphJiwGPXr1jddIhOegiu1FwO5qRGvFXOdJZ4" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-9gVQ4dYFwwWSjIDZnLEWnxCjeSWFphJiwGPXr1jddIhOegiu1FwO5qRGvFXOdJZ4" crossorigin="anonymous">
         <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
     </head>
     <body>
     <div class="container">

--- a/jbpm-workitems/jbpm-workitems-template-resources/src/main/resources/repoheader.html
+++ b/jbpm-workitems/jbpm-workitems-template-resources/src/main/resources/repoheader.html
@@ -5,11 +5,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css" integrity="sha384-9gVQ4dYFwwWSjIDZnLEWnxCjeSWFphJiwGPXr1jddIhOegiu1FwO5qRGvFXOdJZ4" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-9gVQ4dYFwwWSjIDZnLEWnxCjeSWFphJiwGPXr1jddIhOegiu1FwO5qRGvFXOdJZ4" crossorigin="anonymous">
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script type="text/javascript" src="http://ajax.aspnetcdn.com/ajax/jquery.validate/1.7/jquery.validate.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
     <script src="http://fusejs.io/assets/js/fuse.min.js"></script>
     <script src="serviceinfo.js"></script>
     <style>


### PR DESCRIPTION
Closes : [DBACLD-189743](https://jsw.ibm.com/browse/DBACLD-189743) , [DBACLD-189747](https://jsw.ibm.com/browse/DBACLD-189747)

Fixes [CVE][Medium] https://github.com/advisories/GHSA-9v3m-8fp8-mj99, https://github.com/advisories/GHSA-3wqf-4x89-9g79, https://github.com/advisories/GHSA-ph58-4vrj-w6hr, https://github.com/advisories/GHSA-3mgp-fx93-9xv5, https://github.com/advisories/GHSA-7mvr-5x2g-wfc8, https://github.com/advisories/GHSA-4p24-vmcr-4gqj bootstrap-3.3.7.min.js

Updated bootstrap 3.3.7 to 3.4.1 and 4.1.0 to 4.3.1