### PR TITLE
Fix Flaky test: CaseServiceImplTest#testUpdateNotExistingCaseComment

### DIFF
--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/marshalling/CaseFileInstanceMarshallingStrategy.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/marshalling/CaseFileInstanceMarshallingStrategy.java
@@ -121,7 +121,7 @@ public class CaseFileInstanceMarshallingStrategy implements ObjectMarshallingStr
     public byte[] marshal(Context context, ObjectOutputStream os, Object object) throws IOException {        
         logger.debug("About to marshal {}", object);
         CaseFileInstanceImpl caseFile = (CaseFileInstanceImpl) object;
-        Map<String, Object> caseFileContent = new HashMap<>();
+        Map<String, Object> caseFileContent = new LinkedHashMap<>();
         caseFileContent.put(CASE_ID_KEY, caseFile.getCaseId());
         caseFileContent.put(CASE_DEF_ID_KEY, caseFile.getDefinitionId());
         caseFileContent.put(CASE_START_KEY, caseFile.getCaseStartDate());

--- a/jbpm-test/src/main/java/org/jbpm/test/services/AbstractServicesTest.java
+++ b/jbpm-test/src/main/java/org/jbpm/test/services/AbstractServicesTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -132,7 +133,7 @@ public abstract class AbstractServicesTest extends AbstractBaseTest {
         DeploymentDescriptor customDescriptor = createDeploymentDescriptor();
 
         if (extraResources == null) {
-            extraResources = new HashMap<>();
+            extraResources = new LinkedHashMap<>();
         }
         if (customDescriptor != null) {
             extraResources.put("src/main/resources/" + DeploymentDescriptor.META_INF_LOCATION, customDescriptor.toXml());


### PR DESCRIPTION
## What is the purpose of this PR

- This PR fixes the flaky test CaseServiceImplTest#testUpdateNotExistingCaseComment by enforcing deterministic XML field serialization order.

## Why The test fails

- The Test fails because JAXB serializes the fields of DeploymentDescriptorImpl and ObjectModel classes using Hashmap iteration order, which is nondeterministic. 
- When NonDex shuffles the Hashmap iteration order, XML elements are written in the wrong order, causing XML schema validation to fail with a MarshalException during test setup.

## How to Reproduce the test failure

Run the following commands

- `mvn clean install -DskipTests -pl jbpm-case-mgmt/jbpm-case-mgmt-impl -am`
- `mvn -pl jbpm-case-mgmt/jbpm-case-mgmt-impl edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.jbpm.casemgmt.impl.CaseServiceImplTest#testUpdateNotExistingCaseComment`

## Expected Results
 - The test should pass consistently with NonDex shuffling enabled across all seeds.
 
 ## Actual Results
 - The test fails with: javax.xml.bind.MarshalException - Invalid content was found starting with element because XML fields are serialized in wrong order.
 
 ## Description of fix
 - Added @XmlType(propOrder=...) annotation to DeploymentDescriptorImpl and ObjectModel to enforce deterministic XML field serialization order.
 - Changed Hashmap to LinkedHashMap in CaseFileInstanceMarshallingStrategy and AbstractServicesTest to preserve insertion order
