### PR TITLE
Revert "[JBPM-10258]Fix timer initialization for standalone tests"

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/JbpmBpmn2TestCase.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/JbpmBpmn2TestCase.java
@@ -39,7 +39,6 @@ import org.drools.core.audit.WorkingMemoryInMemoryLogger;
 import org.drools.core.audit.event.LogEvent;
 import org.drools.core.audit.event.RuleFlowLogEvent;
 import org.drools.core.audit.event.RuleFlowNodeLogEvent;
-import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.impl.EnvironmentFactory;
 import org.drools.core.impl.KnowledgeBaseFactory;
 import org.drools.core.util.DroolsStreamUtils;
@@ -60,7 +59,6 @@ import org.jbpm.process.audit.JPAAuditLogService;
 import org.jbpm.process.audit.NodeInstanceLog;
 import org.jbpm.process.audit.ProcessInstanceLog;
 import org.jbpm.process.audit.VariableInstanceLog;
-import org.jbpm.process.instance.ProcessRuntimeImpl;
 import org.jbpm.process.instance.event.DefaultSignalManagerFactory;
 import org.jbpm.process.instance.impl.DefaultProcessInstanceManagerFactory;
 import org.jbpm.ruleflow.core.RuleFlowProcess;
@@ -82,13 +80,11 @@ import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
 import org.kie.api.builder.KieRepository;
 import org.kie.api.builder.Message.Level;
-import org.kie.api.command.ExecutableCommand;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.definition.process.Node;
 import org.kie.api.definition.process.Process;
 import org.kie.api.io.Resource;
 import org.kie.api.marshalling.ObjectMarshallingStrategy;
-import org.kie.api.runtime.Context;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
@@ -99,7 +95,6 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkflowProcessInstance;
 import org.kie.internal.builder.KnowledgeBuilderConfiguration;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
-import org.kie.internal.command.RegistryContext;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.persistence.jpa.JPAKnowledgeService;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
@@ -465,25 +460,6 @@ public abstract class JbpmBpmn2TestCase extends AbstractBaseTest {
             result = (StatefulKnowledgeSession) kbase.newKieSession(conf, env);
             logger = new WorkingMemoryInMemoryLogger(result);
         }
-        
-        // Initialize start timers for standalone sessions (no RuntimeManager)
-        // RuntimeManager-based tests handle initialization separately
-        // Use ExecutableCommand to work with both persistent and non-persistent sessions
-        result.execute(new ExecutableCommand<Void>() {
-            private static final long serialVersionUID = 1L;
-            
-            @Override
-            public Void execute(Context context) {
-                KieSession ksession = 
-                    ((RegistryContext) context).lookup(KieSession.class);
-                ProcessRuntimeImpl pr = 
-                    (ProcessRuntimeImpl) 
-                    ((InternalKnowledgeRuntime) ksession).getProcessRuntime();
-                pr.initStartTimers();
-                return null;
-            }
-        });
-        
         return result;
     }
 

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/persistence/TimerCycleOnBinaryPackageTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/persistence/TimerCycleOnBinaryPackageTest.java
@@ -94,10 +94,8 @@ public class TimerCycleOnBinaryPackageTest extends JbpmBpmn2TestCase {
                                                                                                              .addEventListener(new TriggerRulesEventListener(ksession));
     
             // Explicitly initialize start timers after all listeners are attached
-            // Clear auto-init flag first to allow manual initialization
             KieSession internal = ((SingleSessionCommandService)
                     ((CommandBasedStatefulKnowledgeSession) ksession).getRunner()).getKieSession();
-            internal.getEnvironment().set("TIMERS_INITIALIZED", null);
             ((ProcessRuntimeImpl) ((InternalKnowledgeRuntime) internal).getProcessRuntime()).initStartTimers();
     
             countDownListener.waitTillCompleted();
@@ -124,10 +122,8 @@ public class TimerCycleOnBinaryPackageTest extends JbpmBpmn2TestCase {
                     .addEventListener(new TriggerRulesEventListener(ksession));
     
             // Explicitly initialize start timers after all listeners are attached (reloaded session)
-            // Clear auto-init flag first to allow manual initialization
             KieSession internal2 = ((SingleSessionCommandService)
                     ((CommandBasedStatefulKnowledgeSession) ksession).getRunner()).getKieSession();
-            internal2.getEnvironment().set("TIMERS_INITIALIZED", null);
             ((ProcessRuntimeImpl) ((InternalKnowledgeRuntime) internal2).getProcessRuntime()).initStartTimers();
     
             countDownListener.waitTillCompleted();
@@ -166,10 +162,8 @@ public class TimerCycleOnBinaryPackageTest extends JbpmBpmn2TestCase {
                     .addEventListener(new TriggerRulesEventListener(ksession));
     
             // Explicitly initialize start timers after all listeners are attached
-            // Clear auto-init flag first to allow manual initialization
             KieSession internal = ((SingleSessionCommandService)
                     ((CommandBasedStatefulKnowledgeSession) ksession).getRunner()).getKieSession();
-            internal.getEnvironment().set("TIMERS_INITIALIZED", null);
             ((ProcessRuntimeImpl) ((InternalKnowledgeRuntime) internal).getProcessRuntime()).initStartTimers();
     
             countDownListener.waitTillCompleted();
@@ -195,10 +189,8 @@ public class TimerCycleOnBinaryPackageTest extends JbpmBpmn2TestCase {
                     .addEventListener(new TriggerRulesEventListener(ksession));
     
             // Explicitly initialize start timers after all listeners are attached (reloaded session)
-            // Clear auto-init flag first to allow manual initialization
             KieSession internal2 = ((SingleSessionCommandService)
                     ((CommandBasedStatefulKnowledgeSession) ksession).getRunner()).getKieSession();
-            internal2.getEnvironment().set("TIMERS_INITIALIZED", null);
             ((ProcessRuntimeImpl) ((InternalKnowledgeRuntime) internal2).getProcessRuntime()).initStartTimers();
     
             countDownListener.waitTillCompleted();

--- a/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeImpl.java
@@ -63,7 +63,6 @@ import org.kie.api.event.rule.MatchCreatedEvent;
 import org.kie.api.event.rule.RuleFlowGroupDeactivatedEvent;
 import org.kie.api.internal.utils.ServiceRegistry;
 import org.kie.api.runtime.Context;
-import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.EnvironmentName;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
@@ -110,16 +109,6 @@ public class ProcessRuntimeImpl implements InternalProcessRuntime {
 	}
 	
 	public void initStartTimers() {
-	    // Prevent double initialization by checking environment flag
-	    // This persists across ProcessRuntimeImpl deserialization for persistent sessions
-	    Environment env = kruntime.getEnvironment();
-	    if (env != null && Boolean.TRUE.equals(env.get("TIMERS_INITIALIZED"))) {
-	        return;
-	    }
-	    if (env != null) {
-	        env.set("TIMERS_INITIALIZED", Boolean.TRUE);
-	    }
-	    
 	    // if there is no service implementation registered or is cluster coordinator we should start timers
         if(ServiceRegistry.ifSupported(ClusterAwareService.class, cluster -> !cluster.isCoordinator()).orElse(Boolean.FALSE)) {
             return;

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/SingletonRuntimeManager.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/SingletonRuntimeManager.java
@@ -192,8 +192,6 @@ public class SingletonRuntimeManager extends AbstractRuntimeManager {
             public Void execute(org.kie.api.runtime.Context context) {
                 KieSession ksession = ((RegistryContext) context).lookup( KieSession.class );
                 ksession.getEnvironment().set("Active", false);
-                // Clear timer initialization flag to allow restart on reactivation
-                ksession.getEnvironment().set("TIMERS_INITIALIZED", null);
                 
                 InternalProcessRuntime processRuntime = ((InternalKnowledgeRuntime) ksession).getProcessRuntime();
                 ((ProcessRuntimeImpl) processRuntime).removeProcessEventListeners();


### PR DESCRIPTION
Reverts kiegroup/jbpm#2510

Due to blocking test failures in FDB